### PR TITLE
Add Quickstart docs and explicit make.sh targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,37 @@
 
 By enforcing a strict **Straight-Line SIMD** execution model and **Static Memory Topology**, Lockstep allows the compiler to generate machine code that is mathematically guaranteed to saturate CPU vector units without the overhead of branch misprediction or cache contention.
 
+## Quickstart
+
+### Required tools
+
+* Java runtime (for the ANTLR tool)
+* ANTLR4 CLI/tooling available as `antlr4`
+* Python 3 with the ANTLR runtime package (`antlr4-python3-runtime`)
+
+### Regenerate parser artifacts
+
+```bash
+./make.sh generate
+```
+
+### Run the debug compiler sample
+
+```bash
+./make.sh run-sample
+```
+
+### Expected high-level output
+
+The sample run prints a frontend trace that shows discovered language elements in order, including:
+
+* compiler frontend header (`=== LOCKSTEP COMPILER FRONTEND ===`)
+* struct and pure function discovery
+* shader kernel name + parameters
+* pipeline topology, streams/accumulators, and bind routing
+
+---
+
 ## 1. Core Philosophy
 
 * **Data-Oriented by Design:** Logic is secondary to data flow. Programs are modeled as physical circuits (pipelines) rather than sequences of instructions.

--- a/make.sh
+++ b/make.sh
@@ -1,1 +1,50 @@
-antlr4 -Dlanguage=Python3 -visitor Lockstep.g4
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET="${1:-help}"
+
+generate() {
+  antlr4 -Dlanguage=Python3 -visitor Lockstep.g4
+}
+
+run_sample() {
+  python3 debug_compiler.py
+}
+
+clean() {
+  rm -f \
+    LockstepLexer.py LockstepParser.py LockstepVisitor.py LockstepListener.py \
+    LockstepLexer.tokens Lockstep.tokens \
+    LockstepLexer.interp Lockstep.interp
+}
+
+help() {
+  cat <<'USAGE'
+Usage: ./make.sh <target>
+
+Targets:
+  generate    Regenerate parser artifacts from Lockstep.g4
+  run-sample  Run debug_compiler.py with the built-in sample source
+  clean       Remove generated ANTLR artifacts
+USAGE
+}
+
+case "$TARGET" in
+  generate)
+    generate
+    ;;
+  run-sample)
+    run_sample
+    ;;
+  clean)
+    clean
+    ;;
+  help|-h|--help)
+    help
+    ;;
+  *)
+    echo "Unknown target: $TARGET" >&2
+    help
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
### Motivation

* Provide a concise Quickstart so contributors can quickly rebuild parser artifacts and run the example frontend.  
* Make the existing one-line build step reproducible and discoverable by introducing explicit targets for common tasks.  
* Document the required tooling and the expected high-level output for the sample run to reduce onboarding friction.

### Description

* Inserted a `Quickstart` section in `README.md` that lists required tools (Java runtime, ANTLR4 CLI, and `antlr4-python3-runtime`), the `generate` and `run-sample` commands, and the expected frontend trace output.  
* Replaced the previous one-line `antlr4` call with a target-driven helper script `make.sh` that exposes `generate`, `run-sample`, and `clean` targets plus `help`.  
* `generate` runs the ANTLR codegen with `antlr4 -Dlanguage=Python3 -visitor Lockstep.g4`, `run-sample` runs `python3 debug_compiler.py`, and `clean` removes generated ANTLR artifacts.

### Testing

* Ran `./make.sh help` which printed usage information and succeeded.  
* Ran `./make.sh clean` which removed generated artifacts and succeeded.  
* Ran `./make.sh generate` which failed in this environment because the `antlr4` CLI is not installed.  
* Ran `./make.sh run-sample` which failed in this environment because the Python ANTLR runtime (`antlr4-python3-runtime`) is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e1ff087b48328b22b467889a7c3d2)