### PR TITLE
Handle parser errors explicitly in debug compiler

### DIFF
--- a/debug_compiler.py
+++ b/debug_compiler.py
@@ -1,5 +1,6 @@
 import sys
 from antlr4 import InputStream, CommonTokenStream
+from antlr4.error.ErrorListener import ErrorListener
 
 # antlr4 -Dlanguage=Python3 -visitor Lockstep.g4
 from LockstepLexer import LockstepLexer
@@ -62,13 +63,45 @@ class LockstepDebugVisitor(LockstepVisitor):
         return self.visitChildren(ctx)
 
 
+class ParseErrorCollector(ErrorListener):
+    """Collects syntax errors emitted by ANTLR during lex/parse."""
+
+    def __init__(self):
+        super().__init__()
+        self.errors = []
+
+    def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e):
+        self.errors.append((line, column, msg))
+
+
+class LockstepCompileError(Exception):
+    """Raised when the Lockstep source contains parse errors."""
+
+    def __init__(self, errors):
+        self.errors = errors
+        super().__init__(self._format_message())
+
+    def _format_message(self):
+        count = len(self.errors)
+        suffix = "" if count == 1 else "s"
+        return f"Compilation failed with {count} parse error{suffix}."
+
+
 def compile_lockstep(source_code: str):
     input_stream = InputStream(source_code)
     lexer = LockstepLexer(input_stream)
+    error_listener = ParseErrorCollector()
+    lexer.removeErrorListeners()
+    lexer.addErrorListener(error_listener)
     stream = CommonTokenStream(lexer)
 
     parser = LockstepParser(stream)
+    parser.removeErrorListeners()
+    parser.addErrorListener(error_listener)
     tree = parser.program()
+
+    if error_listener.errors:
+        raise LockstepCompileError(error_listener.errors)
 
     visitor = LockstepDebugVisitor()
     visitor.visit(tree)
@@ -103,4 +136,10 @@ pipeline Physics {
 """
 
 if __name__ == "__main__":
-    compile_lockstep(TEST_SOURCE)
+    try:
+        compile_lockstep(TEST_SOURCE)
+    except LockstepCompileError as err:
+        print(str(err), file=sys.stderr)
+        for line, column, message in err.errors:
+            print(f"  line {line}:{column} {message}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
### Motivation
- Fail fast and provide concise, structured syntax diagnostics from the ANTLR front-end instead of traversing an invalid parse tree.

### Description
- Added `ParseErrorCollector` (subclassing `ErrorListener`) to collect lexer/parser syntax errors as `(line, column, message)`.
- Introduced `LockstepCompileError` to represent parse failures and carry collected diagnostics.
- Updated `compile_lockstep` to remove default listeners and attach the collector to both the lexer and parser, and to raise `LockstepCompileError` when parse errors exist before visitor traversal.
- Changed `__main__` to catch `LockstepCompileError`, print a concise summary (`line:column message`) to `stderr`, and exit with a non-zero status via `sys.exit(1)`.

### Testing
- Ran `python -m py_compile debug_compiler.py`, which succeeded.
- Attempting `python debug_compiler.py` could not be fully exercised here because the `antlr4` runtime is not installed and the script fails with `ModuleNotFoundError: No module named 'antlr4'`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e1fc754848328b78bd86eeab49161)