### PR TITLE
Add tests to raise debug_compiler coverage to 100%

### DIFF
--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1,4 +1,5 @@
 import importlib
+import runpy
 import sys
 import types
 
@@ -25,6 +26,8 @@ def _install_fake_generated_modules(monkeypatch):
     parser_module = types.ModuleType("LockstepParser")
 
     class StubParser:
+        error_to_emit = None
+
         class ProgramContext:
             pass
 
@@ -51,14 +54,19 @@ def _install_fake_generated_modules(monkeypatch):
 
         def __init__(self, stream):
             self.stream = stream
+            self._listeners = []
 
         def removeErrorListeners(self):
-            pass
+            self._listeners = []
 
         def addErrorListener(self, listener):
-            pass
+            self._listeners.append(listener)
 
         def program(self):
+            if self.error_to_emit is not None:
+                line, column, msg = self.error_to_emit
+                for listener in self._listeners:
+                    listener.syntaxError(None, None, line, column, msg, None)
             return object()
 
     parser_module.LockstepParser = StubParser
@@ -153,3 +161,97 @@ def test_compile_lockstep_visits_tree_on_success(debug_compiler_module, monkeypa
     debug_compiler_module.compile_lockstep("pipeline P { }")
 
     assert visited["tree"] == "TREE"
+
+
+def _token(text):
+    return types.SimpleNamespace(getText=lambda: text)
+
+
+def test_visitor_methods_print_expected_output(debug_compiler_module, capsys):
+    visitor = debug_compiler_module.LockstepDebugVisitor()
+
+    class _Param:
+        def __init__(self, modifier, p_type, p_name):
+            self._modifier = _token(modifier)
+            self._type = _token(p_type)
+            self._name = _token(p_name)
+
+        def getChild(self, index):
+            assert index == 0
+            return self._modifier
+
+        def typeName(self):
+            return self._type
+
+        def ID(self):
+            return self._name
+
+    class _ParamList:
+        def param(self):
+            return [_Param("in", "Vec3", "pos")]
+
+    class _BindStmt:
+        def __init__(self, text):
+            self._text = text
+
+        def getText(self):
+            return self._text
+
+    visitor.visitProgram(object())
+    visitor.visitStructDecl(types.SimpleNamespace(ID=lambda: _token("Vec3")))
+    visitor.visitPureDecl(
+        types.SimpleNamespace(ID=lambda: _token("add"), typeName=lambda: _token("Vec3"))
+    )
+    visitor.visitShaderDecl(
+        types.SimpleNamespace(ID=lambda: _token("ApplyGravity"), paramList=lambda: _ParamList())
+    )
+    visitor.visitPipelineDecl(types.SimpleNamespace(ID=lambda: _token("Physics")))
+    visitor.visitStreamDecl(
+        types.SimpleNamespace(
+            typeName=lambda: _token("Vec3"), INT=lambda: _token("1000"), ID=lambda: _token("raw")
+        )
+    )
+    visitor.visitAccumDecl(
+        types.SimpleNamespace(typeName=lambda: _token("float"), ID=lambda: _token("energy"))
+    )
+    visitor.visitBindBlock(types.SimpleNamespace(bindStmt=lambda: [_BindStmt("a=b"), _BindStmt("c=d")]))
+
+    stdout = capsys.readouterr().out
+    assert "=== LOCKSTEP COMPILER FRONTEND ===" in stdout
+    assert "[Struct] Discovered: Vec3" in stdout
+    assert "[Pure Function] add -> Vec3" in stdout
+    assert "[Shader Kernel] ApplyGravity" in stdout
+    assert "Param: (in) Vec3 pos" in stdout
+    assert "[Pipeline Topology] Physics" in stdout
+    assert "Stream: raw <Vec3, 1000>" in stdout
+    assert "Accumulator: energy <float>" in stdout
+    assert "Routing:" in stdout
+    assert "a=b" in stdout
+    assert "c=d" in stdout
+
+
+def test_visitor_shader_decl_without_param_list(debug_compiler_module, capsys):
+    visitor = debug_compiler_module.LockstepDebugVisitor()
+    visitor.visitShaderDecl(types.SimpleNamespace(ID=lambda: _token("Kernel"), paramList=lambda: None))
+    assert "[Shader Kernel] Kernel" in capsys.readouterr().out
+
+
+def test_module_main_success_path(monkeypatch, capsys):
+    _install_fake_generated_modules(monkeypatch)
+    sys.modules.pop("debug_compiler", None)
+    runpy.run_module("debug_compiler", run_name="__main__")
+    assert capsys.readouterr().err == ""
+
+
+def test_module_main_error_path_exits_with_stderr(monkeypatch, capsys):
+    _install_fake_generated_modules(monkeypatch)
+    sys.modules["LockstepParser"].LockstepParser.error_to_emit = (7, 9, "bad syntax")
+    sys.modules.pop("debug_compiler", None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_module("debug_compiler", run_name="__main__")
+
+    assert exc_info.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "Compilation failed with 1 parse error." in stderr
+    assert "line 7:9 bad syntax" in stderr


### PR DESCRIPTION
### Motivation
- Reach 100% coverage for `debug_compiler.py` by exercising all visitor branches and the module `__main__` execution paths.
- Make the test harness more realistic by allowing the fake ANTLR parser to register listeners and optionally emit syntax errors.
- Validate both successful parse/visit flows and the error-reporting path that triggers `SystemExit(1)` with stderr diagnostics.

### Description
- Updated `tests/test_debug_compiler.py` to import `runpy` and expand the generated-module stubs so `LockstepParser` tracks listeners and supports an injectable `error_to_emit` field.
- Added tests that exercise `LockstepDebugVisitor` output for `Program`, `StructDecl`, `PureDecl`, `ShaderDecl` (with and without params), `PipelineDecl`, `StreamDecl`, `AccumDecl`, and `BindBlock` printing.
- Added tests for `compile_lockstep` success and failure behaviors and module `__main__` execution for both the clean run and a parse-error exit path.
- Only the test file was modified; no production source files were changed.

### Testing
- Installed test extras and ran the test suite with `pytest`, resulting in `8 passed`.
- Coverage report shows `debug_compiler.py` at `100%` statement and branch coverage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e2e5142c88328ab6ab11c16212f41)