### PR TITLE
Add per-error diagnostic lines to Lockstep compile error messages

### DIFF
--- a/debug_compiler.py
+++ b/debug_compiler.py
@@ -84,7 +84,11 @@ class LockstepCompileError(Exception):
     def _format_message(self):
         count = len(self.errors)
         suffix = "" if count == 1 else "s"
-        return f"Compilation failed with {count} parse error{suffix}."
+        summary = f"Compilation failed with {count} parse error{suffix}."
+        details = "\n".join(
+            f"line {line}:{column} {message}" for line, column, message in self.errors
+        )
+        return summary if not details else f"{summary}\n{details}"
 
 
 def compile_lockstep(source_code: str):

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -98,8 +98,11 @@ def test_lockstep_compile_error_formats_singular_and_plural(debug_compiler_modul
     one = debug_compiler_module.LockstepCompileError([(1, 1, "oops")])
     many = debug_compiler_module.LockstepCompileError([(1, 1, "oops"), (2, 4, "bad")])
 
-    assert str(one) == "Compilation failed with 1 parse error."
-    assert str(many) == "Compilation failed with 2 parse errors."
+    assert str(one) == "Compilation failed with 1 parse error.\nline 1:1 oops"
+    assert (
+        str(many)
+        == "Compilation failed with 2 parse errors.\nline 1:1 oops\nline 2:4 bad"
+    )
 
 
 def test_parse_error_collector_captures_location_and_message(debug_compiler_module):


### PR DESCRIPTION
### Motivation
- Improve diagnostics by including per-error details (line, column, message) in compile error output while preserving the existing summary for compatibility.

### Description
- Preserve the existing summary line in `LockstepCompileError._format_message` and append deterministic per-error lines formatted as `line {line}:{column} {message}`.
- Ensure singular/plural wording remains correct by retaining the original summary logic.
- Update `tests/test_debug_compiler.py::test_lockstep_compile_error_formats_singular_and_plural` to assert the new detailed output for both one and multiple errors.

### Testing
- Ran `pytest -q tests/test_debug_compiler.py` which initially failed due to repository `--cov` addopts requiring unavailable plugins in this environment.
- Re-ran tests with repository addopts disabled via `-o addopts=''` which failed when `PYTHONPATH` was not set for module resolution.
- Finally ran `PYTHONPATH=/workspace/lockstep pytest -q -o addopts='' tests/test_debug_compiler.py` and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e4e1888048328839ae877a55ce7ef)