### PR TITLE
debug_compiler: return structured compile result and collect architecture entities

### DIFF
--- a/debug_compiler.py
+++ b/debug_compiler.py
@@ -1,4 +1,7 @@
 import sys
+from dataclasses import dataclass, field
+from typing import Any
+
 from antlr4 import InputStream, CommonTokenStream
 from antlr4.error.ErrorListener import ErrorListener
 
@@ -11,56 +14,80 @@ from LockstepVisitor import LockstepVisitor
 class LockstepDebugVisitor(LockstepVisitor):
     """Walks the Parse Tree and extracts the pipeline architecture."""
 
+    def __init__(self, verbose: bool = True):
+        self.verbose = verbose
+        self.structs = []
+        self.shaders = []
+        self.streams = []
+        self.accumulators = []
+
+    def _print(self, message: str):
+        if self.verbose:
+            print(message)
+
     def visitProgram(self, ctx: LockstepParser.ProgramContext):
-        print("=== LOCKSTEP COMPILER FRONTEND ===")
-        print("Parsing program...\n")
+        self._print("=== LOCKSTEP COMPILER FRONTEND ===")
+        self._print("Parsing program...\n")
         return self.visitChildren(ctx)
 
     def visitStructDecl(self, ctx: LockstepParser.StructDeclContext):
         name = ctx.ID().getText()
-        print(f"[Struct] Discovered: {name}")
+        self.structs.append(name)
+        self._print(f"[Struct] Discovered: {name}")
         return self.visitChildren(ctx)
 
     def visitPureDecl(self, ctx: LockstepParser.PureDeclContext):
         name = ctx.ID().getText()
         ret_type = ctx.typeName().getText()
-        print(f"[Pure Function] {name} -> {ret_type}")
+        self._print(f"[Pure Function] {name} -> {ret_type}")
         return self.visitChildren(ctx)
 
     def visitShaderDecl(self, ctx: LockstepParser.ShaderDeclContext):
         name = ctx.ID().getText()
-        print(f"\n[Shader Kernel] {name}")
+        params = []
+        self._print(f"\n[Shader Kernel] {name}")
         if ctx.paramList():
             for param in ctx.paramList().param():
                 modifier = param.getChild(0).getText()
                 p_type = param.typeName().getText()
                 p_name = param.ID().getText()
-                print(f"  └─ Param: ({modifier}) {p_type} {p_name}")
+                params.append({"modifier": modifier, "type": p_type, "name": p_name})
+                self._print(f"  └─ Param: ({modifier}) {p_type} {p_name}")
+        self.shaders.append({"name": name, "params": params})
         return self.visitChildren(ctx)
 
     def visitPipelineDecl(self, ctx: LockstepParser.PipelineDeclContext):
         name = ctx.ID().getText()
-        print(f"\n[Pipeline Topology] {name}")
+        self._print(f"\n[Pipeline Topology] {name}")
         return self.visitChildren(ctx)
 
     def visitStreamDecl(self, ctx: LockstepParser.StreamDeclContext):
         s_type = ctx.typeName().getText()
         capacity = ctx.INT().getText()
         name = ctx.ID().getText()
-        print(f"  └─ Stream: {name} <{s_type}, {capacity}>")
+        self.streams.append({"name": name, "type": s_type, "capacity": capacity})
+        self._print(f"  └─ Stream: {name} <{s_type}, {capacity}>")
         return self.visitChildren(ctx)
 
     def visitAccumDecl(self, ctx: LockstepParser.AccumDeclContext):
         a_type = ctx.typeName().getText()
         name = ctx.ID().getText()
-        print(f"  └─ Accumulator: {name} <{a_type}>")
+        self.accumulators.append({"name": name, "type": a_type})
+        self._print(f"  └─ Accumulator: {name} <{a_type}>")
         return self.visitChildren(ctx)
 
     def visitBindBlock(self, ctx: LockstepParser.BindBlockContext):
-        print("  └─ Routing:")
+        self._print("  └─ Routing:")
         for stmt in ctx.bindStmt():
-            print(f"       {stmt.getText()}")
+            self._print(f"       {stmt.getText()}")
         return self.visitChildren(ctx)
+
+
+@dataclass
+class LockstepCompileResult:
+    parse_tree: Any
+    entities: dict[str, Any]
+    diagnostics: list[tuple[int, int, str]] = field(default_factory=list)
 
 
 class ParseErrorCollector(ErrorListener):
@@ -87,7 +114,7 @@ class LockstepCompileError(Exception):
         return f"Compilation failed with {count} parse error{suffix}."
 
 
-def compile_lockstep(source_code: str):
+def compile_lockstep(source_code: str, verbose: bool = True) -> LockstepCompileResult:
     input_stream = InputStream(source_code)
     lexer = LockstepLexer(input_stream)
     error_listener = ParseErrorCollector()
@@ -103,8 +130,18 @@ def compile_lockstep(source_code: str):
     if error_listener.errors:
         raise LockstepCompileError(error_listener.errors)
 
-    visitor = LockstepDebugVisitor()
+    visitor = LockstepDebugVisitor(verbose=verbose)
     visitor.visit(tree)
+    return LockstepCompileResult(
+        parse_tree=tree,
+        entities={
+            "structs": visitor.structs,
+            "shaders": visitor.shaders,
+            "streams": visitor.streams,
+            "accumulators": visitor.accumulators,
+        },
+        diagnostics=[],
+    )
 
 
 TEST_SOURCE = """

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -151,6 +151,13 @@ def test_compile_lockstep_visits_tree_on_success(debug_compiler_module, monkeypa
     visited = {"tree": None}
 
     class SpyVisitor:
+        def __init__(self, verbose=True):
+            self.verbose = verbose
+            self.structs = ["Vec3"]
+            self.shaders = [{"name": "ApplyGravity", "params": []}]
+            self.streams = [{"name": "raw", "type": "Vec3", "capacity": "1000"}]
+            self.accumulators = [{"name": "energy", "type": "float"}]
+
         def visit(self, tree):
             visited["tree"] = tree
 
@@ -158,9 +165,17 @@ def test_compile_lockstep_visits_tree_on_success(debug_compiler_module, monkeypa
     monkeypatch.setattr(debug_compiler_module, "LockstepParser", SuccessParser)
     monkeypatch.setattr(debug_compiler_module, "LockstepDebugVisitor", SpyVisitor)
 
-    debug_compiler_module.compile_lockstep("pipeline P { }")
+    result = debug_compiler_module.compile_lockstep("pipeline P { }", verbose=False)
 
     assert visited["tree"] == "TREE"
+    assert result.parse_tree == "TREE"
+    assert result.entities == {
+        "structs": ["Vec3"],
+        "shaders": [{"name": "ApplyGravity", "params": []}],
+        "streams": [{"name": "raw", "type": "Vec3", "capacity": "1000"}],
+        "accumulators": [{"name": "energy", "type": "float"}],
+    }
+    assert result.diagnostics == []
 
 
 def _token(text):
@@ -228,12 +243,25 @@ def test_visitor_methods_print_expected_output(debug_compiler_module, capsys):
     assert "Routing:" in stdout
     assert "a=b" in stdout
     assert "c=d" in stdout
+    assert visitor.structs == ["Vec3"]
+    assert visitor.shaders == [{"name": "ApplyGravity", "params": [{"modifier": "in", "type": "Vec3", "name": "pos"}]}]
+    assert visitor.streams == [{"name": "raw", "type": "Vec3", "capacity": "1000"}]
+    assert visitor.accumulators == [{"name": "energy", "type": "float"}]
 
 
 def test_visitor_shader_decl_without_param_list(debug_compiler_module, capsys):
     visitor = debug_compiler_module.LockstepDebugVisitor()
     visitor.visitShaderDecl(types.SimpleNamespace(ID=lambda: _token("Kernel"), paramList=lambda: None))
     assert "[Shader Kernel] Kernel" in capsys.readouterr().out
+    assert visitor.shaders == [{"name": "Kernel", "params": []}]
+
+
+def test_visitor_can_run_without_printing(debug_compiler_module, capsys):
+    visitor = debug_compiler_module.LockstepDebugVisitor(verbose=False)
+    visitor.visitStructDecl(types.SimpleNamespace(ID=lambda: _token("Vec3")))
+
+    assert capsys.readouterr().out == ""
+    assert visitor.structs == ["Vec3"]
 
 
 def test_module_main_success_path(monkeypatch, capsys):


### PR DESCRIPTION
### Motivation
- Expose parsed metadata programmatically instead of only printing to stdout so callers can inspect the parse tree and discovered architecture entities.
- Preserve the existing CLI printing behavior while enabling silent/non-verbose usage for downstream tooling.
- Surface optional diagnostics in a consistent, typed result object.

### Description
- Added a `LockstepCompileResult` dataclass containing `parse_tree`, `entities`, and `diagnostics` and updated `compile_lockstep` to return it and accept a `verbose` flag.
- Refactored `LockstepDebugVisitor` to collect discovered entities into instance fields `structs`, `shaders`, `streams`, and `accumulators` and added an internal `_print` helper gated by `verbose` so printing remains optional.
- Wired the visitor-collected state into the returned `entities` mapping and kept `diagnostics` available on the result (currently populated as an empty list).
- Extended `tests/test_debug_compiler.py` to validate the returned `LockstepCompileResult` structure on success, assert visitor-collected data, and verify that `verbose=False` suppresses printing.

### Testing
- Ran the unit tests for the modified file with `PYTHONPATH=. pytest -q -o addopts='' tests/test_debug_compiler.py` and all tests passed (`9 passed`).
- Also exercised `compile_lockstep` error and visitor behaviors via the updated test suite which asserts parse error collection and successful visit semantics.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e4e2bc14883288e0269f9d61d3793)