### PR TITLE
Add argparse-driven input handling for debug_compiler CLI

### DIFF
--- a/debug_compiler.py
+++ b/debug_compiler.py
@@ -1,4 +1,6 @@
+import argparse
 import sys
+from pathlib import Path
 from antlr4 import InputStream, CommonTokenStream
 from antlr4.error.ErrorListener import ErrorListener
 
@@ -135,11 +137,38 @@ pipeline Physics {
 }
 """
 
-if __name__ == "__main__":
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description="Debug parser for Lockstep source files.")
+    parser.add_argument(
+        "path",
+        nargs="?",
+        help="Optional path to a Lockstep source file. Reads from stdin when omitted.",
+    )
+    return parser
+
+
+def run_cli(argv=None, *, stdin=None, stderr=None, compiler=compile_lockstep):
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    stdin = sys.stdin if stdin is None else stdin
+    stderr = sys.stderr if stderr is None else stderr
+
+    if args.path:
+        source = Path(args.path).read_text(encoding="utf-8")
+    else:
+        source = stdin.read()
+
     try:
-        compile_lockstep(TEST_SOURCE)
+        compiler(source)
     except LockstepCompileError as err:
-        print(str(err), file=sys.stderr)
+        print(str(err), file=stderr)
         for line, column, message in err.errors:
-            print(f"  line {line}:{column} {message}", file=sys.stderr)
-        sys.exit(1)
+            print(f"  line {line}:{column} {message}", file=stderr)
+        return 1
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(run_cli())

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1,4 +1,5 @@
 import importlib
+import io
 import runpy
 import sys
 import types
@@ -239,7 +240,13 @@ def test_visitor_shader_decl_without_param_list(debug_compiler_module, capsys):
 def test_module_main_success_path(monkeypatch, capsys):
     _install_fake_generated_modules(monkeypatch)
     sys.modules.pop("debug_compiler", None)
-    runpy.run_module("debug_compiler", run_name="__main__")
+    monkeypatch.setattr(sys, "argv", ["debug_compiler.py"])
+    monkeypatch.setattr(sys, "stdin", io.StringIO("pipeline P { }"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_module("debug_compiler", run_name="__main__")
+
+    assert exc_info.value.code == 0
     assert capsys.readouterr().err == ""
 
 
@@ -247,6 +254,8 @@ def test_module_main_error_path_exits_with_stderr(monkeypatch, capsys):
     _install_fake_generated_modules(monkeypatch)
     sys.modules["LockstepParser"].LockstepParser.error_to_emit = (7, 9, "bad syntax")
     sys.modules.pop("debug_compiler", None)
+    monkeypatch.setattr(sys, "argv", ["debug_compiler.py"])
+    monkeypatch.setattr(sys, "stdin", io.StringIO("pipeline P { }"))
 
     with pytest.raises(SystemExit) as exc_info:
         runpy.run_module("debug_compiler", run_name="__main__")
@@ -255,3 +264,50 @@ def test_module_main_error_path_exits_with_stderr(monkeypatch, capsys):
     stderr = capsys.readouterr().err
     assert "Compilation failed with 1 parse error." in stderr
     assert "line 7:9 bad syntax" in stderr
+
+
+def test_run_cli_reads_source_from_stdin_when_path_omitted(debug_compiler_module):
+    captured = {}
+
+    def fake_compiler(source):
+        captured["source"] = source
+
+    exit_code = debug_compiler_module.run_cli(
+        [],
+        stdin=io.StringIO("pipeline FromStdin { }"),
+        compiler=fake_compiler,
+    )
+
+    assert exit_code == 0
+    assert captured["source"] == "pipeline FromStdin { }"
+
+
+def test_run_cli_reads_source_from_path(debug_compiler_module, tmp_path):
+    source_file = tmp_path / "sample.lock"
+    source_file.write_text("pipeline FromFile { }", encoding="utf-8")
+    captured = {}
+
+    def fake_compiler(source):
+        captured["source"] = source
+
+    exit_code = debug_compiler_module.run_cli([str(source_file)], compiler=fake_compiler)
+
+    assert exit_code == 0
+    assert captured["source"] == "pipeline FromFile { }"
+
+
+def test_run_cli_returns_non_zero_and_writes_errors(debug_compiler_module):
+    def failing_compiler(_source):
+        raise debug_compiler_module.LockstepCompileError([(4, 2, "unexpected")])
+
+    stderr = io.StringIO()
+    exit_code = debug_compiler_module.run_cli(
+        [],
+        stdin=io.StringIO("pipeline Broken {"),
+        stderr=stderr,
+        compiler=failing_compiler,
+    )
+
+    assert exit_code == 1
+    assert "Compilation failed with 1 parse error." in stderr.getvalue()
+    assert "line 4:2 unexpected" in stderr.getvalue()


### PR DESCRIPTION
### Motivation
- Replace the module's hardcoded runtime use of `TEST_SOURCE` with a proper CLI so the compiler can read real source files or stdin.
- Make the CLI behavior testable by extracting a small helper that can be invoked from unit tests with injected `stdin`/`stderr` and a fake compiler.
- Preserve existing error-reporting semantics so `LockstepCompileError` still produces human-readable stderr output and a non-zero exit code.
- Keep `TEST_SOURCE` in the module for examples/tests but avoid using it as the runtime default.

### Description
- Added `argparse` and `Path` imports and implemented `build_arg_parser()` to provide an optional positional `path` argument that, when omitted, causes the program to read source from stdin.
- Introduced `run_cli(argv=None, *, stdin=None, stderr=None, compiler=compile_lockstep)` which centralizes argument parsing, source loading (from file or `stdin`), compile invocation, and maps `LockstepCompileError` to stderr output and return code (`1` on error, `0` on success).
- Updated the module entrypoint to call `sys.exit(run_cli())` instead of executing `compile_lockstep(TEST_SOURCE)`.
- Expanded `tests/test_debug_compiler.py` to set `sys.argv`/`sys.stdin` for module-entry tests and added unit tests for the new `run_cli` helper to verify reading from stdin, reading from a path, and error-exit behavior.

### Testing
- Running plain `pytest -q` initially errored due to configured coverage `addopts` (requires `pytest-cov` plugin), so tests were run with the coverage options disabled using `PYTHONPATH=. pytest -q -o addopts='' tests/test_debug_compiler.py`.
- The focused test run completed successfully with all tests passing: `11 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e4e38f1488328aff429eec68c9aab)