### PR TITLE
Refactor Lockstep expression grammar precedence and add parser tests

### DIFF
--- a/Lockstep.g4
+++ b/Lockstep.g4
@@ -53,19 +53,22 @@ varDecl: typeName ID ('=' expr)? ';';
 assignStmt: lvalue '=' expr ';';
 returnStmt: 'return' expr ';';
 
-expr
+expr: logicalExpr;
+
+logicalExpr: logicalOrExpr;
+logicalOrExpr: logicalAndExpr ('||' logicalAndExpr)*;
+logicalAndExpr: equalityExpr ('&&' equalityExpr)*;
+equalityExpr: relExpr (('==' | '!=') relExpr)*;
+relExpr: addExpr (('<' | '<=' | '>' | '>=') addExpr)*;
+addExpr: mulExpr (('+' | '-') mulExpr)*;
+mulExpr: unaryExpr (('*' | '/' | '%') unaryExpr)*;
+unaryExpr: ('-' | '!') unaryExpr | primaryExpr;
+primaryExpr
     : '(' expr ')'
     | ID '(' exprList? ')'
-    | expr ('*' | '/' | '%') expr
-    | expr ('+' | '-') expr
-    | expr ('<' | '<=' | '>' | '>=') expr
-    | expr ('==' | '!=') expr
-    | expr ('&&' | '||') expr
     | lvalue
     | INT
     | FLOAT
-    | '-' expr
-    | '!' expr
     ;
 
 exprList: expr (',' expr)*;

--- a/tests/test_expr_precedence.py
+++ b/tests/test_expr_precedence.py
@@ -1,0 +1,86 @@
+import importlib
+import pathlib
+import subprocess
+import sys
+
+import pytest
+from antlr4 import CommonTokenStream, InputStream
+
+
+@pytest.fixture(scope="module")
+def generated_parser(tmp_path_factory):
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    tmp_dir = tmp_path_factory.mktemp("antlr_generated")
+    antlr_jar = tmp_dir / "antlr.jar"
+
+    try:
+        subprocess.run(
+            ["curl", "-fsSL", "https://www.antlr.org/download/antlr-4.13.2-complete.jar", "-o", str(antlr_jar)],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        subprocess.run(
+            ["java", "-jar", str(antlr_jar), "-Dlanguage=Python3", "-visitor", "-o", str(tmp_dir), "Lockstep.g4"],
+            cwd=repo_root,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        pytest.skip(f"ANTLR generation unavailable: {exc}")
+
+    sys.path.insert(0, str(tmp_dir))
+    try:
+        lexer_module = importlib.import_module("LockstepLexer")
+        parser_module = importlib.import_module("LockstepParser")
+        yield lexer_module.LockstepLexer, parser_module.LockstepParser
+    finally:
+        sys.path.remove(str(tmp_dir))
+        for module_name in ["LockstepLexer", "LockstepParser", "LockstepVisitor", "LockstepListener"]:
+            sys.modules.pop(module_name, None)
+
+
+def _parse_expr(text, lexer_cls, parser_cls):
+    parser = parser_cls(CommonTokenStream(lexer_cls(InputStream(text))))
+    tree = parser.expr()
+
+    assert parser.getNumberOfSyntaxErrors() == 0
+    assert parser.getCurrentToken().type == parser.EOF
+
+    return tree.toStringTree(recog=parser)
+
+
+def test_unary_binds_tighter_than_multiplication(generated_parser):
+    lexer_cls, parser_cls = generated_parser
+    parsed = _parse_expr("-a*b", lexer_cls, parser_cls)
+
+    assert "(mulExpr (unaryExpr - (unaryExpr (primaryExpr (lvalue a)))) *" in parsed
+
+
+def test_unary_over_parenthesized_comparison(generated_parser):
+    lexer_cls, parser_cls = generated_parser
+    parsed = _parse_expr("!(a<b)", lexer_cls, parser_cls)
+
+    assert "(unaryExpr ! (unaryExpr (primaryExpr ( (expr" in parsed
+    assert "< (addExpr" in parsed
+
+
+def test_multiplication_binds_tighter_than_addition(generated_parser):
+    lexer_cls, parser_cls = generated_parser
+    parsed = _parse_expr("a+b*c", lexer_cls, parser_cls)
+
+    assert "(addExpr (mulExpr (unaryExpr (primaryExpr (lvalue a)))) +" in parsed
+    assert "(mulExpr (unaryExpr (primaryExpr (lvalue b))) * (unaryExpr (primaryExpr (lvalue c))))" in parsed
+
+
+def test_logical_and_binds_tighter_than_or(generated_parser):
+    lexer_cls, parser_cls = generated_parser
+    parsed = _parse_expr("a==b||c&&d", lexer_cls, parser_cls)
+
+    assert "(logicalOrExpr (logicalAndExpr" in parsed
+    assert "|| (logicalAndExpr" in parsed
+    assert "(logicalAndExpr (equalityExpr" in parsed
+    assert "&& (equalityExpr" in parsed


### PR DESCRIPTION
### Motivation

- Make expression parsing unambiguous by introducing explicit precedence layers so unary operators bind tighter than multiplicative/additive operators and logical operators form proper precedence levels. 

### Description

- Replace the single left-recursive `expr` alternatives with layered nonterminals: `logicalOrExpr`, `logicalAndExpr`, `equalityExpr`, `relExpr`, `addExpr`, `mulExpr`, `unaryExpr`, and `primaryExpr` in `Lockstep.g4` so precedence is explicit. 
- Implement `unaryExpr` as `('-' | '!') unaryExpr | primaryExpr` so unary binds tighter than `mulExpr`/`addExpr`. 
- Move parentheses, function calls, lvalues, and literals into `primaryExpr` to preserve call/lvalue parsing at the base level. 
- Add `tests/test_expr_precedence.py` which generates ANTLR Python artifacts in a temporary directory and asserts parse-tree shapes for `-a*b`, `!(a<b)`, `a+b*c`, and `a==b||c&&d` to validate precedence. 

### Testing

- Ran the new parser-focused test file with `pytest -q -o addopts='' tests/test_expr_precedence.py` and the suite reported `4 passed`. 
- Ran the repository test suite with `pytest -q -o addopts=''` and the test run reported `12 passed` (no failures related to the grammar change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e4e534e1083289a10027e3891f232)