### PR TITLE
Gracefully handle source read failures in debug_compiler.run_cli

### DIFF
--- a/debug_compiler.py
+++ b/debug_compiler.py
@@ -199,7 +199,22 @@ def run_cli(argv=None, *, stdin=None, stderr=None, compiler=compile_lockstep):
     stderr = sys.stderr if stderr is None else stderr
 
     if args.path:
-        source = Path(args.path).read_text(encoding="utf-8")
+        source_path = Path(args.path)
+        try:
+            source = source_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            print(f"Unable to read '{source_path}': file not found.", file=stderr)
+            return 1
+        except PermissionError as err:
+            reason = err.strerror or "permission denied"
+            print(f"Unable to read '{source_path}': {reason}.", file=stderr)
+            return 1
+        except UnicodeDecodeError as err:
+            print(
+                f"Unable to read '{source_path}': invalid UTF-8 ({err.reason}).",
+                file=stderr,
+            )
+            return 1
     else:
         source = stdin.read()
 

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -365,3 +365,65 @@ def test_run_cli_returns_non_zero_and_writes_errors(debug_compiler_module):
     assert exit_code == 1
     assert "Compilation failed with 1 parse error." in stderr.getvalue()
     assert "line 4:2 unexpected" in stderr.getvalue()
+
+
+def test_run_cli_returns_non_zero_for_missing_path(debug_compiler_module, tmp_path):
+    missing = tmp_path / "missing.lock"
+    stderr = io.StringIO()
+    called = {"compiler": False}
+
+    def fake_compiler(_source):
+        called["compiler"] = True
+
+    exit_code = debug_compiler_module.run_cli(
+        [str(missing)],
+        stderr=stderr,
+        compiler=fake_compiler,
+    )
+
+    assert exit_code == 1
+    assert called["compiler"] is False
+    assert f"Unable to read '{missing}': file not found." in stderr.getvalue()
+
+
+def test_run_cli_returns_non_zero_for_unreadable_path(debug_compiler_module, monkeypatch):
+    stderr = io.StringIO()
+    called = {"compiler": False}
+
+    def fake_compiler(_source):
+        called["compiler"] = True
+
+    def raise_permission_error(_self, encoding):
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(debug_compiler_module.Path, "read_text", raise_permission_error)
+
+    exit_code = debug_compiler_module.run_cli(
+        ["locked.lock"],
+        stderr=stderr,
+        compiler=fake_compiler,
+    )
+
+    assert exit_code == 1
+    assert called["compiler"] is False
+    assert "Unable to read 'locked.lock': permission denied." in stderr.getvalue()
+
+
+def test_run_cli_returns_non_zero_for_invalid_utf8(debug_compiler_module, tmp_path):
+    bad_source = tmp_path / "invalid.lock"
+    bad_source.write_bytes(b"\xff\xfe\xfa")
+    stderr = io.StringIO()
+    called = {"compiler": False}
+
+    def fake_compiler(_source):
+        called["compiler"] = True
+
+    exit_code = debug_compiler_module.run_cli(
+        [str(bad_source)],
+        stderr=stderr,
+        compiler=fake_compiler,
+    )
+
+    assert exit_code == 1
+    assert called["compiler"] is False
+    assert f"Unable to read '{bad_source}': invalid UTF-8" in stderr.getvalue()


### PR DESCRIPTION
### Motivation
- Ensure the CLI fails fast with clear, user-friendly error messages when reading a source file fails instead of invoking the compiler with invalid input.
- Make error conditions explicit for missing files, permission errors, and invalid UTF-8 so callers and scripts can react to distinct IO problems.

### Description
- Wrapped `Path(args.path).read_text(encoding="utf-8")` in `try/except` to catch `FileNotFoundError`, `PermissionError`, and `UnicodeDecodeError` in `run_cli` of `debug_compiler.py`.
- Print concise, path-aware messages to `stderr` describing the failure reason and return `1` immediately when a read error occurs.
- Ensured the compiler is not called when source loading fails by returning before compilation.
- Added unit tests in `tests/test_debug_compiler.py` to cover missing file, unreadable file (simulated via monkeypatch), and invalid UTF-8 cases, verifying non-zero exit and that the compiler is not invoked.

### Testing
- Running the project tests with the repository coverage addopts caused an initial pytest invocation to fail due to coverage flags, so tests were executed with addopts disabled.
- `PYTHONPATH=. pytest -q -o addopts='' tests/test_debug_compiler.py` was run and all tests in that file passed (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e5a42fd60832883bab00e60600eb5)