### PR TITLE
Promote compiler diagnostics to first-class output

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,31 @@ The compiler generates a C-compatible header for the Host application (C/C++, Ru
 2. **Bind:** Host calls `Lockstep_BindMemory(ptr)`.
 3. **Prime:** Host writes initial data into the SoA offsets provided by the header.
 4. **Tick:** Host calls `Lockstep_Tick()` to execute the pipeline.
+
+---
+
+## 6. Compiler Frontend Usage
+
+`debug_compiler.py` exposes `compile_lockstep(source_code, verbose=True)` and returns a `LockstepCompileResult` containing:
+
+* `parse_tree`: ANTLR parse tree for the source.
+* `entities`: extracted frontend entities (`structs`, `shaders`, `streams`, `accumulators`).
+* `diagnostics`: first-class compiler diagnostics (`LockstepDiagnostic`) for non-fatal observations.
+
+### Diagnostic Shape
+
+Each diagnostic includes:
+
+* `severity` (`"info"`, `"warning"`, or `"error"`)
+* `code` (stable diagnostic identifier such as `LCK101`, `LCK201`)
+* `message`
+* `line`
+* `column`
+* optional `hint`
+
+### Behavior
+
+* **Non-fatal observations** (for example empty `bind` blocks or duplicate declarations) are returned in `LockstepCompileResult.diagnostics` and compilation still succeeds.
+* **Fatal parse errors** still raise `LockstepCompileError`.
+  * `LockstepCompileError.errors` contains parse diagnostics.
+  * `LockstepCompileError.diagnostics` mirrors available pre-failure diagnostic context when parse fails.

--- a/debug_compiler.py
+++ b/debug_compiler.py
@@ -13,6 +13,16 @@ from LockstepParser import LockstepParser
 from LockstepVisitor import LockstepVisitor
 
 
+@dataclass
+class LockstepDiagnostic:
+    severity: str
+    code: str
+    message: str
+    line: int
+    column: int
+    hint: str | None = None
+
+
 class LockstepDebugVisitor(LockstepVisitor):
     """Walks the Parse Tree and extracts the pipeline architecture."""
 
@@ -22,10 +32,22 @@ class LockstepDebugVisitor(LockstepVisitor):
         self.shaders = []
         self.streams = []
         self.accumulators = []
+        self.diagnostics: list[LockstepDiagnostic] = []
+        self._seen_structs = set()
+        self._seen_shaders = set()
+        self._seen_streams = set()
+        self._seen_accumulators = set()
 
     def _print(self, message: str):
         if self.verbose:
             print(message)
+
+    def _line_col(self, ctx) -> tuple[int, int]:
+        token = getattr(ctx, "start", None)
+        return (
+            getattr(token, "line", 0),
+            getattr(token, "column", 0),
+        )
 
     def visitProgram(self, ctx: LockstepParser.ProgramContext):
         self._print("=== LOCKSTEP COMPILER FRONTEND ===")
@@ -34,6 +56,19 @@ class LockstepDebugVisitor(LockstepVisitor):
 
     def visitStructDecl(self, ctx: LockstepParser.StructDeclContext):
         name = ctx.ID().getText()
+        line, column = self._line_col(ctx)
+        if name in self._seen_structs:
+            self.diagnostics.append(
+                LockstepDiagnostic(
+                    severity="warning",
+                    code="LCK201",
+                    message=f"Struct '{name}' is redeclared.",
+                    line=line,
+                    column=column,
+                    hint="Rename or remove duplicate struct declarations.",
+                )
+            )
+        self._seen_structs.add(name)
         self.structs.append(name)
         self._print(f"[Struct] Discovered: {name}")
         return self.visitChildren(ctx)
@@ -47,6 +82,19 @@ class LockstepDebugVisitor(LockstepVisitor):
     def visitShaderDecl(self, ctx: LockstepParser.ShaderDeclContext):
         name = ctx.ID().getText()
         params = []
+        line, column = self._line_col(ctx)
+        if name in self._seen_shaders:
+            self.diagnostics.append(
+                LockstepDiagnostic(
+                    severity="warning",
+                    code="LCK202",
+                    message=f"Shader '{name}' is redeclared.",
+                    line=line,
+                    column=column,
+                    hint="Rename or remove duplicate shader declarations.",
+                )
+            )
+        self._seen_shaders.add(name)
         self._print(f"\n[Shader Kernel] {name}")
         if ctx.paramList():
             for param in ctx.paramList().param():
@@ -67,6 +115,19 @@ class LockstepDebugVisitor(LockstepVisitor):
         s_type = ctx.typeName().getText()
         capacity = ctx.INT().getText()
         name = ctx.ID().getText()
+        line, column = self._line_col(ctx)
+        if name in self._seen_streams:
+            self.diagnostics.append(
+                LockstepDiagnostic(
+                    severity="warning",
+                    code="LCK203",
+                    message=f"Stream '{name}' is redeclared.",
+                    line=line,
+                    column=column,
+                    hint="Each stream in a pipeline should have a unique name.",
+                )
+            )
+        self._seen_streams.add(name)
         self.streams.append({"name": name, "type": s_type, "capacity": capacity})
         self._print(f"  └─ Stream: {name} <{s_type}, {capacity}>")
         return self.visitChildren(ctx)
@@ -74,13 +135,39 @@ class LockstepDebugVisitor(LockstepVisitor):
     def visitAccumDecl(self, ctx: LockstepParser.AccumDeclContext):
         a_type = ctx.typeName().getText()
         name = ctx.ID().getText()
+        line, column = self._line_col(ctx)
+        if name in self._seen_accumulators:
+            self.diagnostics.append(
+                LockstepDiagnostic(
+                    severity="warning",
+                    code="LCK204",
+                    message=f"Accumulator '{name}' is redeclared.",
+                    line=line,
+                    column=column,
+                    hint="Each accumulator in a pipeline should have a unique name.",
+                )
+            )
+        self._seen_accumulators.add(name)
         self.accumulators.append({"name": name, "type": a_type})
         self._print(f"  └─ Accumulator: {name} <{a_type}>")
         return self.visitChildren(ctx)
 
     def visitBindBlock(self, ctx: LockstepParser.BindBlockContext):
         self._print("  └─ Routing:")
-        for stmt in ctx.bindStmt():
+        bind_statements = ctx.bindStmt()
+        line, column = self._line_col(ctx)
+        if not bind_statements:
+            self.diagnostics.append(
+                LockstepDiagnostic(
+                    severity="info",
+                    code="LCK101",
+                    message="Bind block is empty; pipeline has no executable routes.",
+                    line=line,
+                    column=column,
+                    hint="Add at least one binding statement in the bind block.",
+                )
+            )
+        for stmt in bind_statements:
             self._print(f"       {stmt.getText()}")
         return self.visitChildren(ctx)
 
@@ -89,7 +176,7 @@ class LockstepDebugVisitor(LockstepVisitor):
 class LockstepCompileResult:
     parse_tree: Any
     entities: dict[str, Any]
-    diagnostics: list[tuple[int, int, str]] = field(default_factory=list)
+    diagnostics: list[LockstepDiagnostic] = field(default_factory=list)
 
 
 class ParseErrorCollector(ErrorListener):
@@ -97,17 +184,27 @@ class ParseErrorCollector(ErrorListener):
 
     def __init__(self):
         super().__init__()
-        self.errors = []
+        self.errors: list[LockstepDiagnostic] = []
 
     def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e):
-        self.errors.append((line, column, msg))
+        self.errors.append(
+            LockstepDiagnostic(
+                severity="error",
+                code="LCK001",
+                message=msg,
+                line=line,
+                column=column,
+                hint="Fix syntax errors before semantic analysis can continue.",
+            )
+        )
 
 
 class LockstepCompileError(Exception):
     """Raised when the Lockstep source contains parse errors."""
 
-    def __init__(self, errors):
+    def __init__(self, errors, diagnostics=None):
         self.errors = errors
+        self.diagnostics = diagnostics or []
         super().__init__(self._format_message())
 
     def _format_message(self):
@@ -115,7 +212,7 @@ class LockstepCompileError(Exception):
         suffix = "" if count == 1 else "s"
         summary = f"Compilation failed with {count} parse error{suffix}."
         details = "\n".join(
-            f"line {line}:{column} {message}" for line, column, message in self.errors
+            f"line {error.line}:{error.column} {error.message}" for error in self.errors
         )
         return summary if not details else f"{summary}\n{details}"
 
@@ -134,7 +231,7 @@ def compile_lockstep(source_code: str, verbose: bool = True) -> LockstepCompileR
     tree = parser.program()
 
     if error_listener.errors:
-        raise LockstepCompileError(error_listener.errors)
+        raise LockstepCompileError(error_listener.errors, diagnostics=error_listener.errors)
 
     visitor = LockstepDebugVisitor(verbose=verbose)
     visitor.visit(tree)
@@ -146,7 +243,7 @@ def compile_lockstep(source_code: str, verbose: bool = True) -> LockstepCompileR
             "streams": visitor.streams,
             "accumulators": visitor.accumulators,
         },
-        diagnostics=[],
+        diagnostics=visitor.diagnostics,
     )
 
 
@@ -207,8 +304,8 @@ def run_cli(argv=None, *, stdin=None, stderr=None, compiler=compile_lockstep):
         compiler(source)
     except LockstepCompileError as err:
         print(str(err), file=stderr)
-        for line, column, message in err.errors:
-            print(f"  line {line}:{column} {message}", file=stderr)
+        for error in err.errors:
+            print(f"  line {error.line}:{error.column} {error.message}", file=stderr)
         return 1
 
     return 0

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1,10 +1,16 @@
 import importlib
 import io
+import pathlib
 import runpy
 import sys
 import types
 
 import pytest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 
 def _install_fake_generated_modules(monkeypatch):
@@ -95,9 +101,27 @@ def debug_compiler_module(monkeypatch):
     return importlib.import_module("debug_compiler")
 
 
+def _diagnostic(module, line, column, message, *, severity="error", code="LCK001"):
+    return module.LockstepDiagnostic(
+        severity=severity,
+        code=code,
+        message=message,
+        line=line,
+        column=column,
+        hint="Fix syntax errors before semantic analysis can continue.",
+    )
+
+
 def test_lockstep_compile_error_formats_singular_and_plural(debug_compiler_module):
-    one = debug_compiler_module.LockstepCompileError([(1, 1, "oops")])
-    many = debug_compiler_module.LockstepCompileError([(1, 1, "oops"), (2, 4, "bad")])
+    one = debug_compiler_module.LockstepCompileError(
+        [_diagnostic(debug_compiler_module, 1, 1, "oops")]
+    )
+    many = debug_compiler_module.LockstepCompileError(
+        [
+            _diagnostic(debug_compiler_module, 1, 1, "oops"),
+            _diagnostic(debug_compiler_module, 2, 4, "bad"),
+        ]
+    )
 
     assert str(one) == "Compilation failed with 1 parse error.\nline 1:1 oops"
     assert (
@@ -106,11 +130,20 @@ def test_lockstep_compile_error_formats_singular_and_plural(debug_compiler_modul
     )
 
 
-def test_parse_error_collector_captures_location_and_message(debug_compiler_module):
+def test_parse_error_collector_captures_diagnostic(debug_compiler_module):
     collector = debug_compiler_module.ParseErrorCollector()
     collector.syntaxError(None, None, 12, 7, "unexpected token", None)
 
-    assert collector.errors == [(12, 7, "unexpected token")]
+    assert collector.errors == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK001",
+            message="unexpected token",
+            line=12,
+            column=7,
+            hint="Fix syntax errors before semantic analysis can continue.",
+        )
+    ]
 
 
 def test_compile_lockstep_raises_when_parser_reports_errors(
@@ -139,7 +172,17 @@ def test_compile_lockstep_raises_when_parser_reports_errors(
     with pytest.raises(debug_compiler_module.LockstepCompileError) as exc_info:
         debug_compiler_module.compile_lockstep("pipeline P { }")
 
-    assert exc_info.value.errors == [(3, 5, "mismatched input")]
+    assert exc_info.value.errors == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK001",
+            message="mismatched input",
+            line=3,
+            column=5,
+            hint="Fix syntax errors before semantic analysis can continue.",
+        )
+    ]
+    assert exc_info.value.diagnostics == exc_info.value.errors
 
 
 def test_compile_lockstep_visits_tree_on_success(debug_compiler_module, monkeypatch):
@@ -165,6 +208,16 @@ def test_compile_lockstep_visits_tree_on_success(debug_compiler_module, monkeypa
             self.shaders = [{"name": "ApplyGravity", "params": []}]
             self.streams = [{"name": "raw", "type": "Vec3", "capacity": "1000"}]
             self.accumulators = [{"name": "energy", "type": "float"}]
+            self.diagnostics = [
+                debug_compiler_module.LockstepDiagnostic(
+                    severity="warning",
+                    code="LCK203",
+                    message="Stream 'raw' is redeclared.",
+                    line=8,
+                    column=4,
+                    hint="Each stream in a pipeline should have a unique name.",
+                )
+            ]
 
         def visit(self, tree):
             visited["tree"] = tree
@@ -185,11 +238,24 @@ def test_compile_lockstep_visits_tree_on_success(debug_compiler_module, monkeypa
         "streams": [{"name": "raw", "type": "Vec3", "capacity": "1000"}],
         "accumulators": [{"name": "energy", "type": "float"}],
     }
-    assert result.diagnostics == []
+    assert result.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="warning",
+            code="LCK203",
+            message="Stream 'raw' is redeclared.",
+            line=8,
+            column=4,
+            hint="Each stream in a pipeline should have a unique name.",
+        )
+    ]
 
 
 def _token(text):
     return types.SimpleNamespace(getText=lambda: text)
+
+
+def _ctx(start_line=0, start_col=0, **kwargs):
+    return types.SimpleNamespace(start=types.SimpleNamespace(line=start_line, column=start_col), **kwargs)
 
 
 def test_visitor_methods_print_expected_output(debug_compiler_module, capsys):
@@ -223,31 +289,19 @@ def test_visitor_methods_print_expected_output(debug_compiler_module, capsys):
             return self._text
 
     visitor.visitProgram(object())
-    visitor.visitStructDecl(types.SimpleNamespace(ID=lambda: _token("Vec3")))
-    visitor.visitPureDecl(
-        types.SimpleNamespace(ID=lambda: _token("add"), typeName=lambda: _token("Vec3"))
-    )
-    visitor.visitShaderDecl(
-        types.SimpleNamespace(
-            ID=lambda: _token("ApplyGravity"), paramList=lambda: _ParamList()
-        )
-    )
-    visitor.visitPipelineDecl(types.SimpleNamespace(ID=lambda: _token("Physics")))
+    visitor.visitStructDecl(_ctx(ID=lambda: _token("Vec3")))
+    visitor.visitPureDecl(_ctx(ID=lambda: _token("add"), typeName=lambda: _token("Vec3")))
+    visitor.visitShaderDecl(_ctx(ID=lambda: _token("ApplyGravity"), paramList=lambda: _ParamList()))
+    visitor.visitPipelineDecl(_ctx(ID=lambda: _token("Physics")))
     visitor.visitStreamDecl(
-        types.SimpleNamespace(
+        _ctx(
             typeName=lambda: _token("Vec3"),
             INT=lambda: _token("1000"),
             ID=lambda: _token("raw"),
         )
     )
-    visitor.visitAccumDecl(
-        types.SimpleNamespace(
-            typeName=lambda: _token("float"), ID=lambda: _token("energy")
-        )
-    )
-    visitor.visitBindBlock(
-        types.SimpleNamespace(bindStmt=lambda: [_BindStmt("a=b"), _BindStmt("c=d")])
-    )
+    visitor.visitAccumDecl(_ctx(typeName=lambda: _token("float"), ID=lambda: _token("energy")))
+    visitor.visitBindBlock(_ctx(bindStmt=lambda: [_BindStmt("a=b"), _BindStmt("c=d")]))
 
     stdout = capsys.readouterr().out
     assert "=== LOCKSTEP COMPILER FRONTEND ===" in stdout
@@ -270,20 +324,46 @@ def test_visitor_methods_print_expected_output(debug_compiler_module, capsys):
     ]
     assert visitor.streams == [{"name": "raw", "type": "Vec3", "capacity": "1000"}]
     assert visitor.accumulators == [{"name": "energy", "type": "float"}]
+    assert visitor.diagnostics == []
+
+
+def test_visitor_emits_diagnostics_for_non_fatal_observations(debug_compiler_module):
+    visitor = debug_compiler_module.LockstepDebugVisitor(verbose=False)
+
+    visitor.visitStructDecl(_ctx(start_line=2, start_col=1, ID=lambda: _token("Vec3")))
+    visitor.visitStructDecl(_ctx(start_line=3, start_col=1, ID=lambda: _token("Vec3")))
+    visitor.visitBindBlock(_ctx(start_line=10, start_col=4, bindStmt=lambda: []))
+
+    assert visitor.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="warning",
+            code="LCK201",
+            message="Struct 'Vec3' is redeclared.",
+            line=3,
+            column=1,
+            hint="Rename or remove duplicate struct declarations.",
+        ),
+        debug_compiler_module.LockstepDiagnostic(
+            severity="info",
+            code="LCK101",
+            message="Bind block is empty; pipeline has no executable routes.",
+            line=10,
+            column=4,
+            hint="Add at least one binding statement in the bind block.",
+        ),
+    ]
 
 
 def test_visitor_shader_decl_without_param_list(debug_compiler_module, capsys):
     visitor = debug_compiler_module.LockstepDebugVisitor()
-    visitor.visitShaderDecl(
-        types.SimpleNamespace(ID=lambda: _token("Kernel"), paramList=lambda: None)
-    )
+    visitor.visitShaderDecl(_ctx(ID=lambda: _token("Kernel"), paramList=lambda: None))
     assert "[Shader Kernel] Kernel" in capsys.readouterr().out
     assert visitor.shaders == [{"name": "Kernel", "params": []}]
 
 
 def test_visitor_can_run_without_printing(debug_compiler_module, capsys):
     visitor = debug_compiler_module.LockstepDebugVisitor(verbose=False)
-    visitor.visitStructDecl(types.SimpleNamespace(ID=lambda: _token("Vec3")))
+    visitor.visitStructDecl(_ctx(ID=lambda: _token("Vec3")))
 
     assert capsys.readouterr().out == ""
     assert visitor.structs == ["Vec3"]
@@ -352,7 +432,18 @@ def test_run_cli_reads_source_from_path(debug_compiler_module, tmp_path):
 
 def test_run_cli_returns_non_zero_and_writes_errors(debug_compiler_module):
     def failing_compiler(_source):
-        raise debug_compiler_module.LockstepCompileError([(4, 2, "unexpected")])
+        raise debug_compiler_module.LockstepCompileError(
+            [
+                debug_compiler_module.LockstepDiagnostic(
+                    severity="error",
+                    code="LCK001",
+                    message="unexpected",
+                    line=4,
+                    column=2,
+                    hint="Fix syntax errors before semantic analysis can continue.",
+                )
+            ]
+        )
 
     stderr = io.StringIO()
     exit_code = debug_compiler_module.run_cli(


### PR DESCRIPTION
### Motivation

- Make diagnostics a structured, first-class output so non-fatal frontend observations (warnings/info) can be surfaced to callers while preserving hard-fail behavior for parse errors.

### Description

- Add `LockstepDiagnostic` dataclass (severity, code, message, line, column, optional `hint`) and switch `LockstepCompileResult.diagnostics` to return `list[LockstepDiagnostic]` instead of raw tuples.
- Change `ParseErrorCollector` to emit `LockstepDiagnostic` parse errors and make `LockstepCompileError` accept/hold structured diagnostics (keeps raising on fatal parse errors but carries pre-failure context).
- Extend `LockstepDebugVisitor` to accumulate non-fatal diagnostics for semantic observations: duplicate `struct`/`shader`/`stream`/`accumulator` declarations (warnings) and empty `bind` blocks (info); visitor exposes `diagnostics` and `compile_lockstep` returns them.
- Update CLI error printing to format structured diagnostics, update tests to assert on full diagnostic objects and adjust test helpers, and document diagnostic behavior in `README.md` under "Compiler Frontend Usage".

### Testing

- Ran unit tests with `pytest -q -o addopts=''` (to avoid requiring `pytest-cov` from the repo `addopts`); result: `13 passed, 4 skipped`.
- Note: running `pytest -q` with the repo default `addopts` failed in this environment because `pytest-cov` was not available; tests were executed successfully with `-o addopts=''` as shown above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e5a5252dc8328987b4b00a3e96c7b)