### PR TITLE
Add semantic validation phase after parsing in compile_lockstep

### DIFF
--- a/debug_compiler.py
+++ b/debug_compiler.py
@@ -89,7 +89,240 @@ class LockstepDebugVisitor(LockstepVisitor):
 class LockstepCompileResult:
     parse_tree: Any
     entities: dict[str, Any]
-    diagnostics: list[tuple[int, int, str]] = field(default_factory=list)
+    diagnostics: list["SemanticDiagnostic"] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SemanticDiagnostic:
+    line: int
+    column: int
+    severity: str
+    message: str
+
+
+@dataclass(frozen=True)
+class CallableParam:
+    modifier: str
+    type_name: str
+    name: str
+
+
+@dataclass(frozen=True)
+class CallableSymbol:
+    kind: str
+    name: str
+    params: list[CallableParam]
+    return_type: str | None = None
+
+
+@dataclass
+class PipelineScope:
+    name: str
+    streams: dict[str, str] = field(default_factory=dict)
+    accumulators: dict[str, str] = field(default_factory=dict)
+    uniforms: dict[str, str] = field(default_factory=dict)
+
+    def resolve(self, ident: str) -> tuple[str, str] | None:
+        if ident in self.streams:
+            return ("stream", self.streams[ident])
+        if ident in self.accumulators:
+            return ("accumulator", self.accumulators[ident])
+        if ident in self.uniforms:
+            return ("uniform", self.uniforms[ident])
+        return None
+
+
+@dataclass
+class SymbolTable:
+    structs: list[str] = field(default_factory=list)
+    pure_functions: dict[str, CallableSymbol] = field(default_factory=dict)
+    shaders: dict[str, CallableSymbol] = field(default_factory=dict)
+    filters: dict[str, CallableSymbol] = field(default_factory=dict)
+    pipelines: dict[str, PipelineScope] = field(default_factory=dict)
+
+    @property
+    def callables(self) -> dict[str, CallableSymbol]:
+        merged = {}
+        merged.update(self.pure_functions)
+        merged.update(self.shaders)
+        merged.update(self.filters)
+        return merged
+
+
+class LockstepSemanticAnalyzer:
+    """Builds a symbol table and validates semantic correctness."""
+
+    def __init__(self):
+        self.symbols = SymbolTable()
+        self.diagnostics: list[SemanticDiagnostic] = []
+
+    def analyze(self, tree: Any) -> tuple[SymbolTable, list[SemanticDiagnostic]]:
+        self.symbols = SymbolTable()
+        self.diagnostics: list[SemanticDiagnostic] = []
+
+        declarations = getattr(tree, "declaration", None)
+        if callable(declarations):
+            for decl in declarations():
+                self._visit_declaration(decl)
+
+        return self.symbols, self.diagnostics
+
+    def _visit_declaration(self, decl: Any):
+        for method_name, handler in (
+            ("structDecl", self._record_struct),
+            ("pureDecl", self._record_pure),
+            ("shaderDecl", self._record_shader),
+            ("filterDecl", self._record_filter),
+            ("pipelineDecl", self._record_pipeline),
+        ):
+            getter = getattr(decl, method_name, None)
+            if callable(getter):
+                ctx = getter()
+                if ctx is not None:
+                    handler(ctx)
+                    return
+
+    def _record_struct(self, ctx: Any):
+        self.symbols.structs.append(ctx.ID().getText())
+
+    def _record_pure(self, ctx: Any):
+        name = ctx.ID().getText()
+        params = []
+        plist = getattr(ctx, "pureParamList", lambda: None)()
+        if plist is not None:
+            children = plist.getChildren()
+            chunks = [node.getText() for node in children if node.getText() != ","]
+            for i in range(0, len(chunks), 2):
+                params.append(CallableParam("in", chunks[i], chunks[i + 1]))
+        self.symbols.pure_functions[name] = CallableSymbol(
+            kind="pure", name=name, params=params, return_type=ctx.typeName().getText()
+        )
+
+    def _record_shader(self, ctx: Any):
+        self.symbols.shaders[ctx.ID().getText()] = self._callable_from_param_list(
+            kind="shader", name=ctx.ID().getText(), param_list_ctx=ctx.paramList()
+        )
+
+    def _record_filter(self, ctx: Any):
+        self.symbols.filters[ctx.ID().getText()] = self._callable_from_param_list(
+            kind="filter", name=ctx.ID().getText(), param_list_ctx=ctx.paramList()
+        )
+
+    def _callable_from_param_list(self, kind: str, name: str, param_list_ctx: Any):
+        params = []
+        if param_list_ctx is not None:
+            for param in param_list_ctx.param():
+                params.append(
+                    CallableParam(
+                        modifier=param.getChild(0).getText(),
+                        type_name=param.typeName().getText(),
+                        name=param.ID().getText(),
+                    )
+                )
+        return CallableSymbol(kind=kind, name=name, params=params)
+
+    def _record_pipeline(self, ctx: Any):
+        scope = PipelineScope(name=ctx.ID().getText())
+        for member in ctx.pipelineMember():
+            if member.streamDecl() is not None:
+                decl = member.streamDecl()
+                scope.streams[decl.ID().getText()] = decl.typeName().getText()
+            elif member.accumDecl() is not None:
+                decl = member.accumDecl()
+                scope.accumulators[decl.ID().getText()] = decl.typeName().getText()
+            elif member.uniformDecl() is not None:
+                decl = member.uniformDecl()
+                scope.uniforms[decl.ID().getText()] = decl.typeName().getText()
+
+        self.symbols.pipelines[scope.name] = scope
+        self._validate_bind_block(ctx.bindBlock(), scope)
+
+    def _validate_bind_block(self, bind_ctx: Any, scope: PipelineScope):
+        for stmt in bind_ctx.bindStmt():
+            ids = stmt.ID()
+            if len(ids) == 3:
+                self._validate_fold(stmt, scope)
+            else:
+                self._validate_bind_call(stmt, scope)
+
+    def _validate_bind_call(self, stmt: Any, scope: PipelineScope):
+        target_id, kernel_id = stmt.ID()[0], stmt.ID()[1]
+        target_name, kernel_name = target_id.getText(), kernel_id.getText()
+        target_symbol = scope.resolve(target_name)
+        if target_symbol is None or target_symbol[0] != "stream":
+            self._error(stmt, f"bind target '{target_name}' must be a declared stream")
+
+        callable_symbol = self.symbols.callables.get(kernel_name)
+        if callable_symbol is None:
+            self._error(stmt, f"callable '{kernel_name}' is not declared")
+            return
+
+        args = stmt.argList().ID() if stmt.argList() is not None else []
+        if len(args) != len(callable_symbol.params):
+            self._error(
+                stmt,
+                f"call to '{kernel_name}' expects {len(callable_symbol.params)} args, got {len(args)}",
+            )
+            return
+
+        for arg_token, param in zip(args, callable_symbol.params):
+            resolved = scope.resolve(arg_token.getText())
+            if resolved is None:
+                self._error_from_token(
+                    arg_token,
+                    f"argument '{arg_token.getText()}' is not declared in pipeline scope",
+                )
+                continue
+
+            arg_kind, arg_type = resolved
+            if not self._modifier_compatible(param.modifier, arg_kind):
+                self._error_from_token(
+                    arg_token,
+                    f"argument '{arg_token.getText()}' ({arg_kind}) is invalid for '{param.modifier}' parameter",
+                )
+            if arg_type != param.type_name:
+                self._error_from_token(
+                    arg_token,
+                    f"argument '{arg_token.getText()}' type '{arg_type}' does not match expected '{param.type_name}'",
+                )
+
+    def _validate_fold(self, stmt: Any, scope: PipelineScope):
+        source_id = stmt.ID()[2]
+        source = source_id.getText()
+        resolved = scope.resolve(source)
+        if resolved is None:
+            self._error_from_token(
+                source_id,
+                f"fold source '{source}' is not declared in pipeline scope",
+            )
+            return
+        if resolved[0] != "accumulator":
+            self._error_from_token(source_id, f"fold source '{source}' must be an accumulator")
+
+    def _modifier_compatible(self, modifier: str, symbol_kind: str):
+        compat = {
+            "in": {"stream", "uniform", "accumulator"},
+            "out": {"stream"},
+            "uniform": {"uniform"},
+            "accum": {"accumulator"},
+        }
+        return symbol_kind in compat.get(modifier, set())
+
+    def _location(self, ctx_or_token: Any) -> tuple[int, int]:
+        token = getattr(ctx_or_token, "start", None)
+        if token is None:
+            token = ctx_or_token
+        line = getattr(token, "line", 0) or 0
+        column = getattr(token, "column", 0) or 0
+        return line, column
+
+    def _error(self, ctx: Any, message: str):
+        line, column = self._location(ctx)
+        self.diagnostics.append(SemanticDiagnostic(line, column, "error", message))
+
+    def _error_from_token(self, token: Any, message: str):
+        line, column = self._location(token)
+        self.diagnostics.append(SemanticDiagnostic(line, column, "error", message))
 
 
 class ParseErrorCollector(ErrorListener):
@@ -138,6 +371,7 @@ def compile_lockstep(source_code: str, verbose: bool = True) -> LockstepCompileR
 
     visitor = LockstepDebugVisitor(verbose=verbose)
     visitor.visit(tree)
+    semantic_symbols, semantic_diagnostics = LockstepSemanticAnalyzer().analyze(tree)
     return LockstepCompileResult(
         parse_tree=tree,
         entities={
@@ -145,8 +379,22 @@ def compile_lockstep(source_code: str, verbose: bool = True) -> LockstepCompileR
             "shaders": visitor.shaders,
             "streams": visitor.streams,
             "accumulators": visitor.accumulators,
+            "symbol_table": {
+                "structs": semantic_symbols.structs,
+                "pure_functions": list(semantic_symbols.pure_functions),
+                "shaders": list(semantic_symbols.shaders),
+                "filters": list(semantic_symbols.filters),
+                "pipelines": {
+                    name: {
+                        "streams": scope.streams,
+                        "accumulators": scope.accumulators,
+                        "uniforms": scope.uniforms,
+                    }
+                    for name, scope in semantic_symbols.pipelines.items()
+                },
+            },
         },
-        diagnostics=[],
+        diagnostics=semantic_diagnostics,
     )
 
 

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -184,8 +184,82 @@ def test_compile_lockstep_visits_tree_on_success(debug_compiler_module, monkeypa
         "shaders": [{"name": "ApplyGravity", "params": []}],
         "streams": [{"name": "raw", "type": "Vec3", "capacity": "1000"}],
         "accumulators": [{"name": "energy", "type": "float"}],
+        "symbol_table": {
+            "structs": [],
+            "pure_functions": [],
+            "shaders": [],
+            "filters": [],
+            "pipelines": {},
+        },
     }
     assert result.diagnostics == []
+
+
+def test_semantic_bind_stmt_validation_reports_errors(debug_compiler_module):
+    analyzer = debug_compiler_module.LockstepSemanticAnalyzer()
+    analyzer.symbols.shaders["ApplyGravity"] = debug_compiler_module.CallableSymbol(
+        kind="shader",
+        name="ApplyGravity",
+        params=[
+            debug_compiler_module.CallableParam("in", "Vec3", "pos"),
+            debug_compiler_module.CallableParam("out", "Vec3", "new_pos"),
+            debug_compiler_module.CallableParam("accum", "float", "energy"),
+            debug_compiler_module.CallableParam("uniform", "float", "dt"),
+        ],
+    )
+    scope = debug_compiler_module.PipelineScope(
+        name="Physics",
+        streams={"raw_positions": "Vec3", "final_positions": "Vec3"},
+        accumulators={"total_energy": "float"},
+        uniforms={"dt": "float"},
+    )
+
+    def _id_token(text, line=1, column=0):
+        return types.SimpleNamespace(getText=lambda: text, line=line, column=column)
+
+    bad_call = types.SimpleNamespace(
+        ID=lambda: [_id_token("missing_stream"), _id_token("MissingKernel")],
+        argList=lambda: types.SimpleNamespace(ID=lambda: [_id_token("raw_positions")]),
+        start=types.SimpleNamespace(line=4, column=2),
+    )
+    analyzer._validate_bind_call(bad_call, scope)
+
+    arity_call = types.SimpleNamespace(
+        ID=lambda: [_id_token("final_positions"), _id_token("ApplyGravity")],
+        argList=lambda: types.SimpleNamespace(ID=lambda: [_id_token("raw_positions")]),
+        start=types.SimpleNamespace(line=5, column=2),
+    )
+    analyzer._validate_bind_call(arity_call, scope)
+
+    type_call = types.SimpleNamespace(
+        ID=lambda: [_id_token("final_positions"), _id_token("ApplyGravity")],
+        argList=lambda: types.SimpleNamespace(
+            ID=lambda: [
+                _id_token("raw_positions", 6, 10),
+                _id_token("final_positions", 6, 20),
+                _id_token("raw_positions", 6, 30),
+                _id_token("total_energy", 6, 40),
+            ]
+        ),
+        start=types.SimpleNamespace(line=6, column=2),
+    )
+    analyzer._validate_bind_call(type_call, scope)
+
+    fold_stmt = types.SimpleNamespace(
+        ID=lambda: [_id_token("sys_energy"), _id_token("sum"), _id_token("final_positions", 7, 12)],
+        start=types.SimpleNamespace(line=7, column=2),
+    )
+    analyzer._validate_fold(fold_stmt, scope)
+
+    diagnostics = analyzer.diagnostics
+    assert any("must be a declared stream" in d.message for d in diagnostics)
+    assert any("is not declared" in d.message for d in diagnostics)
+    assert any("expects 4 args, got 1" in d.message for d in diagnostics)
+    assert any("invalid for 'accum'" in d.message for d in diagnostics)
+    assert any("raw_positions' type 'Vec3' does not match expected 'float'" in d.message for d in diagnostics)
+    assert any("must be an accumulator" in d.message for d in diagnostics)
+    assert diagnostics[0].line == 4
+    assert diagnostics[0].column == 2
 
 
 def _token(text):


### PR DESCRIPTION
### Motivation

- Add a semantic-validation pass to catch pipeline-level errors (bind/fold misuse, undeclared identifiers, signature mismatches) earlier and report precise diagnostics with source locations.
- Build a lightweight symbol-table model so downstream tooling can inspect declared structs, callables, and per-pipeline scopes.

### Description

- Introduced `LockstepSemanticAnalyzer` and a `SymbolTable` model (structs, pure functions, shaders, filters, pipelines with streams/accumulators/uniforms) and related dataclasses `CallableParam`, `CallableSymbol`, `PipelineScope`, and `SemanticDiagnostic` in `debug_compiler.py`.
- Implemented semantic checks for `bindStmt` and `fold` forms: verify bind target is a stream, callable/kernel exists, arguments exist in pipeline scope, fold source exists and is an accumulator, check argument arity and modifier/type compatibility, and record diagnostics with line/column where available.
- Extended `compile_lockstep` to run the semantic analyzer after the parse visitor and include the symbol-table snapshot in `entities` and semantic diagnostics in `LockstepCompileResult.diagnostics`.
- Added tests and adjusted expectations in `tests/test_debug_compiler.py` to validate the new compile result shape and to assert semantic diagnostic contents and locations.

### Testing

- Running `pytest` with project coverage options failed in this environment due to unavailable `pytest-cov` flags from `pyproject.toml` (error: unrecognized arguments from coverage options).
- Ran the unit tests with coverage flags disabled using `PYTHONPATH=/workspace/lockstep pytest -q -o addopts='' tests/test_debug_compiler.py tests/test_expr_precedence.py` and observed all tests pass with `13 passed, 4 skipped`.
- Also ran the single test `PYTHONPATH=/workspace/lockstep pytest -q -o addopts='' tests/test_debug_compiler.py::test_compile_lockstep_visits_tree_on_success` which passed (1 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e5a398b0083289085a7868b636340)