### PR TITLE
Add semantic validation phase to compile_lockstep

### DIFF
--- a/debug_compiler.py
+++ b/debug_compiler.py
@@ -202,19 +202,38 @@ class ParseErrorCollector(ErrorListener):
 class LockstepCompileError(Exception):
     """Raised when the Lockstep source contains parse errors."""
 
-    def __init__(self, errors, diagnostics=None):
+    def __init__(self, errors, diagnostics=None, *, phase: str = "parse"):
         self.errors = errors
         self.diagnostics = diagnostics or []
+        self.phase = phase
         super().__init__(self._format_message())
 
     def _format_message(self):
         count = len(self.errors)
         suffix = "" if count == 1 else "s"
-        summary = f"Compilation failed with {count} parse error{suffix}."
+        summary = f"Compilation failed with {count} {self.phase} error{suffix}."
         details = "\n".join(
             f"line {error.line}:{error.column} {error.message}" for error in self.errors
         )
         return summary if not details else f"{summary}\n{details}"
+
+
+class LockstepSemanticValidator(LockstepVisitor):
+    """Runs semantic checks on a parsed Lockstep program."""
+
+    def __init__(self):
+        self.diagnostics: list[LockstepDiagnostic] = []
+
+    def validate(self, tree):
+        self.visit(tree)
+        return self.diagnostics
+
+
+def validate_semantics(parse_tree: Any) -> list[LockstepDiagnostic]:
+    """Validate semantic constraints after syntactic parsing succeeds."""
+
+    validator = LockstepSemanticValidator()
+    return validator.validate(parse_tree)
 
 
 def compile_lockstep(source_code: str, verbose: bool = True) -> LockstepCompileResult:
@@ -233,6 +252,19 @@ def compile_lockstep(source_code: str, verbose: bool = True) -> LockstepCompileR
     if error_listener.errors:
         raise LockstepCompileError(error_listener.errors, diagnostics=error_listener.errors)
 
+    semantic_diagnostics = validate_semantics(tree)
+    semantic_errors = [
+        diagnostic
+        for diagnostic in semantic_diagnostics
+        if diagnostic.severity == "error"
+    ]
+    if semantic_errors:
+        raise LockstepCompileError(
+            semantic_errors,
+            diagnostics=semantic_diagnostics,
+            phase="semantic",
+        )
+
     visitor = LockstepDebugVisitor(verbose=verbose)
     visitor.visit(tree)
     return LockstepCompileResult(
@@ -243,7 +275,7 @@ def compile_lockstep(source_code: str, verbose: bool = True) -> LockstepCompileR
             "streams": visitor.streams,
             "accumulators": visitor.accumulators,
         },
-        diagnostics=visitor.diagnostics,
+        diagnostics=[*semantic_diagnostics, *visitor.diagnostics],
     )
 
 

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -250,6 +250,98 @@ def test_compile_lockstep_visits_tree_on_success(debug_compiler_module, monkeypa
     ]
 
 
+def test_compile_lockstep_runs_semantic_validation_phase(
+    debug_compiler_module, monkeypatch
+):
+    class SuccessParser:
+        def __init__(self, stream):
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            return "TREE"
+
+    monkeypatch.setattr(
+        debug_compiler_module, "CommonTokenStream", lambda lexer: object()
+    )
+    monkeypatch.setattr(debug_compiler_module, "LockstepParser", SuccessParser)
+    monkeypatch.setattr(
+        debug_compiler_module,
+        "validate_semantics",
+        lambda parse_tree: [
+            debug_compiler_module.LockstepDiagnostic(
+                severity="info",
+                code="LCK301",
+                message=f"validated {parse_tree}",
+                line=1,
+                column=0,
+                hint="semantic phase ran",
+            )
+        ],
+    )
+
+    result = debug_compiler_module.compile_lockstep("pipeline P { }", verbose=False)
+
+    assert result.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="info",
+            code="LCK301",
+            message="validated TREE",
+            line=1,
+            column=0,
+            hint="semantic phase ran",
+        )
+    ]
+
+
+def test_compile_lockstep_raises_for_semantic_errors(
+    debug_compiler_module, monkeypatch
+):
+    class SuccessParser:
+        def __init__(self, stream):
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            return "TREE"
+
+    monkeypatch.setattr(
+        debug_compiler_module, "CommonTokenStream", lambda lexer: object()
+    )
+    monkeypatch.setattr(debug_compiler_module, "LockstepParser", SuccessParser)
+    monkeypatch.setattr(
+        debug_compiler_module,
+        "validate_semantics",
+        lambda _parse_tree: [
+            debug_compiler_module.LockstepDiagnostic(
+                severity="error",
+                code="LCK401",
+                message="semantic problem",
+                line=5,
+                column=2,
+                hint="fix semantic issue",
+            )
+        ],
+    )
+
+    with pytest.raises(debug_compiler_module.LockstepCompileError) as exc_info:
+        debug_compiler_module.compile_lockstep("pipeline P { }", verbose=False)
+
+    assert str(exc_info.value) == (
+        "Compilation failed with 1 semantic error.\nline 5:2 semantic problem"
+    )
+
+
 def _token(text):
     return types.SimpleNamespace(getText=lambda: text)
 


### PR DESCRIPTION
### Motivation
- Ensure semantic constraints are checked immediately after parsing so semantic problems are detected and reported before further processing.
- Provide an extension point for future semantic checks and surface semantic diagnostics alongside parse/visitor diagnostics.

### Description
- Introduce `LockstepSemanticValidator` (subclassing `LockstepVisitor`) and a `validate_semantics(parse_tree)` helper that returns semantic `LockstepDiagnostic`s.
- Run `validate_semantics` in `compile_lockstep` after parsing and before the debug visitor, and raise `LockstepCompileError` when any semantic diagnostics with `severity == "error"` are present.
- Extend `LockstepCompileError` to accept a `phase` keyword (default `"parse"`) and update its formatted message to include the phase.
- Merge semantic diagnostics into the compile result `diagnostics` on successful compilation and add unit tests to cover the semantic phase behavior.

### Testing
- Added tests `test_compile_lockstep_runs_semantic_validation_phase` and `test_compile_lockstep_raises_for_semantic_errors` which exercise successful semantic diagnostics and semantic-error propagation, respectively.
- Ran tests with `pytest -q -o addopts=''` and observed `18 passed, 4 skipped`.
- Running `pytest -q` in this environment initially failed due to project `addopts` including coverage flags not available here, so the controlled invocation above was used to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a07e5905d08328a75a9aac1934fa2c)