### PR TITLE
Avoid duplicate diagnostic lines in run_cli compile errors

### DIFF
--- a/debug_compiler.py
+++ b/debug_compiler.py
@@ -350,9 +350,14 @@ def run_cli(argv=None, *, stdin=None, stderr=None, compiler=compile_lockstep):
     try:
         compiler(source)
     except LockstepCompileError as err:
-        print(str(err), file=stderr)
+        count = len(err.errors)
+        suffix = "" if count == 1 else "s"
+        print(
+            f"Compilation failed with {count} {err.phase} error{suffix}.",
+            file=stderr,
+        )
         for error in err.errors:
-            print(f"  line {error.line}:{error.column} {error.message}", file=stderr)
+            print(f"line {error.line}:{error.column} {error.message}", file=stderr)
         return 1
 
     return 0

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -546,8 +546,10 @@ def test_run_cli_returns_non_zero_and_writes_errors(debug_compiler_module):
     )
 
     assert exit_code == 1
-    assert "Compilation failed with 1 parse error." in stderr.getvalue()
-    assert "line 4:2 unexpected" in stderr.getvalue()
+    assert stderr.getvalue().splitlines() == [
+        "Compilation failed with 1 parse error.",
+        "line 4:2 unexpected",
+    ]
 
 
 def test_run_cli_returns_non_zero_for_missing_path(debug_compiler_module, tmp_path):


### PR DESCRIPTION
### Motivation

- Ensure the CLI renders `LockstepCompileError` consistently with a single path so callers and scripts receive a stable, non-duplicated output format.

### Description

- Updated `run_cli()` in `debug_compiler.py` to stop printing `str(err)` and instead print a single summary line followed by one line per diagnostic.
- Normalized diagnostic line formatting to `line {line}:{column} {message}` so lines are consistent and not double-emitted.
- Updated `test_run_cli_returns_non_zero_and_writes_errors` to assert the exact line-by-line `stderr` content using `splitlines()` to guarantee ordering (summary first, then diagnostics).

### Testing

- Running `pytest -q` initially failed in this environment due to project `addopts` requiring `pytest-cov` flags not available here.
- Running `pytest -q -o addopts=''` passed with `18 passed, 4 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0822c3cf483288880d71446d899b8)