### PR TITLE
Extend debug compiler entity extraction for filters, uniforms, and bind routes

### DIFF
--- a/debug_compiler.py
+++ b/debug_compiler.py
@@ -26,17 +26,25 @@ class LockstepDiagnostic:
 class LockstepDebugVisitor(LockstepVisitor):
     """Walks the Parse Tree and extracts the pipeline architecture."""
 
-    def __init__(self, verbose: bool = True):
+    def __init__(self, verbose: bool = True, *, normalize_bind_routes: bool = False):
         self.verbose = verbose
+        self.normalize_bind_routes = normalize_bind_routes
         self.structs = []
         self.shaders = []
+        self.filters = []
+        self.pure_functions = []
         self.streams = []
         self.accumulators = []
+        self.uniforms = []
+        self.bind_routes = []
         self.diagnostics: list[LockstepDiagnostic] = []
         self._seen_structs = set()
         self._seen_shaders = set()
+        self._seen_filters = set()
+        self._seen_pure_functions = set()
         self._seen_streams = set()
         self._seen_accumulators = set()
+        self._seen_uniforms = set()
 
     def _print(self, message: str):
         if self.verbose:
@@ -76,7 +84,49 @@ class LockstepDebugVisitor(LockstepVisitor):
     def visitPureDecl(self, ctx: LockstepParser.PureDeclContext):
         name = ctx.ID().getText()
         ret_type = ctx.typeName().getText()
+        line, column = self._line_col(ctx)
+        if name in self._seen_pure_functions:
+            self.diagnostics.append(
+                LockstepDiagnostic(
+                    severity="warning",
+                    code="LCK205",
+                    message=f"Pure function '{name}' is redeclared.",
+                    line=line,
+                    column=column,
+                    hint="Rename or remove duplicate pure function declarations.",
+                )
+            )
+        self._seen_pure_functions.add(name)
+        self.pure_functions.append({"name": name, "return_type": ret_type})
         self._print(f"[Pure Function] {name} -> {ret_type}")
+        return self.visitChildren(ctx)
+
+    def visitFilterDecl(self, ctx: LockstepParser.FilterDeclContext):
+        name = ctx.ID().getText()
+        line, column = self._line_col(ctx)
+        if name in self._seen_filters:
+            self.diagnostics.append(
+                LockstepDiagnostic(
+                    severity="warning",
+                    code="LCK206",
+                    message=f"Filter '{name}' is redeclared.",
+                    line=line,
+                    column=column,
+                    hint="Rename or remove duplicate filter declarations.",
+                )
+            )
+        self._seen_filters.add(name)
+
+        params = []
+        self._print(f"\n[Filter Kernel] {name}")
+        if ctx.paramList():
+            for param in ctx.paramList().param():
+                modifier = param.getChild(0).getText()
+                p_type = param.typeName().getText()
+                p_name = param.ID().getText()
+                params.append({"modifier": modifier, "type": p_type, "name": p_name})
+                self._print(f"  └─ Param: ({modifier}) {p_type} {p_name}")
+        self.filters.append({"name": name, "params": params})
         return self.visitChildren(ctx)
 
     def visitShaderDecl(self, ctx: LockstepParser.ShaderDeclContext):
@@ -152,6 +202,30 @@ class LockstepDebugVisitor(LockstepVisitor):
         self._print(f"  └─ Accumulator: {name} <{a_type}>")
         return self.visitChildren(ctx)
 
+    def visitUniformDecl(self, ctx: LockstepParser.UniformDeclContext):
+        u_type = ctx.typeName().getText()
+        name = ctx.ID().getText()
+        line, column = self._line_col(ctx)
+        if name in self._seen_uniforms:
+            self.diagnostics.append(
+                LockstepDiagnostic(
+                    severity="warning",
+                    code="LCK207",
+                    message=f"Uniform '{name}' is redeclared.",
+                    line=line,
+                    column=column,
+                    hint="Each uniform in a pipeline should have a unique name.",
+                )
+            )
+        self._seen_uniforms.add(name)
+
+        initializer = None
+        if ctx.expr():
+            initializer = ctx.expr().getText()
+        self.uniforms.append({"name": name, "type": u_type, "initializer": initializer})
+        self._print(f"  └─ Uniform: {name} <{u_type}>")
+        return self.visitChildren(ctx)
+
     def visitBindBlock(self, ctx: LockstepParser.BindBlockContext):
         self._print("  └─ Routing:")
         bind_statements = ctx.bindStmt()
@@ -168,7 +242,11 @@ class LockstepDebugVisitor(LockstepVisitor):
                 )
             )
         for stmt in bind_statements:
-            self._print(f"       {stmt.getText()}")
+            route = stmt.getText()
+            if self.normalize_bind_routes:
+                route = " ".join(route.split())
+            self.bind_routes.append(route)
+            self._print(f"       {route}")
         return self.visitChildren(ctx)
 
 
@@ -272,8 +350,12 @@ def compile_lockstep(source_code: str, verbose: bool = True) -> LockstepCompileR
         entities={
             "structs": visitor.structs,
             "shaders": visitor.shaders,
+            "filters": visitor.filters,
+            "pure_functions": visitor.pure_functions,
             "streams": visitor.streams,
             "accumulators": visitor.accumulators,
+            "uniforms": visitor.uniforms,
+            "bind_routes": visitor.bind_routes,
         },
         diagnostics=[*semantic_diagnostics, *visitor.diagnostics],
     )

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -47,6 +47,9 @@ def _install_fake_generated_modules(monkeypatch):
         class ShaderDeclContext:
             pass
 
+        class FilterDeclContext:
+            pass
+
         class PipelineDeclContext:
             pass
 
@@ -54,6 +57,9 @@ def _install_fake_generated_modules(monkeypatch):
             pass
 
         class AccumDeclContext:
+            pass
+
+        class UniformDeclContext:
             pass
 
         class BindBlockContext:
@@ -206,8 +212,12 @@ def test_compile_lockstep_visits_tree_on_success(debug_compiler_module, monkeypa
             self.verbose = verbose
             self.structs = ["Vec3"]
             self.shaders = [{"name": "ApplyGravity", "params": []}]
+            self.filters = [{"name": "OnlyActive", "params": []}]
+            self.pure_functions = [{"name": "add", "return_type": "Vec3"}]
             self.streams = [{"name": "raw", "type": "Vec3", "capacity": "1000"}]
             self.accumulators = [{"name": "energy", "type": "float"}]
+            self.uniforms = [{"name": "dt", "type": "float", "initializer": "0.016"}]
+            self.bind_routes = ["final=ApplyGravity(raw,final,energy,dt);"]
             self.diagnostics = [
                 debug_compiler_module.LockstepDiagnostic(
                     severity="warning",
@@ -235,8 +245,12 @@ def test_compile_lockstep_visits_tree_on_success(debug_compiler_module, monkeypa
     assert result.entities == {
         "structs": ["Vec3"],
         "shaders": [{"name": "ApplyGravity", "params": []}],
+        "filters": [{"name": "OnlyActive", "params": []}],
+        "pure_functions": [{"name": "add", "return_type": "Vec3"}],
         "streams": [{"name": "raw", "type": "Vec3", "capacity": "1000"}],
         "accumulators": [{"name": "energy", "type": "float"}],
+        "uniforms": [{"name": "dt", "type": "float", "initializer": "0.016"}],
+        "bind_routes": ["final=ApplyGravity(raw,final,energy,dt);"],
     }
     assert result.diagnostics == [
         debug_compiler_module.LockstepDiagnostic(
@@ -384,6 +398,7 @@ def test_visitor_methods_print_expected_output(debug_compiler_module, capsys):
     visitor.visitStructDecl(_ctx(ID=lambda: _token("Vec3")))
     visitor.visitPureDecl(_ctx(ID=lambda: _token("add"), typeName=lambda: _token("Vec3")))
     visitor.visitShaderDecl(_ctx(ID=lambda: _token("ApplyGravity"), paramList=lambda: _ParamList()))
+    visitor.visitFilterDecl(_ctx(ID=lambda: _token("OnlyActive"), paramList=lambda: _ParamList()))
     visitor.visitPipelineDecl(_ctx(ID=lambda: _token("Physics")))
     visitor.visitStreamDecl(
         _ctx(
@@ -393,6 +408,13 @@ def test_visitor_methods_print_expected_output(debug_compiler_module, capsys):
         )
     )
     visitor.visitAccumDecl(_ctx(typeName=lambda: _token("float"), ID=lambda: _token("energy")))
+    visitor.visitUniformDecl(
+        _ctx(
+            typeName=lambda: _token("float"),
+            ID=lambda: _token("dt"),
+            expr=lambda: _token("0.016"),
+        )
+    )
     visitor.visitBindBlock(_ctx(bindStmt=lambda: [_BindStmt("a=b"), _BindStmt("c=d")]))
 
     stdout = capsys.readouterr().out
@@ -402,8 +424,10 @@ def test_visitor_methods_print_expected_output(debug_compiler_module, capsys):
     assert "[Shader Kernel] ApplyGravity" in stdout
     assert "Param: (in) Vec3 pos" in stdout
     assert "[Pipeline Topology] Physics" in stdout
+    assert "[Filter Kernel] OnlyActive" in stdout
     assert "Stream: raw <Vec3, 1000>" in stdout
     assert "Accumulator: energy <float>" in stdout
+    assert "Uniform: dt <float>" in stdout
     assert "Routing:" in stdout
     assert "a=b" in stdout
     assert "c=d" in stdout
@@ -414,8 +438,17 @@ def test_visitor_methods_print_expected_output(debug_compiler_module, capsys):
             "params": [{"modifier": "in", "type": "Vec3", "name": "pos"}],
         }
     ]
+    assert visitor.filters == [
+        {
+            "name": "OnlyActive",
+            "params": [{"modifier": "in", "type": "Vec3", "name": "pos"}],
+        }
+    ]
+    assert visitor.pure_functions == [{"name": "add", "return_type": "Vec3"}]
     assert visitor.streams == [{"name": "raw", "type": "Vec3", "capacity": "1000"}]
     assert visitor.accumulators == [{"name": "energy", "type": "float"}]
+    assert visitor.uniforms == [{"name": "dt", "type": "float", "initializer": "0.016"}]
+    assert visitor.bind_routes == ["a=b", "c=d"]
     assert visitor.diagnostics == []
 
 
@@ -424,6 +457,20 @@ def test_visitor_emits_diagnostics_for_non_fatal_observations(debug_compiler_mod
 
     visitor.visitStructDecl(_ctx(start_line=2, start_col=1, ID=lambda: _token("Vec3")))
     visitor.visitStructDecl(_ctx(start_line=3, start_col=1, ID=lambda: _token("Vec3")))
+    visitor.visitPureDecl(
+        _ctx(start_line=4, start_col=1, ID=lambda: _token("add"), typeName=lambda: _token("Vec3"))
+    )
+    visitor.visitPureDecl(
+        _ctx(start_line=5, start_col=1, ID=lambda: _token("add"), typeName=lambda: _token("Vec3"))
+    )
+    visitor.visitFilterDecl(_ctx(start_line=6, start_col=1, ID=lambda: _token("f"), paramList=lambda: None))
+    visitor.visitFilterDecl(_ctx(start_line=7, start_col=1, ID=lambda: _token("f"), paramList=lambda: None))
+    visitor.visitUniformDecl(
+        _ctx(start_line=8, start_col=1, typeName=lambda: _token("float"), ID=lambda: _token("dt"), expr=lambda: None)
+    )
+    visitor.visitUniformDecl(
+        _ctx(start_line=9, start_col=1, typeName=lambda: _token("float"), ID=lambda: _token("dt"), expr=lambda: None)
+    )
     visitor.visitBindBlock(_ctx(start_line=10, start_col=4, bindStmt=lambda: []))
 
     assert visitor.diagnostics == [
@@ -434,6 +481,30 @@ def test_visitor_emits_diagnostics_for_non_fatal_observations(debug_compiler_mod
             line=3,
             column=1,
             hint="Rename or remove duplicate struct declarations.",
+        ),
+        debug_compiler_module.LockstepDiagnostic(
+            severity="warning",
+            code="LCK205",
+            message="Pure function 'add' is redeclared.",
+            line=5,
+            column=1,
+            hint="Rename or remove duplicate pure function declarations.",
+        ),
+        debug_compiler_module.LockstepDiagnostic(
+            severity="warning",
+            code="LCK206",
+            message="Filter 'f' is redeclared.",
+            line=7,
+            column=1,
+            hint="Rename or remove duplicate filter declarations.",
+        ),
+        debug_compiler_module.LockstepDiagnostic(
+            severity="warning",
+            code="LCK207",
+            message="Uniform 'dt' is redeclared.",
+            line=9,
+            column=1,
+            hint="Each uniform in a pipeline should have a unique name.",
         ),
         debug_compiler_module.LockstepDiagnostic(
             severity="info",
@@ -451,6 +522,24 @@ def test_visitor_shader_decl_without_param_list(debug_compiler_module, capsys):
     visitor.visitShaderDecl(_ctx(ID=lambda: _token("Kernel"), paramList=lambda: None))
     assert "[Shader Kernel] Kernel" in capsys.readouterr().out
     assert visitor.shaders == [{"name": "Kernel", "params": []}]
+
+
+def test_visitor_bind_routes_can_be_normalized(debug_compiler_module):
+    visitor = debug_compiler_module.LockstepDebugVisitor(
+        verbose=False,
+        normalize_bind_routes=True,
+    )
+
+    class _BindStmt:
+        def __init__(self, text):
+            self._text = text
+
+        def getText(self):
+            return self._text
+
+    visitor.visitBindBlock(_ctx(bindStmt=lambda: [_BindStmt(" a   =b(c , d ) ; ")]))
+
+    assert visitor.bind_routes == ["a =b(c , d ) ;"]
 
 
 def test_visitor_can_run_without_printing(debug_compiler_module, capsys):


### PR DESCRIPTION
### Motivation
- Add richer entity extraction to the debug compiler so callers can observe `filters`, `pure_functions`, `uniforms`, and `bind_routes` from the parse tree. 
- Surface non-fatal duplicate-name diagnostics for the new entity kinds to help users spot accidental redeclarations. 
- Provide an option to normalize bind-route strings for deterministic comparison/consumption while preserving prior behavior and API shape. 

### Description
- Extended `LockstepDebugVisitor` to track `filters`, `pure_functions`, `uniforms`, and `bind_routes`, and added an opt-in `normalize_bind_routes` flag to normalize route text. 
- Implemented `visitFilterDecl`, enhanced `visitPureDecl` and added `visitUniformDecl` to collect entity records and emit duplicate-name warnings (`LCK205`, `LCK206`, `LCK207`). 
- Updated `visitBindBlock` to append collected routes to `bind_routes` and apply normalization when requested. 
- Kept existing entity keys intact and updated `compile_lockstep()` to include the new keys (`filters`, `pure_functions`, `uniforms`, `bind_routes`) in `LockstepCompileResult.entities` while preserving `structs`, `shaders`, `streams`, and `accumulators`. 
- Expanded `tests/test_debug_compiler.py` to add stub contexts, validate new collections in compile results, assert duplicate diagnostics for newly tracked entities, and test bind-route normalization. 

### Testing
- Running `pytest -q tests/test_debug_compiler.py` initially failed due to repo-level `addopts` coverage flags not available in the environment (unrelated to the code changes). 
- Running `pytest -q tests/test_debug_compiler.py -o addopts=''` executed the test module and all tests passed (`19 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0822e05748328945a8780e39bd475)