### PR TITLE
Support decimal/exponent numeric literal forms in Lockstep grammar

### DIFF
--- a/Lockstep.g4
+++ b/Lockstep.g4
@@ -76,7 +76,13 @@ lvalue: ID ('.' ID)*;
 typeName: ID;
 
 ID: [a-zA-Z_][a-zA-Z0-9_]*;
+FLOAT
+    : [0-9]+ '.' [0-9]* EXPONENT?
+    | '.' [0-9]+ EXPONENT?
+    | [0-9]+ EXPONENT
+    ;
 INT: [0-9]+;
-FLOAT: [0-9]+ '.' [0-9]+;
+
+fragment EXPONENT: [eE] [+-]? [0-9]+;
 WS: [ \t\r\n]+ -> skip;
 COMMENT: '//' ~[\r\n]* -> skip;

--- a/tests/test_expr_precedence.py
+++ b/tests/test_expr_precedence.py
@@ -91,3 +91,19 @@ def test_logical_and_binds_tighter_than_or(generated_parser):
     assert "|| (logicalAndExpr" in parsed
     assert "(logicalAndExpr (equalityExpr" in parsed
     assert "&& (equalityExpr" in parsed
+
+
+@pytest.mark.parametrize("literal", ["1.0", "1.", ".5", "1e3", "1.2e-3"])
+def test_numeric_literal_variants_parse(generated_parser, literal):
+    lexer_cls, parser_cls = generated_parser
+    parsed = _parse_expr(literal, lexer_cls, parser_cls)
+
+    assert "(primaryExpr" in parsed
+
+
+def test_numeric_literals_keep_member_access_precedence(generated_parser):
+    lexer_cls, parser_cls = generated_parser
+    parsed = _parse_expr("obj.x + .5", lexer_cls, parser_cls)
+
+    assert "(lvalue obj . x)" in parsed
+    assert "(primaryExpr .5)" in parsed


### PR DESCRIPTION
### Motivation
- Allow the language to accept common numeric literal forms such as `1.0`, `1.`, `.5`, `1e3`, and `1.2e-3` while keeping `INT` as integer-only and avoiding lexer ambiguities with `.` in `lvalue` expressions.

### Description
- Reworked numeric lexer rules in `Lockstep.g4` by introducing a `FLOAT` token with alternatives for decimal and exponent forms and a `fragment EXPONENT` for scientific notation, and left `INT` as `[0-9]+`.
- Preserved member-access parsing as `lvalue: ID ('.' ID)*` so `obj.x` continues to be recognized without interference from leading-dot floats.
- Added parameterized tests in `tests/test_expr_precedence.py` to assert parsing of `"1.0"`, `"1."`, `".5"`, `"1e3"`, `"1.2e-3"` and a regression test `obj.x + .5` to ensure member-access precedence is unchanged.
- Attempted to regenerate ANTLR Python artifacts using the ANTLR jar (`java -jar antlr-4.13.1-complete.jar -Dlanguage=Python3 -visitor Lockstep.g4`).

### Testing
- Ran `pytest -q` which completed successfully for the suite, with expression-parse tests skipped in their fixture because the environment lacked the `antlr4` CLI wrapper; overall suite passed otherwise.
- Attempted to run `./make.sh` which failed due to missing `antlr4` command, then successfully generated parser artifacts with `java -jar /tmp/antlr-4.13.1-complete.jar -Dlanguage=Python3 -visitor Lockstep.g4`.
- Ran `pytest -q tests/test_expr_precedence.py` after generating artifacts but the test fixture still invokes the `antlr4` wrapper and therefore the file-level tests were skipped in this environment; no parser regressions were observed in manually generated artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a08230549c8328b61f5bd1ee9d2e18)