### PR TITLE
Refactor expr precedence tests to assert parse-tree structure

### DIFF
--- a/tests/test_expr_precedence.py
+++ b/tests/test_expr_precedence.py
@@ -54,40 +54,106 @@ def _parse_expr(text, lexer_cls, parser_cls):
     assert parser.getNumberOfSyntaxErrors() == 0
     assert parser.getCurrentToken().type == parser.EOF
 
-    return tree.toStringTree(recog=parser)
+    return tree, parser
+
+
+def _expr_levels(expr_ctx):
+    logical_expr = expr_ctx.logicalExpr()
+    logical_or = logical_expr.logicalOrExpr()
+    return logical_or, logical_or.logicalAndExpr()
+
+
+def _single_chain(expr_ctx):
+    logical_or, logical_and_nodes = _expr_levels(expr_ctx)
+    assert len(logical_and_nodes) == 1
+    equality_nodes = logical_and_nodes[0].equalityExpr()
+    assert len(equality_nodes) == 1
+    rel_nodes = equality_nodes[0].relExpr()
+    assert len(rel_nodes) == 1
+    add_nodes = rel_nodes[0].addExpr()
+    assert len(add_nodes) == 1
+    return logical_or, logical_and_nodes[0], equality_nodes[0], rel_nodes[0], add_nodes[0]
 
 
 def test_unary_binds_tighter_than_multiplication(generated_parser):
     lexer_cls, parser_cls = generated_parser
-    parsed = _parse_expr("-a*b", lexer_cls, parser_cls)
+    tree, _ = _parse_expr("-a*b", lexer_cls, parser_cls)
+    _, _, _, _, add_ctx = _single_chain(tree)
 
-    assert "(mulExpr (unaryExpr - (unaryExpr (primaryExpr (lvalue a)))) *" in parsed
+    mul_nodes = add_ctx.mulExpr()
+    assert len(mul_nodes) == 1
+    mul_ctx = mul_nodes[0]
+    unary_nodes = mul_ctx.unaryExpr()
+
+    assert len(unary_nodes) == 2
+    assert unary_nodes[0].getChild(0).getText() == "-"
+    assert unary_nodes[0].unaryExpr().primaryExpr().lvalue().getText() == "a"
+    assert unary_nodes[1].primaryExpr().lvalue().getText() == "b"
+
+
+def test_precedence_tree_snapshot(generated_parser):
+    lexer_cls, parser_cls = generated_parser
+    tree, parser = _parse_expr("a+b*c", lexer_cls, parser_cls)
+    parsed = tree.toStringTree(recog=parser)
+
+    assert parsed.startswith("(expr (logicalExpr (logicalOrExpr")
 
 
 def test_unary_over_parenthesized_comparison(generated_parser):
     lexer_cls, parser_cls = generated_parser
-    parsed = _parse_expr("!(a<b)", lexer_cls, parser_cls)
+    tree, _ = _parse_expr("!(a<b)", lexer_cls, parser_cls)
+    _, _, _, _, add_ctx = _single_chain(tree)
 
-    assert "(unaryExpr ! (unaryExpr (primaryExpr ( (expr" in parsed
-    assert "< (addExpr" in parsed
+    mul_ctx = add_ctx.mulExpr()[0]
+    outer_unary = mul_ctx.unaryExpr()[0]
+
+    assert outer_unary.getChild(0).getText() == "!"
+    parenthesized = outer_unary.unaryExpr().primaryExpr().expr()
+
+    inner_logical_or, inner_and_nodes = _expr_levels(parenthesized)
+    assert len(inner_logical_or.logicalAndExpr()) == 1
+    assert len(inner_and_nodes[0].equalityExpr()) == 1
+    rel_nodes = inner_and_nodes[0].equalityExpr()[0].relExpr()
+    assert len(rel_nodes) == 2
+    assert rel_nodes[0].addExpr()[0].mulExpr()[0].unaryExpr()[0].primaryExpr().lvalue().getText() == "a"
+    assert rel_nodes[1].addExpr()[0].mulExpr()[0].unaryExpr()[0].primaryExpr().lvalue().getText() == "b"
 
 
 def test_multiplication_binds_tighter_than_addition(generated_parser):
     lexer_cls, parser_cls = generated_parser
-    parsed = _parse_expr("a+b*c", lexer_cls, parser_cls)
+    tree, _ = _parse_expr("a+b*c", lexer_cls, parser_cls)
+    _, _, _, _, add_ctx = _single_chain(tree)
 
-    assert "(addExpr (mulExpr (unaryExpr (primaryExpr (lvalue a)))) +" in parsed
-    assert (
-        "(mulExpr (unaryExpr (primaryExpr (lvalue b))) * (unaryExpr (primaryExpr (lvalue c))))"
-        in parsed
-    )
+    mul_nodes = add_ctx.mulExpr()
+
+    assert len(mul_nodes) == 2
+    left_mul, right_mul = mul_nodes
+    assert left_mul.unaryExpr()[0].primaryExpr().lvalue().getText() == "a"
+    assert right_mul.unaryExpr()[0].primaryExpr().lvalue().getText() == "b"
+    assert right_mul.unaryExpr()[1].primaryExpr().lvalue().getText() == "c"
 
 
 def test_logical_and_binds_tighter_than_or(generated_parser):
     lexer_cls, parser_cls = generated_parser
-    parsed = _parse_expr("a==b||c&&d", lexer_cls, parser_cls)
+    tree, _ = _parse_expr("a==b||c&&d", lexer_cls, parser_cls)
+    logical_or, logical_and_nodes = _expr_levels(tree)
 
-    assert "(logicalOrExpr (logicalAndExpr" in parsed
-    assert "|| (logicalAndExpr" in parsed
-    assert "(logicalAndExpr (equalityExpr" in parsed
-    assert "&& (equalityExpr" in parsed
+    assert len(logical_and_nodes) == 2
+    left_and, right_and = logical_and_nodes
+    assert "||" in logical_or.getText()
+
+    left_equality_nodes = left_and.equalityExpr()
+    right_equality_nodes = right_and.equalityExpr()
+    assert len(left_equality_nodes) == 1
+    assert len(right_equality_nodes) == 2
+
+    left_lhs = left_equality_nodes[0].relExpr()[0].addExpr()[0].mulExpr()[0].unaryExpr()[0]
+    left_rhs = left_equality_nodes[0].relExpr()[1].addExpr()[0].mulExpr()[0].unaryExpr()[0]
+    right_lhs = right_equality_nodes[0].relExpr()[0].addExpr()[0].mulExpr()[0].unaryExpr()[0]
+    right_rhs = right_equality_nodes[1].relExpr()[0].addExpr()[0].mulExpr()[0].unaryExpr()[0]
+
+    assert left_lhs.primaryExpr().lvalue().getText() == "a"
+    assert left_rhs.primaryExpr().lvalue().getText() == "b"
+    assert right_lhs.primaryExpr().lvalue().getText() == "c"
+    assert right_rhs.primaryExpr().lvalue().getText() == "d"
+    assert "&&" in right_and.getText()


### PR DESCRIPTION
### Motivation
- Make expression-precedence tests robust to changes in `toStringTree()` formatting by asserting the actual parse-tree structure using rule-context types instead of fragile substring matches.
- Capture associativity and binding via parent/child relationships on parser contexts to better reflect grammar semantics.
- Keep a small high-level snapshot test for basic sanity while moving core checks to structural assertions.

### Description
- Change `_parse_expr` to return the `expr()` context and the parser instance (`return tree, parser`) so tests can traverse rule contexts directly.
- Add helper functions `_expr_levels` and `_single_chain` to navigate common expression layers (`logicalOrExpr`, `logicalAndExpr`, `equalityExpr`, `relExpr`, `addExpr`) and reduce repetition.
- Replace `toStringTree()` substring asserts with structural assertions that traverse context nodes (e.g. `.mulExpr()`, `.unaryExpr()`, `.primaryExpr().lvalue().getText()`) to verify precedence and associativity.
- Preserve a lightweight snapshot-style check `test_precedence_tree_snapshot` that only asserts a stable high-level parse-tree prefix.

### Testing
- Ran `pytest -q tests/test_expr_precedence.py` which failed due to project `addopts` including coverage flags not supported in the environment (pytest error about unrecognized arguments).
- Ran `pytest -q -o addopts='' tests/test_expr_precedence.py` which executed the file and reported `5 skipped` because ANTLR generation is unavailable in the test environment, so tests correctly skip via the fixture.
- No additional automated tests were added or modified beyond the updated `tests/test_expr_precedence.py` file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a08231b8608328a5b332b9556c457c)