### PR TITLE
Normalize and deduplicate diagnostics in compile_lockstep

### DIFF
--- a/debug_compiler.py
+++ b/debug_compiler.py
@@ -257,6 +257,36 @@ class LockstepCompileResult:
     diagnostics: list[LockstepDiagnostic] = field(default_factory=list)
 
 
+_SEVERITY_PRIORITY = {"error": 0, "warning": 1, "info": 2}
+
+
+def normalize_diagnostics(
+    diagnostics: list[LockstepDiagnostic],
+) -> list[LockstepDiagnostic]:
+    """Deduplicate and deterministically sort diagnostics."""
+
+    deduped: dict[tuple[str, str, int, int], LockstepDiagnostic] = {}
+    for diagnostic in diagnostics:
+        key = (
+            diagnostic.code,
+            diagnostic.message,
+            diagnostic.line,
+            diagnostic.column,
+        )
+        if key not in deduped:
+            deduped[key] = diagnostic
+
+    return sorted(
+        deduped.values(),
+        key=lambda diagnostic: (
+            diagnostic.line,
+            diagnostic.column,
+            _SEVERITY_PRIORITY.get(diagnostic.severity, 99),
+            diagnostic.code,
+        ),
+    )
+
+
 class ParseErrorCollector(ErrorListener):
     """Collects syntax errors emitted by ANTLR during lex/parse."""
 
@@ -628,10 +658,6 @@ class LockstepSemanticValidator(LockstepVisitor):
                 self._check_expression_identifier(ctx.ID().getText(), ctx)
             return self.visitChildren(ctx)
 
-        if ctx.lvalue():
-            root_identifier = ctx.lvalue().ID(0).getText()
-            self._check_expression_identifier(root_identifier, ctx)
-
         return self.visitChildren(ctx)
 
     def visitLvalue(self, ctx: LockstepParser.LvalueContext):
@@ -667,7 +693,7 @@ def compile_lockstep(source_code: str, verbose: bool = True) -> LockstepCompileR
     if error_listener.errors:
         raise LockstepCompileError(error_listener.errors, diagnostics=error_listener.errors)
 
-    semantic_diagnostics = validate_semantics(tree)
+    semantic_diagnostics = normalize_diagnostics(validate_semantics(tree))
     semantic_errors = [
         diagnostic
         for diagnostic in semantic_diagnostics
@@ -682,6 +708,8 @@ def compile_lockstep(source_code: str, verbose: bool = True) -> LockstepCompileR
 
     visitor = LockstepDebugVisitor(verbose=verbose)
     visitor.visit(tree)
+    all_diagnostics = normalize_diagnostics([*semantic_diagnostics, *visitor.diagnostics])
+
     return LockstepCompileResult(
         parse_tree=tree,
         entities={
@@ -694,7 +722,7 @@ def compile_lockstep(source_code: str, verbose: bool = True) -> LockstepCompileR
             "uniforms": visitor.uniforms,
             "bind_routes": visitor.bind_routes,
         },
-        diagnostics=[*semantic_diagnostics, *visitor.diagnostics],
+        diagnostics=all_diagnostics,
     )
 
 

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -374,6 +374,98 @@ def test_compile_lockstep_raises_for_semantic_errors(
     )
 
 
+def test_compile_lockstep_normalizes_diagnostics_order_and_duplicates(
+    debug_compiler_module, monkeypatch
+):
+    class SuccessParser:
+        def __init__(self, stream):
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            return "TREE"
+
+    class SpyVisitor:
+        def __init__(self, verbose=True):
+            self.verbose = verbose
+            self.structs = []
+            self.shaders = []
+            self.filters = []
+            self.pure_functions = []
+            self.streams = []
+            self.accumulators = []
+            self.uniforms = []
+            self.bind_routes = []
+            self.diagnostics = [
+                debug_compiler_module.LockstepDiagnostic(
+                    severity="warning",
+                    code="LCK099",
+                    message="same issue",
+                    line=3,
+                    column=1,
+                ),
+                debug_compiler_module.LockstepDiagnostic(
+                    severity="error",
+                    code="LCK200",
+                    message="later diagnostic",
+                    line=10,
+                    column=4,
+                ),
+            ]
+
+        def visit(self, tree):
+            return tree
+
+    monkeypatch.setattr(
+        debug_compiler_module, "CommonTokenStream", lambda lexer: object()
+    )
+    monkeypatch.setattr(debug_compiler_module, "LockstepParser", SuccessParser)
+    monkeypatch.setattr(debug_compiler_module, "LockstepDebugVisitor", SpyVisitor)
+    monkeypatch.setattr(
+        debug_compiler_module,
+        "validate_semantics",
+        lambda _parse_tree: [
+            debug_compiler_module.LockstepDiagnostic(
+                severity="warning",
+                code="LCK099",
+                message="same issue",
+                line=3,
+                column=1,
+            ),
+            debug_compiler_module.LockstepDiagnostic(
+                severity="info",
+                code="LCK050",
+                message="same location info",
+                line=3,
+                column=1,
+            ),
+            debug_compiler_module.LockstepDiagnostic(
+                severity="info",
+                code="LCK010",
+                message="same location info from semantics",
+                line=3,
+                column=1,
+            ),
+        ],
+    )
+
+    result = debug_compiler_module.compile_lockstep("pipeline P { }", verbose=False)
+
+    assert [
+        (d.line, d.column, d.severity, d.code, d.message) for d in result.diagnostics
+    ] == [
+        (3, 1, "warning", "LCK099", "same issue"),
+        (3, 1, "info", "LCK010", "same location info from semantics"),
+        (3, 1, "info", "LCK050", "same location info"),
+        (10, 4, "error", "LCK200", "later diagnostic"),
+    ]
+
+
 def _token(text):
     return types.SimpleNamespace(getText=lambda: text)
 
@@ -838,3 +930,44 @@ def test_semantic_validator_reports_fold_reference_errors(debug_compiler_module)
     assert "must reference an accumulator" in validator.diagnostics[0].message
     assert validator.diagnostics[1].code == "LCK404"
     assert "has type int" in validator.diagnostics[1].message
+
+
+def test_semantic_validator_nested_lvalue_reports_single_undefined_identifier(
+    debug_compiler_module,
+):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator._push_scope()
+
+    lvalue_ctx = _ctx(
+        start_line=40,
+        start_col=8,
+        ID=lambda index=0: [_token("missing")][index],
+    )
+
+    primary_ctx = _ctx(
+        start_line=40,
+        start_col=8,
+        ID=lambda: None,
+        lvalue=lambda: lvalue_ctx,
+    )
+
+    original_visit_children = validator.visitChildren
+
+    def _visit_children(ctx):
+        if hasattr(ctx, "lvalue") and callable(ctx.lvalue) and ctx.lvalue() is not None:
+            validator.visitLvalue(ctx.lvalue())
+        return original_visit_children(ctx)
+
+    validator.visitChildren = _visit_children
+    validator.visitPrimaryExpr(primary_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK301",
+            message="Undefined identifier 'missing'.",
+            line=40,
+            column=8,
+            hint="Declare the identifier in scope before using it.",
+        )
+    ]


### PR DESCRIPTION
### Motivation
- Ensure diagnostic output is deterministic and stable across runs by normalizing ordering. 
- Remove duplicate diagnostics that arise when the same issue is reported from multiple phases or visitor sites. 
- Avoid double-reporting undefined identifiers for nested lvalue expressions by picking a single validation site.

### Description
- Add a `normalize_diagnostics` helper that deduplicates diagnostics by the tuple `(code, message, line, column)` and sorts them using `(line, column, severity priority, code)`. 
- Introduce a severity priority map `_SEVERITY_PRIORITY = {"error": 0, "warning": 1, "info": 2}` used by the sorter. 
- Apply normalization to semantic diagnostics (`validate_semantics(tree)`) and to the final combined diagnostics returned from `compile_lockstep`. 
- Prevent duplicate identifier reports by removing the extra identifier check in `visitPrimaryExpr` and relying on `visitLvalue` as the single validation site for lvalue-root checks.
- Add regression tests `test_compile_lockstep_normalizes_diagnostics_order_and_duplicates` and `test_semantic_validator_nested_lvalue_reports_single_undefined_identifier` to assert stable ordering, deduplication, and absence of duplicate undefined-identifier diagnostics.

### Testing
- Ran `pytest -q` initially which failed in this environment due to repo `addopts` coverage flags, so tests were executed with `pytest -q -o addopts=''`. 
- All tests passed with that invocation: `25 passed, 5 skipped`. 
- The new tests asserting diagnostic ordering/deduplication and single undefined-identifier reporting were included and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0917234d48328a670e35fdbcd3071)