### PR TITLE
Add semantic type-environment checks for declaration types

### DIFF
--- a/debug_compiler.py
+++ b/debug_compiler.py
@@ -305,6 +305,7 @@ class LockstepSemanticValidator(LockstepVisitor):
         self.shaders: dict[str, list[dict[str, str]]] = {}
         self.filters: dict[str, list[dict[str, str]]] = {}
         self.current_shader_name: str | None = None
+        self.type_environment: set[str] = {"int", "float"}
 
     def _line_col(self, ctx) -> tuple[int, int]:
         token = getattr(ctx, "start", None)
@@ -397,6 +398,18 @@ class LockstepSemanticValidator(LockstepVisitor):
         target[name] = params
         return name, params
 
+    def _ensure_known_type(self, declared_type: str, ctx, *, usage: str) -> bool:
+        if declared_type in self.type_environment:
+            return True
+        self._add_diagnostic(
+            severity="error",
+            code="LCK308",
+            message=f"Unknown type '{declared_type}' for {usage}.",
+            ctx=ctx,
+            hint="Declare the struct type before use or use a built-in scalar type.",
+        )
+        return False
+
     def _check_expression_identifier(self, name: str, ctx):
         if self._lookup(name) is None:
             self._add_diagnostic(
@@ -473,6 +486,10 @@ class LockstepSemanticValidator(LockstepVisitor):
 
     def visitProgram(self, ctx: LockstepParser.ProgramContext):
         self._push_scope()
+        for declaration in ctx.declaration():
+            struct_decl = declaration.structDecl()
+            if struct_decl is not None:
+                self.type_environment.add(struct_decl.ID().getText())
         result = self.visitChildren(ctx)
         self._pop_scope()
         return result
@@ -510,12 +527,25 @@ class LockstepSemanticValidator(LockstepVisitor):
         return result
 
     def visitVarDecl(self, ctx: LockstepParser.VarDeclContext):
+        self._ensure_known_type(
+            ctx.typeName().getText(),
+            ctx.typeName(),
+            usage=f"local variable '{ctx.ID().getText()}'",
+        )
         self._declare(
             ctx.ID().getText(),
             ctx.typeName().getText(),
             ctx,
             duplicate_code="LCK306",
             kind="local",
+        )
+        return self.visitChildren(ctx)
+
+    def visitParam(self, ctx: LockstepParser.ParamContext):
+        self._ensure_known_type(
+            ctx.typeName().getText(),
+            ctx.typeName(),
+            usage=f"parameter '{ctx.ID().getText()}'",
         )
         return self.visitChildren(ctx)
 
@@ -526,6 +556,11 @@ class LockstepSemanticValidator(LockstepVisitor):
         return result
 
     def visitStreamDecl(self, ctx: LockstepParser.StreamDeclContext):
+        self._ensure_known_type(
+            ctx.typeName().getText(),
+            ctx.typeName(),
+            usage=f"stream '{ctx.ID().getText()}'",
+        )
         self._declare(
             ctx.ID().getText(),
             ctx.typeName().getText(),
@@ -536,6 +571,11 @@ class LockstepSemanticValidator(LockstepVisitor):
         return self.visitChildren(ctx)
 
     def visitAccumDecl(self, ctx: LockstepParser.AccumDeclContext):
+        self._ensure_known_type(
+            ctx.typeName().getText(),
+            ctx.typeName(),
+            usage=f"accumulator '{ctx.ID().getText()}'",
+        )
         self._declare(
             ctx.ID().getText(),
             ctx.typeName().getText(),
@@ -546,6 +586,11 @@ class LockstepSemanticValidator(LockstepVisitor):
         return self.visitChildren(ctx)
 
     def visitUniformDecl(self, ctx: LockstepParser.UniformDeclContext):
+        self._ensure_known_type(
+            ctx.typeName().getText(),
+            ctx.typeName(),
+            usage=f"uniform '{ctx.ID().getText()}'",
+        )
         self._declare(
             ctx.ID().getText(),
             ctx.typeName().getText(),
@@ -581,6 +626,11 @@ class LockstepSemanticValidator(LockstepVisitor):
 
         fold_source_symbol = self._lookup(fold_source)
         declared_type = ctx.typeName().getText()
+        self._ensure_known_type(
+            declared_type,
+            ctx.typeName(),
+            usage=f"fold uniform '{fold_target}'",
+        )
         if fold_source_symbol is None:
             self._add_diagnostic(
                 severity="error",
@@ -642,6 +692,14 @@ class LockstepSemanticValidator(LockstepVisitor):
     def validate(self, tree):
         self.visit(tree)
         return self.diagnostics
+
+    def visitPureDecl(self, ctx: LockstepParser.PureDeclContext):
+        self._ensure_known_type(
+            ctx.typeName().getText(),
+            ctx.typeName(),
+            usage=f"return type of pure function '{ctx.ID().getText()}'",
+        )
+        return self.visitChildren(ctx)
 
 
 def validate_semantics(parse_tree: Any) -> list[LockstepDiagnostic]:

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -77,6 +77,9 @@ def _install_fake_generated_modules(monkeypatch):
         class VarDeclContext:
             pass
 
+        class ParamContext:
+            pass
+
         class PrimaryExprContext:
             pass
 
@@ -838,3 +841,130 @@ def test_semantic_validator_reports_fold_reference_errors(debug_compiler_module)
     assert "must reference an accumulator" in validator.diagnostics[0].message
     assert validator.diagnostics[1].code == "LCK404"
     assert "has type int" in validator.diagnostics[1].message
+
+
+@pytest.mark.parametrize(
+    ("visit_method", "ctx_factory", "expected_message", "line", "column"),
+    [
+        (
+            "visitVarDecl",
+            lambda: _ctx(
+                start_line=1,
+                start_col=2,
+                typeName=lambda: _ctx(start_line=1, start_col=2, getText=lambda: "MissingType"),
+                ID=lambda: _token("local_value"),
+            ),
+            "Unknown type 'MissingType' for local variable 'local_value'.",
+            1,
+            2,
+        ),
+        (
+            "visitParam",
+            lambda: _ctx(
+                start_line=2,
+                start_col=4,
+                typeName=lambda: _ctx(start_line=2, start_col=4, getText=lambda: "MissingType"),
+                ID=lambda: _token("input_value"),
+            ),
+            "Unknown type 'MissingType' for parameter 'input_value'.",
+            2,
+            4,
+        ),
+        (
+            "visitStreamDecl",
+            lambda: _ctx(
+                start_line=3,
+                start_col=6,
+                typeName=lambda: _ctx(start_line=3, start_col=6, getText=lambda: "MissingType"),
+                ID=lambda: _token("s0"),
+            ),
+            "Unknown type 'MissingType' for stream 's0'.",
+            3,
+            6,
+        ),
+        (
+            "visitAccumDecl",
+            lambda: _ctx(
+                start_line=4,
+                start_col=8,
+                typeName=lambda: _ctx(start_line=4, start_col=8, getText=lambda: "MissingType"),
+                ID=lambda: _token("acc0"),
+            ),
+            "Unknown type 'MissingType' for accumulator 'acc0'.",
+            4,
+            8,
+        ),
+        (
+            "visitUniformDecl",
+            lambda: _ctx(
+                start_line=5,
+                start_col=10,
+                typeName=lambda: _ctx(start_line=5, start_col=10, getText=lambda: "MissingType"),
+                ID=lambda: _token("u0"),
+            ),
+            "Unknown type 'MissingType' for uniform 'u0'.",
+            5,
+            10,
+        ),
+        (
+            "visitPureDecl",
+            lambda: _ctx(
+                start_line=6,
+                start_col=12,
+                typeName=lambda: _ctx(start_line=6, start_col=12, getText=lambda: "MissingType"),
+                ID=lambda: _token("make_value"),
+            ),
+            "Unknown type 'MissingType' for return type of pure function 'make_value'.",
+            6,
+            12,
+        ),
+    ],
+)
+def test_semantic_validator_reports_unknown_type_across_declarations(
+    debug_compiler_module,
+    visit_method,
+    ctx_factory,
+    expected_message,
+    line,
+    column,
+):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator._push_scope()
+
+    getattr(validator, visit_method)(ctx_factory())
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK308",
+            message=expected_message,
+            line=line,
+            column=column,
+            hint="Declare the struct type before use or use a built-in scalar type.",
+        )
+    ]
+
+
+def test_semantic_validator_accepts_user_defined_struct_types(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    struct_decl = _ctx(ID=lambda: _token("Vec3"))
+    non_struct_decl = _ctx(structDecl=lambda: None)
+    program_ctx = _ctx(
+        declaration=lambda: [
+            _ctx(structDecl=lambda: struct_decl),
+            non_struct_decl,
+        ]
+    )
+    validator.visitProgram(program_ctx)
+
+    validator._push_scope()
+    validator.visitStreamDecl(
+        _ctx(
+            typeName=lambda: _ctx(start_line=7, start_col=2, getText=lambda: "Vec3"),
+            ID=lambda: _token("positions"),
+        )
+    )
+
+    assert "Vec3" in validator.type_environment
+    assert all(diag.code != "LCK308" for diag in validator.diagnostics)


### PR DESCRIPTION
### Motivation

- Provide a simple semantic type environment so declaration sites can validate referenced types before accepting them. 
- Seed the environment with built-in scalar types and allow user `struct` names to be registered during program traversal so later declarations can reference them. 
- Surface a clear diagnostic when a type cannot be resolved to help users fix source-level type errors early in the semantic phase.

### Description

- Added a `type_environment` (`set[str]`) to `LockstepSemanticValidator` seeded with `"int"` and `"float"` in `debug_compiler.py`. 
- Registered user-defined `struct` names during `visitProgram` traversal so struct names become known to the validator. 
- Introduced `_ensure_known_type(...)` which emits a new semantic diagnostic `LCK308` (with line/column and hint) when a referenced type is unknown, and wired this check into `visitVarDecl`, `visitParam` (new), `visitStreamDecl`, `visitAccumDecl`, `visitUniformDecl`, `visitPureDecl` (return type), and the fold-uniform path in `visitBindStmt`. 
- Updated tests in `tests/test_debug_compiler.py` to add a `ParamContext` stub and to cover unknown-type diagnostics for each declaration context plus a positive test confirming user-defined `struct` types are accepted after program registration.

### Testing

- Ran `pytest -q tests/test_debug_compiler.py` once which failed due to repository `addopts` pytest configuration requiring coverage flags that are not available in the execution environment. 
- Re-ran tests with `pytest -q --override-ini addopts='' tests/test_debug_compiler.py` and all tests passed: `30 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0916fb21083288f5f7d95be633b05)