### PR TITLE
Add default parser-backed compile_lockstep API

### DIFF
--- a/debug_compiler.py
+++ b/debug_compiler.py
@@ -10,7 +10,7 @@ from lockstep_compiler import (
     normalize_diagnostics,
     run_cli,
 )
-from lockstep_compiler.compiler import compile_lockstep as _compile_lockstep
+from lockstep_compiler.compiler import _compile_lockstep_with_dependencies as _compile_lockstep
 from lockstep_compiler.models import LockstepCompileResult
 from lockstep_compiler.visitors import (
     build_debug_visitor,

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -7,7 +7,7 @@ from .models import LockstepCompileResult, normalize_diagnostics
 from .visitors import build_debug_visitor, validate_semantics
 
 
-def compile_lockstep(
+def _compile_lockstep_with_dependencies(
     source_code: str,
     *,
     verbose: bool = True,
@@ -61,4 +61,43 @@ def compile_lockstep(
             "bind_routes": visitor.bind_routes,
         },
         diagnostics=all_diagnostics,
+    )
+
+
+def _load_default_parser_classes() -> tuple[Any, Any, Any]:
+    from generated.parser.LockstepLexer import LockstepLexer
+    from generated.parser.LockstepParser import LockstepParser
+    from generated.parser.LockstepVisitor import LockstepVisitor
+
+    return LockstepLexer, LockstepParser, LockstepVisitor
+
+
+def compile_lockstep(
+    source_code: str,
+    *,
+    verbose: bool = True,
+    lexer_cls=None,
+    parser_cls=None,
+    visitor_cls=None,
+    semantic_validator=None,
+    token_stream_cls=CommonTokenStream,
+    debug_visitor_cls=None,
+) -> LockstepCompileResult:
+    if lexer_cls is None or parser_cls is None or visitor_cls is None:
+        default_lexer_cls, default_parser_cls, default_visitor_cls = (
+            _load_default_parser_classes()
+        )
+        lexer_cls = lexer_cls or default_lexer_cls
+        parser_cls = parser_cls or default_parser_cls
+        visitor_cls = visitor_cls or default_visitor_cls
+
+    return _compile_lockstep_with_dependencies(
+        source_code,
+        verbose=verbose,
+        lexer_cls=lexer_cls,
+        parser_cls=parser_cls,
+        visitor_cls=visitor_cls,
+        semantic_validator=semantic_validator,
+        token_stream_cls=token_stream_cls,
+        debug_visitor_cls=debug_visitor_cls,
     )

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -1,0 +1,84 @@
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import lockstep_compiler
+import lockstep_compiler.compiler as compiler_module
+
+
+def test_package_exports_user_friendly_compile_function():
+    assert lockstep_compiler.compile_lockstep is compiler_module.compile_lockstep
+
+
+def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
+    class StubLexer:
+        def __init__(self, input_stream):
+            self.input_stream = input_stream
+
+        def removeErrorListeners(self):
+            pass
+
+        def addErrorListener(self, listener):
+            pass
+
+    class StubParser:
+        def __init__(self, stream):
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            return "TREE"
+
+    class StubVisitor:
+        pass
+
+    class StubDebugVisitor:
+        def __init__(self, verbose=True):
+            self.verbose = verbose
+            self.structs = []
+            self.shaders = []
+            self.filters = []
+            self.pure_functions = []
+            self.streams = []
+            self.accumulators = []
+            self.uniforms = []
+            self.bind_routes = []
+            self.diagnostics = []
+            self.tree = None
+
+        def visit(self, tree):
+            self.tree = tree
+
+    monkeypatch.setattr(
+        compiler_module,
+        "_load_default_parser_classes",
+        lambda: (StubLexer, StubParser, StubVisitor),
+    )
+
+    result = lockstep_compiler.compile_lockstep(
+        "pipeline P { }",
+        verbose=False,
+        semantic_validator=lambda _tree: [],
+        token_stream_cls=lambda lexer: object(),
+        debug_visitor_cls=StubDebugVisitor,
+    )
+
+    assert result.parse_tree == "TREE"
+    assert result.entities == {
+        "structs": [],
+        "shaders": [],
+        "filters": [],
+        "pure_functions": [],
+        "streams": [],
+        "accumulators": [],
+        "uniforms": [],
+        "bind_routes": [],
+    }


### PR DESCRIPTION
### Motivation
- Provide a user-friendly `compile_lockstep` API that only requires `source_code` (and optional flags) so callers don't need to pass generated parser classes.
- Default to the generated parser classes from `generated/parser` for normal usage while keeping dependency-injection hooks available for tests and mocking.
- Preserve existing debug/CLI behavior and the ability to run semantic validation and debug visitors unchanged.

### Description
- Split the existing implementation into an internal `_compile_lockstep_with_dependencies(...)` that requires explicit `lexer_cls`, `parser_cls`, and `visitor_cls`.
- Added a public `compile_lockstep(...)` wrapper that auto-loads `LockstepLexer`, `LockstepParser`, and `LockstepVisitor` from `generated/parser` when classes are not provided and forwards provided injection parameters when present.
- Added `_load_default_parser_classes()` helper and updated `debug_compiler.py` to invoke the internal helper so the debug CLI continues to pass explicit generated classes.
- Added `tests/test_compiler_api.py` which asserts the package exports the user-facing `compile_lockstep` and verifies `compile_lockstep` works without explicitly passing parser classes (while still allowing monkeypatching/injection).

### Testing
- Ran `pytest -q -o addopts='' tests/test_compiler_api.py tests/test_debug_compiler.py`, and the test suite completed successfully with `27 passed`.
- An initial `pytest` invocation failed in this environment due to `pyproject.toml` injecting `pytest-cov` options that are unavailable, so tests were re-run with `-o addopts=''` to disable those options and then succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a30cff90148328bb9f43f3b0850efc)