### PR TITLE
Ensure run_cli validates compiler and normalizes internal CLI failures

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -44,6 +44,20 @@ def run_cli(argv=None, *, stdin=None, stderr=None, compiler=None):
     else:
         source = stdin.read()
 
+    if compiler is None:
+        print(
+            "Compiler configuration error: no compiler callable was provided.",
+            file=stderr,
+        )
+        return 1
+
+    if not callable(compiler):
+        print(
+            "Compiler configuration error: compiler must be callable.",
+            file=stderr,
+        )
+        return 1
+
     try:
         compiler(source)
     except LockstepCompileError as err:
@@ -55,6 +69,9 @@ def run_cli(argv=None, *, stdin=None, stderr=None, compiler=None):
         )
         for error in err.errors:
             print(f"line {error.line}:{error.column} {error.message}", file=stderr)
+        return 1
+    except Exception:
+        print("Compilation failed due to an internal error.", file=stderr)
         return 1
 
     return 0

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -813,6 +813,22 @@ def test_run_cli_returns_non_zero_for_invalid_utf8(debug_compiler_module, tmp_pa
     assert f"Unable to read '{bad_source}': invalid UTF-8" in stderr.getvalue()
 
 
+def test_run_cli_returns_non_zero_when_compiler_missing(debug_compiler_module):
+    stderr = io.StringIO()
+
+    exit_code = debug_compiler_module.run_cli(
+        [],
+        stdin=io.StringIO("pipeline MissingCompiler { }"),
+        stderr=stderr,
+        compiler=None,
+    )
+
+    assert exit_code == 1
+    assert stderr.getvalue().splitlines() == [
+        "Compiler configuration error: no compiler callable was provided.",
+    ]
+
+
 def test_semantic_validator_reports_undefined_identifier_in_bind(debug_compiler_module):
     validator = debug_compiler_module.LockstepSemanticValidator()
     validator.shaders = {


### PR DESCRIPTION
### Motivation

- Prevent the CLI from crashing when no compiler is provided and make configuration errors visible to users.
- Ensure unexpected programmer/configuration exceptions during compilation produce a consistent stderr message and exit code `1`.
- Add a regression test to lock in deterministic CLI behavior for the missing-compiler case.

### Description

- Added explicit validation in `run_cli` to print a user-facing error and return `1` when `compiler is None`.
- Added a check to ensure the provided `compiler` is callable and return `1` with an explanatory stderr message if not.
- Wrapped the compiler invocation in a broad `except Exception` handler to print `"Compilation failed due to an internal error."` and return `1` for unexpected failures.
- Added `test_run_cli_returns_non_zero_when_compiler_missing` to `tests/test_debug_compiler.py` to assert deterministic stderr output and non-zero exit for `compiler=None`.

### Testing

- Running `pytest -q -o addopts='' tests/test_debug_compiler.py -k run_cli` executed the targeted tests and passed: `7 passed, 19 deselected`.
- A plain `pytest` run initially failed in this environment due to configured coverage `addopts` in `pyproject.toml` that require pytest-cov options, so the targeted command above was used to run tests successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a30d02a1c88328aaf76d4b30026e06)