### PR TITLE
Validate bind modifier-kind and bind-target output semantics (add LCK308/LCK309)

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -320,6 +320,13 @@ def build_semantic_validator(base_visitor_cls):
             return symbol["type"] if symbol else None
 
         def _type_check_bind_call(self, ctx, target_name: str, callee_name: str, arg_names):
+            modifier_to_kind = {
+                "in": "stream",
+                "out": "stream",
+                "uniform": "uniform",
+                "accum": "accumulator",
+            }
+
             kernel = self.shaders.get(callee_name) or self.filters.get(callee_name)
             if kernel is None:
                 self._add_diagnostic(
@@ -355,6 +362,45 @@ def build_semantic_validator(base_visitor_cls):
                     ctx=ctx,
                     hint="Declare pipeline streams/accumulators/uniforms before binding.",
                 )
+            else:
+                output_params = [param for param in kernel if param["modifier"] == "out"]
+                if not output_params:
+                    self._add_diagnostic(
+                        severity="error",
+                        code="LCK309",
+                        message=(
+                            f"Bind target '{target_name}' is assigned from '{callee_name}', "
+                            "but the kernel has no out parameter."
+                        ),
+                        ctx=ctx,
+                        hint="Bind only kernels that declare an out parameter.",
+                    )
+                else:
+                    expected_output = output_params[0]
+                    expected_output_kind = modifier_to_kind[expected_output["modifier"]]
+                    if target_symbol["kind"] != expected_output_kind:
+                        self._add_diagnostic(
+                            severity="error",
+                            code="LCK309",
+                            message=(
+                                f"Bind target '{target_name}' for '{callee_name}' must be a "
+                                f"{expected_output_kind} for out parameter '{expected_output['name']}', "
+                                f"got {target_symbol['kind']}."
+                            ),
+                            ctx=ctx,
+                            hint="Route kernel outputs to a stream-compatible bind target.",
+                        )
+                    if target_symbol["type"] != expected_output["type"]:
+                        self._add_diagnostic(
+                            severity="error",
+                            code="LCK305",
+                            message=(
+                                f"Type mismatch for bind target '{target_name}' in '{callee_name}': "
+                                f"expected {expected_output['type']}, got {target_symbol['type']}."
+                            ),
+                            ctx=ctx,
+                            hint="Align bind target type with the kernel out parameter type.",
+                        )
 
             for arg_name, expected in zip(arg_names, kernel):
                 actual_symbol = self._lookup(arg_name)
@@ -367,6 +413,21 @@ def build_semantic_validator(base_visitor_cls):
                         hint="Declare pipeline symbols before passing them to bind.",
                     )
                     continue
+
+                expected_kind = modifier_to_kind.get(expected["modifier"])
+                if expected_kind is not None and actual_symbol["kind"] != expected_kind:
+                    self._add_diagnostic(
+                        severity="error",
+                        code="LCK308",
+                        message=(
+                            f"Modifier mismatch for argument '{arg_name}' in '{callee_name}': "
+                            f"parameter '{expected['name']}' requires {expected['modifier']} "
+                            f"({expected_kind}), got {actual_symbol['kind']}."
+                        ),
+                        ctx=ctx,
+                        hint="Pass a symbol with the kind required by the parameter modifier.",
+                    )
+
                 actual_type = actual_symbol["type"]
                 if actual_type != expected["type"]:
                     self._add_diagnostic(

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -878,8 +878,65 @@ def test_semantic_validator_reports_bind_arity_and_type_errors(debug_compiler_mo
 
     assert validator.diagnostics[0].code == "LCK304"
     assert "expects 2 argument(s), but got 1" in validator.diagnostics[0].message
-    assert validator.diagnostics[1].code == "LCK305"
-    assert "expected float, got int" in validator.diagnostics[1].message
+    assert validator.diagnostics[1].code == "LCK309"
+    assert "kernel has no out parameter" in validator.diagnostics[1].message
+    assert validator.diagnostics[2].code == "LCK305"
+    assert "expected float, got int" in validator.diagnostics[2].message
+
+
+def test_semantic_validator_reports_bind_modifier_kind_mismatches(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator.shaders = {
+        "Apply": [
+            {"name": "inp", "type": "Vec3", "modifier": "in"},
+            {"name": "u_dt", "type": "float", "modifier": "uniform"},
+            {"name": "energy", "type": "float", "modifier": "accum"},
+        ]
+    }
+    validator._push_scope()
+    validator._declare("s0", "Vec3", _ctx(), duplicate_code="LCK306", kind="stream")
+    validator._declare("dt_stream", "float", _ctx(), duplicate_code="LCK306", kind="stream")
+    validator._declare("dt_uniform", "float", _ctx(), duplicate_code="LCK306", kind="uniform")
+
+    mismatch_ctx = _ctx(
+        start_line=24,
+        start_col=2,
+        ID=lambda: [_token("s0"), _token("Apply"), _token("s0"), _token("dt_stream"), _token("dt_uniform")],
+        argList=lambda: object(),
+        typeName=lambda: _token("float"),
+    )
+    validator.visitBindStmt(mismatch_ctx)
+
+    assert [diag.code for diag in validator.diagnostics] == ["LCK309", "LCK308", "LCK308"]
+    assert "kernel has no out parameter" in validator.diagnostics[0].message
+    assert "requires uniform" in validator.diagnostics[1].message
+    assert "requires accum" in validator.diagnostics[2].message
+
+
+def test_semantic_validator_reports_bind_target_output_semantics(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator.shaders = {
+        "Apply": [
+            {"name": "inp", "type": "Vec3", "modifier": "in"},
+            {"name": "outp", "type": "Vec3", "modifier": "out"},
+        ]
+    }
+    validator._push_scope()
+    validator._declare("inp_stream", "Vec3", _ctx(), duplicate_code="LCK306", kind="stream")
+    validator._declare("out_stream", "Vec3", _ctx(), duplicate_code="LCK306", kind="stream")
+    validator._declare("target_uniform", "Vec3", _ctx(), duplicate_code="LCK306", kind="uniform")
+
+    mismatch_ctx = _ctx(
+        start_line=26,
+        start_col=2,
+        ID=lambda: [_token("target_uniform"), _token("Apply"), _token("inp_stream"), _token("out_stream")],
+        argList=lambda: object(),
+        typeName=lambda: _token("float"),
+    )
+    validator.visitBindStmt(mismatch_ctx)
+
+    assert [diag.code for diag in validator.diagnostics] == ["LCK309"]
+    assert "must be a stream" in validator.diagnostics[0].message
 
 
 def test_semantic_validator_reports_duplicate_pipeline_symbols(debug_compiler_module):


### PR DESCRIPTION
### Motivation
- Ensure binds enforce not only type compatibility but also that argument symbols have the correct symbol kind for the parameter modifier (`in`, `out`, `uniform`, `accum`).
- Prevent incorrect target assignments by verifying the called kernel declares an `out` parameter and that the target symbol matches the kernel's output semantics.
- Provide focused diagnostics that distinguish kind/modifier mismatches from type mismatches so users can act on precise errors.

### Description
- Extended `_type_check_bind_call` to map parameter modifiers to expected symbol kinds (`in`/`out` → `stream`, `uniform` → `uniform`, `accum` → `accumulator`) and validate each argument symbol kind against that mapping.
- Added diagnostic `LCK308` for modifier→kind mismatches with a clear message and hint so these errors are separate from `LCK305` type errors.
- Added output-target validation for bind assignments: emit `LCK309` when assigning from a kernel that has no `out` parameter or when the bind target has an incompatible symbol kind, and continue to emit `LCK305` for target type mismatches against the kernel `out` parameter.
- Updated and added unit tests in `tests/test_debug_compiler.py` to cover: modifier/kind mismatches that previously passed type checks, invalid bind target output semantics, and updated the existing arity/type test to account for the new target-semantics diagnostic.
- Files changed: `lockstep_compiler/visitors.py`, `tests/test_debug_compiler.py`.

### Testing
- Ran the test file with adjusted pytest options to avoid project-level coverage flags: `pytest -q -o addopts='' tests/test_debug_compiler.py`, which completed successfully with all tests passing (`27 passed`).
- Note: running `pytest -q tests/test_debug_compiler.py` without overriding `addopts` fails in this environment due to unavailable coverage flags in the project `pyproject.toml`, so the adjusted invocation was used for validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a30d05116083288d355c4df3646e22)