### PR TITLE
Prefer highest-severity diagnostic during dedup

### DIFF
--- a/lockstep_compiler/models.py
+++ b/lockstep_compiler/models.py
@@ -22,6 +22,26 @@ class LockstepCompileResult:
 _SEVERITY_PRIORITY = {"error": 0, "warning": 1, "info": 2}
 
 
+def _should_replace_diagnostic(
+    existing: LockstepDiagnostic,
+    candidate: LockstepDiagnostic,
+) -> bool:
+    existing_priority = _SEVERITY_PRIORITY.get(existing.severity, 99)
+    candidate_priority = _SEVERITY_PRIORITY.get(candidate.severity, 99)
+    if candidate_priority != existing_priority:
+        return candidate_priority < existing_priority
+
+    existing_hint = (existing.hint or "").strip()
+    candidate_hint = (candidate.hint or "").strip()
+    if bool(candidate_hint) != bool(existing_hint):
+        return bool(candidate_hint)
+
+    if candidate_hint and existing_hint:
+        return candidate_hint < existing_hint
+
+    return False
+
+
 def normalize_diagnostics(
     diagnostics: list[LockstepDiagnostic],
 ) -> list[LockstepDiagnostic]:
@@ -35,7 +55,7 @@ def normalize_diagnostics(
             diagnostic.line,
             diagnostic.column,
         )
-        if key not in deduped:
+        if key not in deduped or _should_replace_diagnostic(deduped[key], diagnostic):
             deduped[key] = diagnostic
 
     return sorted(

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -466,6 +466,116 @@ def test_compile_lockstep_normalizes_diagnostics_order_and_duplicates(
     ]
 
 
+def test_compile_lockstep_dedup_prefers_highest_severity_for_same_key(
+    debug_compiler_module, monkeypatch
+):
+    class SuccessParser:
+        def __init__(self, stream):
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            return "TREE"
+
+    class SpyVisitor:
+        def __init__(self, verbose=True):
+            self.verbose = verbose
+            self.structs = []
+            self.shaders = []
+            self.filters = []
+            self.pure_functions = []
+            self.streams = []
+            self.accumulators = []
+            self.uniforms = []
+            self.bind_routes = []
+            self.diagnostics = [
+                debug_compiler_module.LockstepDiagnostic(
+                    severity="warning",
+                    code="LCK777",
+                    message="same issue",
+                    line=6,
+                    column=2,
+                    hint="visitor hint",
+                ),
+            ]
+
+        def visit(self, tree):
+            return tree
+
+    monkeypatch.setattr(
+        debug_compiler_module, "CommonTokenStream", lambda lexer: object()
+    )
+    monkeypatch.setattr(debug_compiler_module, "LockstepParser", SuccessParser)
+    monkeypatch.setattr(debug_compiler_module, "LockstepDebugVisitor", SpyVisitor)
+    monkeypatch.setattr(
+        debug_compiler_module,
+        "validate_semantics",
+        lambda _parse_tree: [
+            debug_compiler_module.LockstepDiagnostic(
+                severity="error",
+                code="LCK777",
+                message="same issue",
+                line=6,
+                column=2,
+                hint="semantic hint",
+            ),
+        ],
+    )
+
+    with pytest.raises(debug_compiler_module.LockstepCompileError) as exc_info:
+        debug_compiler_module.compile_lockstep("pipeline P { }", verbose=False)
+
+    assert exc_info.value.errors == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK777",
+            message="same issue",
+            line=6,
+            column=2,
+            hint="semantic hint",
+        )
+    ]
+
+
+def test_normalize_diagnostics_prefers_non_empty_hint_for_same_severity(
+    debug_compiler_module,
+):
+    diagnostics = [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="warning",
+            code="LCK888",
+            message="same issue",
+            line=9,
+            column=3,
+            hint="",
+        ),
+        debug_compiler_module.LockstepDiagnostic(
+            severity="warning",
+            code="LCK888",
+            message="same issue",
+            line=9,
+            column=3,
+            hint="detailed hint",
+        ),
+    ]
+
+    assert debug_compiler_module.normalize_diagnostics(diagnostics) == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="warning",
+            code="LCK888",
+            message="same issue",
+            line=9,
+            column=3,
+            hint="detailed hint",
+        )
+    ]
+
+
 def _token(text):
     return types.SimpleNamespace(getText=lambda: text)
 


### PR DESCRIPTION
### Motivation

- Diagnostics that share the same key should resolve deterministically by keeping the most important observation rather than the first-seen entry, so more severe issues (`error`) surface over lesser ones (`warning`/`info`).
- When severities match, deterministic behavior is needed to prefer richer information (non-empty hints) and avoid nondeterministic ordering across runs.

### Description

- Add `_should_replace_diagnostic` to encapsulate replacement rules that prefer lower numeric priority values in `_SEVERITY_PRIORITY` (i.e. `error` > `warning` > `info`).
- When severities are equal, prefer a diagnostic with a non-empty `hint`, and if both hints are non-empty choose lexicographically smaller hint for stable results.
- Update `normalize_diagnostics` to use `_should_replace_diagnostic` so deduplication will replace existing entries when a higher-priority candidate is encountered.
- Add regression tests in `tests/test_debug_compiler.py` to verify same-key diagnostics prefer the higher severity and that non-empty hints are preferred when severities match.

### Testing

- Ran `pytest -q --override-ini addopts='' tests/test_debug_compiler.py` and all tests passed (`27 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a30d07424883288463b6dfa9cdcc13)