### PR TITLE
Refactor fold bind declarations to use shared scope declaration helper

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -438,20 +438,17 @@ def build_semantic_validator(base_visitor_cls):
             fold_target = id_tokens[0].getText()
             fold_operator = id_tokens[1].getText()
             fold_source = id_tokens[2].getText()
+            declared_type = ctx.typeName().getText()
 
-            if self._declared_in_current_scope(fold_target):
-                self._add_diagnostic(
-                    severity="error",
-                    code="LCK306",
-                    message=f"Duplicate declaration for '{fold_target}' in the same scope.",
-                    ctx=ctx,
-                    hint="Rename one declaration or move it to a different scope.",
-                )
-            else:
-                self.scopes[-1][fold_target] = {"type": ctx.typeName().getText(), "kind": "uniform"}
+            self._declare(
+                fold_target,
+                declared_type,
+                ctx,
+                duplicate_code="LCK306",
+                kind="uniform",
+            )
 
             fold_source_symbol = self._lookup(fold_source)
-            declared_type = ctx.typeName().getText()
             if fold_source_symbol is None:
                 self._add_diagnostic(
                     severity="error",

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -932,6 +932,53 @@ def test_semantic_validator_reports_fold_reference_errors(debug_compiler_module)
     assert "has type int" in validator.diagnostics[1].message
 
 
+def test_semantic_validator_reports_duplicate_fold_target(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator._push_scope()
+    validator._declare("acc_energy", "float", _ctx(), duplicate_code="LCK306", kind="accumulator")
+    validator._declare("u0", "float", _ctx(), duplicate_code="LCK306", kind="uniform")
+
+    duplicate_fold_ctx = _ctx(
+        start_line=33,
+        start_col=4,
+        ID=lambda: [_token("u0"), _token("sum"), _token("acc_energy")],
+        argList=lambda: None,
+        typeName=lambda: _token("float"),
+    )
+
+    validator.visitBindStmt(duplicate_fold_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK306",
+            message="Duplicate declaration for 'u0' in the same scope.",
+            line=33,
+            column=4,
+            hint="Rename one declaration or move it to a different scope.",
+        )
+    ]
+
+
+def test_semantic_validator_fold_declares_target_uniform_without_scope(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator._declare("acc_energy", "float", _ctx(), duplicate_code="LCK306", kind="accumulator")
+
+    fold_ctx = _ctx(
+        start_line=34,
+        start_col=5,
+        ID=lambda: [_token("u1"), _token("sum"), _token("acc_energy")],
+        argList=lambda: None,
+        typeName=lambda: _token("float"),
+    )
+
+    validator.visitBindStmt(fold_ctx)
+
+    assert validator.diagnostics == []
+    assert validator.scopes
+    assert validator.scopes[-1]["u1"] == {"type": "float", "kind": "uniform"}
+
+
 def test_semantic_validator_nested_lvalue_reports_single_undefined_identifier(
     debug_compiler_module,
 ):


### PR DESCRIPTION
### Motivation
- Centralize declaration logic for fold targets to reuse duplicate-detection and scope-initialization behavior already implemented in `_declare`.
- Ensure fold-declared uniforms consistently use `kind='uniform'` and the duplicate diagnostic `LCK306` rather than ad-hoc scope mutation.
- Make the fold declaration logic safe when invoked with an empty scope stack by relying on `_declare` to initialize scopes.

### Description
- Replaced the manual `self.scopes[-1][fold_target] = {...}` mutation in `visitBindStmt` with a call to `_declare(fold_target, declared_type, ctx, duplicate_code="LCK306", kind="uniform")` and moved `declared_type` extraction earlier.  (updated `lockstep_compiler/visitors.py`).
- Left the subsequent fold semantic checks (undefined source, non-accumulator source, unsupported operator, and type mismatch) unchanged and executed after the centralized declaration call.
- Added tests to cover fold behaviour: `test_semantic_validator_reports_duplicate_fold_target` to verify `LCK306` is emitted via `_declare`, and `test_semantic_validator_fold_declares_target_uniform_without_scope` to verify a fold creates the uniform even if no scope was previously pushed (updated `tests/test_debug_compiler.py`).

### Testing
- Ran the targeted subset with `pytest -q -o addopts='' tests/test_debug_compiler.py -k 'fold or duplicate_pipeline_symbols or bind_arity'`, which completed successfully (`5 passed, 22 deselected`).
- Ran the full validator tests with `pytest -q -o addopts='' tests/test_debug_compiler.py`, which completed successfully (`27 passed`).
- All automated tests related to fold declarations and bind semantics passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a30d0c4b9c8328acff7d98e324e9fd)