### PR TITLE
Validate struct field access chains in semantic validator

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -242,6 +242,7 @@ def build_semantic_validator(base_visitor_cls):
             self.scopes: list[dict[str, dict[str, str]]] = []
             self.shaders: dict[str, list[dict[str, str]]] = {}
             self.filters: dict[str, list[dict[str, str]]] = {}
+            self.structs: dict[str, dict[str, str]] = {}
 
         def _line_col(self, ctx) -> tuple[int, int]:
             token = getattr(ctx, "start", None)
@@ -318,6 +319,62 @@ def build_semantic_validator(base_visitor_cls):
                 return None
             symbol = self._lookup(name)
             return symbol["type"] if symbol else None
+
+        def _collect_id_tokens(self, ctx):
+            id_tokens = ctx.ID()
+            if isinstance(id_tokens, list):
+                return id_tokens
+
+            tokens = []
+            index = 0
+            while True:
+                try:
+                    token = ctx.ID(index)
+                except Exception:
+                    break
+                if token is None:
+                    break
+                tokens.append(token)
+                index += 1
+            return tokens or [id_tokens]
+
+        def _resolve_lvalue_type(self, ctx):
+            id_tokens = self._collect_id_tokens(ctx)
+            if not id_tokens:
+                return None
+
+            root_identifier = id_tokens[0].getText()
+            current_type = self._check_expression_identifier(root_identifier, ctx)
+            if current_type is None:
+                return None
+
+            for field_token in id_tokens[1:]:
+                field_name = field_token.getText()
+                struct_fields = self.structs.get(current_type)
+                if struct_fields is None:
+                    self._add_diagnostic(
+                        severity="error",
+                        code="LCK302",
+                        message=(
+                            f"Cannot access field '{field_name}' on non-struct type "
+                            f"'{current_type}'."
+                        ),
+                        ctx=ctx,
+                        hint="Use field access only on values declared as struct types.",
+                    )
+                    return None
+                if field_name not in struct_fields:
+                    self._add_diagnostic(
+                        severity="error",
+                        code="LCK302",
+                        message=f"Struct '{current_type}' has no field '{field_name}'.",
+                        ctx=ctx,
+                        hint="Use one of the fields declared on this struct.",
+                    )
+                    return None
+                current_type = struct_fields[field_name]
+
+            return current_type
 
         def _type_check_bind_call(self, ctx, target_name: str, callee_name: str, arg_names):
             modifier_to_kind = {
@@ -456,6 +513,14 @@ def build_semantic_validator(base_visitor_cls):
             self._pop_scope()
             return result
 
+        def visitStructDecl(self, ctx):
+            struct_name = ctx.ID().getText()
+            fields = {}
+            for member in ctx.structMember() or []:
+                fields[member.ID().getText()] = member.typeName().getText()
+            self.structs[struct_name] = fields
+            return self.visitChildren(ctx)
+
         def visitFilterDecl(self, ctx):
             _name, params = self._record_kernel_signature(ctx, self.filters)
             self._push_scope()
@@ -559,8 +624,7 @@ def build_semantic_validator(base_visitor_cls):
             return self.visitChildren(ctx)
 
         def visitLvalue(self, ctx):
-            root_identifier = ctx.ID(0).getText()
-            self._check_expression_identifier(root_identifier, ctx)
+            self._resolve_lvalue_type(ctx)
             return self.visitChildren(ctx)
 
         def validate(self, tree):

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1201,3 +1201,69 @@ def test_semantic_validator_nested_lvalue_reports_single_undefined_identifier(
             hint="Declare the identifier in scope before using it.",
         )
     ]
+
+
+def test_semantic_validator_lvalue_validates_struct_field_chain(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    struct_ctx = _ctx(
+        ID=lambda: _token("Particle"),
+        structMember=lambda: [
+            _ctx(typeName=lambda: _token("Vec3"), ID=lambda: _token("position")),
+        ],
+    )
+    nested_struct_ctx = _ctx(
+        ID=lambda: _token("Vec3"),
+        structMember=lambda: [
+            _ctx(typeName=lambda: _token("float"), ID=lambda: _token("x")),
+        ],
+    )
+    validator.visitStructDecl(struct_ctx)
+    validator.visitStructDecl(nested_struct_ctx)
+
+    validator._push_scope()
+    validator._declare("entity", "Particle", _ctx(), duplicate_code="LCK306", kind="local")
+
+    lvalue_ctx = _ctx(
+        start_line=50,
+        start_col=2,
+        ID=lambda: [_token("entity"), _token("position"), _token("x")],
+    )
+
+    validator.visitLvalue(lvalue_ctx)
+
+    assert validator.diagnostics == []
+
+
+def test_semantic_validator_lvalue_reports_unknown_struct_field(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    struct_ctx = _ctx(
+        ID=lambda: _token("Particle"),
+        structMember=lambda: [
+            _ctx(typeName=lambda: _token("Vec3"), ID=lambda: _token("position")),
+        ],
+    )
+    validator.visitStructDecl(struct_ctx)
+
+    validator._push_scope()
+    validator._declare("entity", "Particle", _ctx(), duplicate_code="LCK306", kind="local")
+
+    lvalue_ctx = _ctx(
+        start_line=52,
+        start_col=4,
+        ID=lambda: [_token("entity"), _token("velocity")],
+    )
+
+    validator.visitLvalue(lvalue_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK302",
+            message="Struct 'Particle' has no field 'velocity'.",
+            line=52,
+            column=4,
+            hint="Use one of the fields declared on this struct.",
+        )
+    ]


### PR DESCRIPTION
### Motivation
- The semantic validator only checked the root identifier of `lvalue` expressions, allowing invalid nested field accesses like `entity.nonexistent_field` to pass undetected.
- The intent is to enforce correct struct field access by tracking struct definitions and resolving each `.` field access in an `lvalue` chain.

### Description
- Add `self.structs: dict[str, dict[str, str]]` to `LockstepSemanticValidator` and populate it in `visitStructDecl` with member names and types. 
- Implement `_collect_id_tokens` to robustly gather `ID` tokens from parse contexts and `_resolve_lvalue_type` to validate the full `ID ('.' ID)*` chain against known struct schemas. 
- Update `visitLvalue` to call `_resolve_lvalue_type` so nested field accesses are validated and the final type resolved. 
- Emit a new diagnostic `LCK302` when accessing a field on a non-struct type or when a struct lacks the referenced field. 
- Add tests in `tests/test_debug_compiler.py` to cover valid nested access (`entity.position.x`) and invalid field access (`entity.velocity`).

### Testing
- Ran `pytest -q -o addopts='' tests/test_debug_compiler.py -k lvalue` which completed successfully with `3 passed, 31 deselected`.
- Ran full tests with `pytest -q -o addopts='' tests/test_debug_compiler.py` which completed successfully with `34 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3222b9ee88328b88fcea27a6f6f16)