### PR TITLE
Add CLI --dump flag for compiled entities introspection

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -14,14 +15,20 @@ def build_arg_parser():
         nargs="?",
         help="Optional path to a Lockstep source file. Reads from stdin when omitted.",
     )
+    parser.add_argument(
+        "--dump",
+        action="store_true",
+        help="Print compiled entities (pipeline topology and bounds) as JSON.",
+    )
     return parser
 
 
-def run_cli(argv=None, *, stdin=None, stderr=None, compiler=None):
+def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
     parser = build_arg_parser()
     args = parser.parse_args(argv)
 
     stdin = sys.stdin if stdin is None else stdin
+    stdout = sys.stdout if stdout is None else stdout
     stderr = sys.stderr if stderr is None else stderr
 
     if args.path:
@@ -59,7 +66,7 @@ def run_cli(argv=None, *, stdin=None, stderr=None, compiler=None):
         return 1
 
     try:
-        compiler(source)
+        result = compiler(source)
     except LockstepCompileError as err:
         count = len(err.errors)
         suffix = "" if count == 1 else "s"
@@ -73,5 +80,9 @@ def run_cli(argv=None, *, stdin=None, stderr=None, compiler=None):
     except Exception:
         print("Compilation failed due to an internal error.", file=stderr)
         return 1
+
+    if args.dump:
+        entities = getattr(result, "entities", result)
+        print(json.dumps(entities, indent=2, sort_keys=True, default=str), file=stdout)
 
     return 0

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -831,6 +831,64 @@ def test_run_cli_reads_source_from_path(debug_compiler_module, tmp_path):
     assert captured["source"] == "pipeline FromFile { }"
 
 
+def test_run_cli_dump_prints_compiled_entities(debug_compiler_module):
+    def fake_compiler(_source):
+        return debug_compiler_module.LockstepCompileResult(
+            parse_tree=None,
+            entities={
+                "streams": [{"name": "positions", "capacity": 1000}],
+                "bind_routes": ["out = Simulate(inp);"],
+            },
+            diagnostics=[],
+        )
+
+    stdout = io.StringIO()
+    exit_code = debug_compiler_module.run_cli(
+        ["--dump"],
+        stdin=io.StringIO("pipeline Physics { }"),
+        stdout=stdout,
+        compiler=fake_compiler,
+    )
+
+    assert exit_code == 0
+    assert stdout.getvalue().splitlines() == [
+        "{",
+        '  "bind_routes": [',
+        '    "out = Simulate(inp);"',
+        "  ],",
+        '  "streams": [',
+        "    {",
+        '      "capacity": 1000,',
+        '      "name": "positions"',
+        "    }",
+        "  ]",
+        "}",
+    ]
+
+
+def test_run_cli_dump_falls_back_to_compiler_result(debug_compiler_module):
+    def fake_compiler(_source):
+        return {"nodes": ["a", "b"]}
+
+    stdout = io.StringIO()
+    exit_code = debug_compiler_module.run_cli(
+        ["--dump"],
+        stdin=io.StringIO("pipeline Physics { }"),
+        stdout=stdout,
+        compiler=fake_compiler,
+    )
+
+    assert exit_code == 0
+    assert stdout.getvalue().splitlines() == [
+        "{",
+        '  "nodes": [',
+        '    "a",',
+        '    "b"',
+        "  ]",
+        "}",
+    ]
+
+
 def test_run_cli_returns_non_zero_and_writes_errors(debug_compiler_module):
     def failing_compiler(_source):
         raise debug_compiler_module.LockstepCompileError(


### PR DESCRIPTION
### Motivation
- Enable quick, developer-friendly introspection of the compiled pipeline topology and bounds from the CLI so users don't need to write ad-hoc scripts to inspect the compiler output.

### Description
- Add a `--dump` CLI flag in `build_arg_parser()` to request JSON output of compiled entities.
- Import `json` and extend `run_cli()` to accept an optional `stdout` stream and capture the compiler return value as `result`.
- When `--dump` is present, print `result.entities` if available, falling back to the raw compiler return value, using `json.dumps(..., indent=2, sort_keys=True, default=str)` to format output.
- Add two regression tests in `tests/test_debug_compiler.py` to validate `--dump` prints `LockstepCompileResult.entities` and that it falls back to a plain dictionary return from the compiler.

### Testing
- Ran targeted tests for the CLI changes with `pytest -q tests/test_debug_compiler.py -k 'run_cli' -o addopts=''`, which passed (`9 passed, 25 deselected`).
- Ran the full suite for the impacted modules with `pytest -q tests/test_compiler_api.py tests/test_debug_compiler.py -o addopts=''`, which passed (`36 passed`).
- Note: running `pytest` without clearing the repo `addopts` in this environment initially failed due to an external coverage configuration injection, so tests were run with `-o addopts=''` to disable those extra arguments and verify the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a322535c5483289c6b24653f949fb9)