### PR TITLE
Make stream/accumulator/uniform redeclaration checks pipeline-local

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -28,9 +28,9 @@ def build_debug_visitor(base_visitor_cls):
             self._seen_shaders = set()
             self._seen_filters = set()
             self._seen_pure_functions = set()
-            self._seen_streams = set()
-            self._seen_accumulators = set()
-            self._seen_uniforms = set()
+            self._seen_streams: set[str] = set()
+            self._seen_accumulators: set[str] = set()
+            self._seen_uniforms: set[str] = set()
 
         def _print(self, message: str):
             if self.verbose:
@@ -144,6 +144,9 @@ def build_debug_visitor(base_visitor_cls):
 
         def visitPipelineDecl(self, ctx):
             name = ctx.ID().getText()
+            self._seen_streams = set()
+            self._seen_accumulators = set()
+            self._seen_uniforms = set()
             self._print(f"\n[Pipeline Topology] {name}")
             return self.visitChildren(ctx)
 

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -738,6 +738,33 @@ def test_visitor_emits_diagnostics_for_non_fatal_observations(debug_compiler_mod
     ]
 
 
+def test_visitor_stream_redeclaration_is_pipeline_local(debug_compiler_module):
+    visitor = debug_compiler_module.LockstepDebugVisitor(verbose=False)
+
+    visitor.visitPipelineDecl(_ctx(ID=lambda: _token("P1")))
+    visitor.visitStreamDecl(
+        _ctx(
+            start_line=2,
+            start_col=1,
+            typeName=lambda: _token("Vec3"),
+            INT=lambda: _token("8"),
+            ID=lambda: _token("s"),
+        )
+    )
+    visitor.visitPipelineDecl(_ctx(ID=lambda: _token("P2")))
+    visitor.visitStreamDecl(
+        _ctx(
+            start_line=6,
+            start_col=1,
+            typeName=lambda: _token("Vec3"),
+            INT=lambda: _token("8"),
+            ID=lambda: _token("s"),
+        )
+    )
+
+    assert visitor.diagnostics == []
+
+
 def test_visitor_shader_decl_without_param_list(debug_compiler_module, capsys):
     visitor = debug_compiler_module.LockstepDebugVisitor()
     visitor.visitShaderDecl(_ctx(ID=lambda: _token("Kernel"), paramList=lambda: None))


### PR DESCRIPTION
### Motivation
- Prevent false-positive redeclaration warnings when separate pipelines declare identically named streams/accumulators/uniforms.
- Preserve global uniqueness for top-level entities (`struct`, `shader`, `filter`, `pure`) which are intended to be unique across the file.

### Description
- Changed `_seen_streams`, `_seen_accumulators`, and `_seen_uniforms` to be tracked as instance sets with explicit typing and reset at the start of each pipeline in `visitPipelineDecl` (`lockstep_compiler/visitors.py`).
- Left `_seen_structs`, `_seen_shaders`, `_seen_filters`, and `_seen_pure_functions` as global-per-visitor checks to keep top-level entity uniqueness unchanged.
- Added a regression test `test_visitor_stream_redeclaration_is_pipeline_local` in `tests/test_debug_compiler.py` that creates two pipelines both declaring `stream<Vec3, 8> s;` and asserts no cross-pipeline warning is emitted.

### Testing
- Ran `pytest -q tests/test_debug_compiler.py` which initially failed due to repository `pyproject.toml` injecting coverage `--cov` options not available in the environment. (This is a test-run error caused by the test runner options.)
- Re-ran tests with addopts disabled using `pytest -q -o addopts='' tests/test_debug_compiler.py` and all tests passed: `37 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a328d24dc483288f4f6eaa08b282ce)