### PR TITLE
Add `--debug` CLI flag for detailed compiler failure output

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import sys
+import traceback
 from pathlib import Path
 
 from .errors import LockstepCompileError
@@ -19,6 +20,11 @@ def build_arg_parser():
         "--dump",
         action="store_true",
         help="Print compiled entities (pipeline topology and bounds) as JSON.",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Print detailed exception diagnostics and traceback on failures.",
     )
     return parser
 
@@ -76,9 +82,35 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
         )
         for error in err.errors:
             print(f"line {error.line}:{error.column} {error.message}", file=stderr)
+        if args.debug:
+            if err.diagnostics:
+                print("diagnostics:", file=stderr)
+                print(
+                    json.dumps(
+                        [
+                            {
+                                "severity": diagnostic.severity,
+                                "code": diagnostic.code,
+                                "message": diagnostic.message,
+                                "line": diagnostic.line,
+                                "column": diagnostic.column,
+                                "hint": diagnostic.hint,
+                            }
+                            for diagnostic in err.diagnostics
+                        ],
+                        indent=2,
+                        sort_keys=True,
+                    ),
+                    file=stderr,
+                )
+            print(f"{type(err).__name__}: {err}", file=stderr)
+            traceback.print_exc(file=stderr)
         return 1
-    except Exception:
+    except Exception as err:
         print("Compilation failed due to an internal error.", file=stderr)
+        if args.debug:
+            print(f"{type(err).__name__}: {err}", file=stderr)
+            traceback.print_exc(file=stderr)
         return 1
 
     if args.dump:

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -920,6 +920,67 @@ def test_run_cli_returns_non_zero_and_writes_errors(debug_compiler_module):
     ]
 
 
+def test_run_cli_internal_error_default_mode_keeps_generic_message(debug_compiler_module):
+    def failing_compiler(_source):
+        raise RuntimeError("kaboom")
+
+    stderr = io.StringIO()
+    exit_code = debug_compiler_module.run_cli(
+        [],
+        stdin=io.StringIO("pipeline Broken {"),
+        stderr=stderr,
+        compiler=failing_compiler,
+    )
+
+    assert exit_code == 1
+    assert stderr.getvalue().splitlines() == [
+        "Compilation failed due to an internal error.",
+    ]
+
+
+def test_run_cli_debug_mode_emits_exception_details_and_traceback(debug_compiler_module):
+    def failing_compiler(_source):
+        raise debug_compiler_module.LockstepCompileError(
+            [
+                debug_compiler_module.LockstepDiagnostic(
+                    severity="error",
+                    code="LCK001",
+                    message="unexpected",
+                    line=4,
+                    column=2,
+                    hint="Fix syntax errors before semantic analysis can continue.",
+                )
+            ],
+            diagnostics=[
+                debug_compiler_module.LockstepDiagnostic(
+                    severity="warning",
+                    code="LCK201",
+                    message="Struct redeclared",
+                    line=2,
+                    column=1,
+                    hint="Rename duplicate struct.",
+                )
+            ],
+        )
+
+    stderr = io.StringIO()
+    exit_code = debug_compiler_module.run_cli(
+        ["--debug"],
+        stdin=io.StringIO("pipeline Broken {"),
+        stderr=stderr,
+        compiler=failing_compiler,
+    )
+
+    output = stderr.getvalue()
+    assert exit_code == 1
+    assert "Compilation failed with 1 parse error." in output
+    assert "line 4:2 unexpected" in output
+    assert "diagnostics:" in output
+    assert '"code": "LCK201"' in output
+    assert "LockstepCompileError: Compilation failed with 1 parse error." in output
+    assert "Traceback (most recent call last):" in output
+
+
 def test_run_cli_returns_non_zero_for_missing_path(debug_compiler_module, tmp_path):
     missing = tmp_path / "missing.lock"
     stderr = io.StringIO()


### PR DESCRIPTION
### Motivation
- Provide a way for developers to see exception types, messages, and tracebacks from the CLI when diagnosing internal compiler failures.
- Allow optional structured logging of `LockstepCompileError.diagnostics` to help surface semantic diagnostics when debugging.
- Preserve the existing user-facing behavior by keeping the generic internal error message in normal (non-debug) runs.

### Description
- Add a `--debug` flag to `build_arg_parser` in `lockstep_compiler/cli.py` to enable verbose failure diagnostics.
- In `run_cli`, retain the existing generic internal error message by default and, when `--debug` is set, print the exception type/message and full traceback to `stderr` for both `LockstepCompileError` and other exceptions.
- When a `LockstepCompileError` contains `diagnostics`, emit a structured JSON representation of those diagnostics to `stderr` when `--debug` is enabled.
- Add tests in `tests/test_debug_compiler.py` to verify default behavior keeps the generic message and debug mode emits diagnostics, exception details, and a traceback.

### Testing
- Ran the targeted tests with `pytest -q -o addopts='' tests/test_debug_compiler.py -k 'run_cli_internal_error_default_mode_keeps_generic_message or run_cli_debug_mode_emits_exception_details_and_traceback or run_cli_returns_non_zero_and_writes_errors'` which passed with `3 passed, 35 deselected`.
- Ran the full debug compiler test module with `pytest -q -o addopts='' tests/test_debug_compiler.py` which passed with `38 passed`.
- An initial `pytest` invocation failed due to repository `addopts` containing CI-only coverage flags, so subsequent runs used `-o addopts=''` to run successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a328d5d6908328a2e00e5c80fed976)