### PR TITLE
Detect duplicate struct field declarations during semantic validation

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -527,8 +527,22 @@ def build_semantic_validator(base_visitor_cls):
         def visitStructDecl(self, ctx):
             struct_name = ctx.ID().getText()
             fields = {}
+            seen_field_names: set[str] = set()
             for member in ctx.structMember() or []:
                 field_name = member.ID().getText()
+                if field_name in seen_field_names:
+                    self._add_diagnostic(
+                        severity="error",
+                        code="LCK311",
+                        message=(
+                            f"Struct '{struct_name}' has duplicate field declaration "
+                            f"'{field_name}'."
+                        ),
+                        ctx=member,
+                        hint="Rename or remove duplicate struct member declarations.",
+                    )
+                    continue
+                seen_field_names.add(field_name)
                 fields[field_name] = SemanticStructField(name=field_name, declared_type=member.typeName().getText())
             self.structs[struct_name] = fields
             return self.visitChildren(ctx)

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -12,7 +12,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 
-from lockstep_compiler.models import SemanticKernelParam, SemanticSymbol
+from lockstep_compiler.models import SemanticKernelParam, SemanticStructField, SemanticSymbol
 
 def _install_fake_generated_modules(monkeypatch):
     """Install minimal ANTLR-generated modules so debug_compiler can import."""
@@ -1296,6 +1296,49 @@ def test_semantic_validator_lvalue_validates_struct_field_chain(debug_compiler_m
     validator.visitLvalue(lvalue_ctx)
 
     assert validator.diagnostics == []
+
+
+def test_semantic_validator_struct_decl_reports_duplicate_member(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    struct_ctx = _ctx(
+        ID=lambda: _token("Particle"),
+        structMember=lambda: [
+            _ctx(start_line=60, start_col=6, typeName=lambda: _token("Vec3"), ID=lambda: _token("position")),
+            _ctx(start_line=61, start_col=8, typeName=lambda: _token("float"), ID=lambda: _token("position")),
+        ],
+    )
+
+    validator.visitStructDecl(struct_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK311",
+            message="Struct 'Particle' has duplicate field declaration 'position'.",
+            line=61,
+            column=8,
+            hint="Rename or remove duplicate struct member declarations.",
+        )
+    ]
+
+
+def test_semantic_validator_struct_decl_keeps_first_duplicate_member(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    struct_ctx = _ctx(
+        ID=lambda: _token("Particle"),
+        structMember=lambda: [
+            _ctx(typeName=lambda: _token("Vec3"), ID=lambda: _token("position")),
+            _ctx(typeName=lambda: _token("float"), ID=lambda: _token("position")),
+        ],
+    )
+
+    validator.visitStructDecl(struct_ctx)
+
+    assert validator.structs["Particle"] == {
+        "position": SemanticStructField(name="position", declared_type="Vec3")
+    }
 
 
 def test_semantic_validator_lvalue_reports_unknown_struct_field(debug_compiler_module):


### PR DESCRIPTION
### Motivation
- Prevent silent overwrites when a struct member name is repeated by reporting a clear semantic error and keeping deterministic behavior.
- Make diagnostics precise by pointing at the duplicate field token so users can quickly fix member-name collisions.

### Description
- Update `LockstepSemanticValidator.visitStructDecl` to track seen struct member names in a `set` while iterating `structMember()` entries and skip subsequent duplicates instead of overwriting the first declaration.
- Emit a new error diagnostic `LCK311` with a message containing the struct and field name and attach the diagnostic to the duplicate member context (`ctx=member`).
- Preserve the first declaration for a field name so `validator.structs` remains deterministic and predictable.
- Add unit tests in `tests/test_debug_compiler.py` that assert duplicate-field diagnostics are produced with correct locations and that the first declaration is retained; also update test imports to include `SemanticStructField`.

### Testing
- Ran the test suite file with `pytest -q -o addopts='' tests/test_debug_compiler.py` and all tests passed (`38 passed`).
- Running `pytest -q tests/test_debug_compiler.py` initially failed due to repository `pyproject.toml` addopts that include coverage options not available in the environment, so the adjusted `-o addopts=''` invocation was used to run the tests successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a328ce04a883288884b70ab4055874)