### PR TITLE
Add centralized declared-type validation in semantic visitor

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -1,3 +1,4 @@
+from difflib import get_close_matches
 from typing import Any
 
 from .models import (
@@ -248,6 +249,7 @@ def build_semantic_validator(base_visitor_cls):
             self.shaders: dict[str, list[SemanticKernelParam]] = {}
             self.filters: dict[str, list[SemanticKernelParam]] = {}
             self.structs: dict[str, dict[str, SemanticStructField]] = {}
+            self._primitive_types = {"int", "float", "bool"}
 
         def _line_col(self, ctx) -> tuple[int, int]:
             token = getattr(ctx, "start", None)
@@ -289,6 +291,31 @@ def build_semantic_validator(base_visitor_cls):
         def _declared_in_current_scope(self, name: str) -> bool:
             return bool(self.scopes and name in self.scopes[-1])
 
+        def _known_types(self) -> set[str]:
+            return self._primitive_types | set(self.structs.keys())
+
+        def _validate_declared_type(self, type_name: str, ctx, code: str) -> bool:
+            known_types = self._known_types()
+            if type_name in known_types:
+                return True
+
+            suggestions = get_close_matches(type_name, sorted(known_types), n=2, cutoff=0.6)
+            hint = (
+                f"Unknown type '{type_name}'. Use a primitive ({', '.join(sorted(self._primitive_types))}) "
+                "or declare a struct with this name before using it."
+            )
+            if suggestions:
+                hint = f"Did you mean {', '.join(suggestions)}? {hint}"
+
+            self._add_diagnostic(
+                severity="error",
+                code=code,
+                message=f"Unknown declared type '{type_name}'.",
+                ctx=ctx,
+                hint=hint,
+            )
+            return False
+
         def _record_kernel_signature(self, ctx, target: dict[str, list[SemanticKernelParam]]):
             name = ctx.ID().getText()
             if name in target:
@@ -302,6 +329,11 @@ def build_semantic_validator(base_visitor_cls):
             params = []
             if ctx.paramList():
                 for param in ctx.paramList().param():
+                    self._validate_declared_type(
+                        param.typeName().getText(),
+                        param.typeName(),
+                        "LCK310",
+                    )
                     params.append(
                         SemanticKernelParam(
                             name=param.ID().getText(),
@@ -549,6 +581,7 @@ def build_semantic_validator(base_visitor_cls):
             return result
 
         def visitVarDecl(self, ctx):
+            self._validate_declared_type(ctx.typeName().getText(), ctx.typeName(), "LCK310")
             self._declare(ctx.ID().getText(), ctx.typeName().getText(), ctx, duplicate_code="LCK306", kind="local")
             return self.visitChildren(ctx)
 
@@ -559,14 +592,17 @@ def build_semantic_validator(base_visitor_cls):
             return result
 
         def visitStreamDecl(self, ctx):
+            self._validate_declared_type(ctx.typeName().getText(), ctx.typeName(), "LCK310")
             self._declare(ctx.ID().getText(), ctx.typeName().getText(), ctx, duplicate_code="LCK306", kind="stream")
             return self.visitChildren(ctx)
 
         def visitAccumDecl(self, ctx):
+            self._validate_declared_type(ctx.typeName().getText(), ctx.typeName(), "LCK310")
             self._declare(ctx.ID().getText(), ctx.typeName().getText(), ctx, duplicate_code="LCK306", kind="accumulator")
             return self.visitChildren(ctx)
 
         def visitUniformDecl(self, ctx):
+            self._validate_declared_type(ctx.typeName().getText(), ctx.typeName(), "LCK310")
             self._declare(ctx.ID().getText(), ctx.typeName().getText(), ctx, duplicate_code="LCK306", kind="uniform")
             return self.visitChildren(ctx)
 
@@ -583,6 +619,8 @@ def build_semantic_validator(base_visitor_cls):
             fold_operator = ctx.foldOperator().getText()
             fold_source = id_tokens[1].getText()
             declared_type = ctx.typeName().getText()
+
+            self._validate_declared_type(declared_type, ctx.typeName(), "LCK310")
 
             self._declare(
                 fold_target,

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1225,6 +1225,137 @@ def test_semantic_validator_fold_declares_target_uniform_without_scope(debug_com
     assert validator.scopes[-1]["u1"] == SemanticSymbol(name="u1", declared_type="float", kind="uniform")
 
 
+def test_semantic_validator_accepts_struct_types_in_declarations(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    class _Param:
+        def __init__(self, modifier, declared_type, name):
+            self._modifier = _token(modifier)
+            self._declared_type = _token(declared_type)
+            self._name = _token(name)
+
+        def getChild(self, index):
+            assert index == 0
+            return self._modifier
+
+        def typeName(self):
+            return self._declared_type
+
+        def ID(self):
+            return self._name
+
+    class _ParamList:
+        def __init__(self, params):
+            self._params = params
+
+        def param(self):
+            return self._params
+
+    validator.visitStructDecl(_ctx(ID=lambda: _token("Particle"), structMember=lambda: []))
+    validator.visitVarDecl(_ctx(ID=lambda: _token("entity"), typeName=lambda: _token("Particle")))
+    validator.visitStreamDecl(
+        _ctx(ID=lambda: _token("particles"), typeName=lambda: _token("Particle"))
+    )
+    validator.visitAccumDecl(_ctx(ID=lambda: _token("acc_particles"), typeName=lambda: _token("Particle")))
+    validator.visitUniformDecl(_ctx(ID=lambda: _token("u_enabled"), typeName=lambda: _token("bool")))
+
+    validator.visitShaderDecl(
+        _ctx(
+            ID=lambda: _token("Apply"),
+            paramList=lambda: _ParamList([_Param("in", "Particle", "inp"), _Param("out", "Particle", "outp")]),
+        )
+    )
+    validator.visitFilterDecl(
+        _ctx(
+            ID=lambda: _token("OnlyEnabled"),
+            paramList=lambda: _ParamList([_Param("uniform", "bool", "enabled")]),
+        )
+    )
+
+    validator._declare("acc_fold", "Particle", _ctx(), duplicate_code="LCK306", kind="accumulator")
+    validator.visitBindStmt(
+        _ctx(
+            ID=lambda: [_token("u_particle"), _token("acc_fold")],
+            foldOperator=lambda: _token("sum"),
+            argList=lambda: None,
+            typeName=lambda: _token("Particle"),
+        )
+    )
+
+    assert validator.diagnostics == []
+
+
+def test_semantic_validator_reports_unknown_declared_type_with_hint(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    class _Param:
+        def __init__(self, modifier, declared_type, name):
+            self._modifier = _token(modifier)
+            self._declared_type = _token(declared_type)
+            self._name = _token(name)
+
+        def getChild(self, index):
+            assert index == 0
+            return self._modifier
+
+        def typeName(self):
+            return self._declared_type
+
+        def ID(self):
+            return self._name
+
+    class _ParamList:
+        def __init__(self, params):
+            self._params = params
+
+        def param(self):
+            return self._params
+
+    validator._push_scope()
+    validator.visitVarDecl(_ctx(start_line=60, start_col=1, ID=lambda: _token("v0"), typeName=lambda: _token("flaot")))
+    validator.visitStreamDecl(
+        _ctx(start_line=61, start_col=1, ID=lambda: _token("s0"), typeName=lambda: _token("flaot"))
+    )
+    validator.visitAccumDecl(
+        _ctx(start_line=62, start_col=1, ID=lambda: _token("a0"), typeName=lambda: _token("flaot"))
+    )
+    validator.visitUniformDecl(
+        _ctx(start_line=63, start_col=1, ID=lambda: _token("u0"), typeName=lambda: _token("flaot"))
+    )
+    validator.visitShaderDecl(
+        _ctx(
+            start_line=64,
+            start_col=1,
+            ID=lambda: _token("S"),
+            paramList=lambda: _ParamList([_Param("in", "flaot", "inp")]),
+        )
+    )
+    validator.visitFilterDecl(
+        _ctx(
+            start_line=65,
+            start_col=1,
+            ID=lambda: _token("F"),
+            paramList=lambda: _ParamList([_Param("uniform", "flaot", "u")]),
+        )
+    )
+    validator._declare("acc_src", "flaot", _ctx(), duplicate_code="LCK306", kind="accumulator")
+    validator.visitBindStmt(
+        _ctx(
+            start_line=66,
+            start_col=1,
+            ID=lambda: [_token("u_fold"), _token("acc_src")],
+            foldOperator=lambda: _token("sum"),
+            argList=lambda: None,
+            typeName=lambda: _token("flaot"),
+        )
+    )
+
+    type_errors = [diag for diag in validator.diagnostics if diag.code == "LCK310"]
+    assert len(type_errors) == 7
+    assert all(diag.message == "Unknown declared type 'flaot'." for diag in type_errors)
+    assert any(diag.hint is not None and "Did you mean float?" in diag.hint for diag in type_errors)
+
+
 def test_semantic_validator_nested_lvalue_reports_single_undefined_identifier(
     debug_compiler_module,
 ):


### PR DESCRIPTION
### Motivation
- Prevent silent use of unknown/typoed types by centralizing declared-type checks for declarations and kernel parameters.
- Provide actionable diagnostics with suggestions when users reference unknown types to speed up developer feedback.

### Description
- Introduced a primitive known-type set `{"int", "float", "bool"}` and a `_known_types()` helper that includes discovered struct names.
- Added `_validate_declared_type(type_name, ctx, code)` which emits `LCK310` errors for unknown types and offers close-match suggestions via `get_close_matches`.
- Invoked the validator for shader/filter parameter signatures, `visitVarDecl`, `visitStreamDecl`, `visitAccumDecl`, `visitUniformDecl`, and the fold-target declaration path inside `visitBindStmt`.
- Tests added to `tests/test_debug_compiler.py` to verify acceptance of declared struct types across declaration sites and to assert that typoed types (e.g. `flaot`) produce `LCK310` diagnostics with suggestion hints.

### Testing
- Ran `pytest -q -o addopts='' tests/test_debug_compiler.py -k "struct_types_in_declarations or unknown_declared_type_with_hint"` which passed with `2 passed, 36 deselected`.
- Ran the full suite with `pytest -q -o addopts='' tests/test_debug_compiler.py` which passed with `38 passed`.
- Note: an initial `pytest` invocation failed in this environment due to project `addopts` injecting coverage flags; subsequent runs used `-o addopts=''` to override and validate the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a328cb96308328a7888c4df0543136)