### PR TITLE
Validate pure function calls in semantic visitor

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -247,6 +247,7 @@ def build_semantic_validator(base_visitor_cls):
             self.scopes: list[dict[str, SemanticSymbol]] = []
             self.shaders: dict[str, list[SemanticKernelParam]] = {}
             self.filters: dict[str, list[SemanticKernelParam]] = {}
+            self.pure_functions: dict[str, dict[str, Any]] = {}
             self.structs: dict[str, dict[str, SemanticStructField]] = {}
 
         def _line_col(self, ctx) -> tuple[int, int]:
@@ -548,6 +549,126 @@ def build_semantic_validator(base_visitor_cls):
             self._pop_scope()
             return result
 
+        def visitPureDecl(self, ctx):
+            name = ctx.ID().getText()
+            params = []
+            if ctx.pureParamList() is not None:
+                param_list = ctx.pureParamList()
+                param_types = param_list.typeName()
+                param_names = param_list.ID()
+                for index, param_name in enumerate(param_names):
+                    params.append(
+                        SemanticKernelParam(
+                            name=param_name.getText(),
+                            declared_type=param_types[index].getText(),
+                            modifier="value",
+                        )
+                    )
+
+            self.pure_functions[name] = {
+                "return_type": ctx.typeName().getText(),
+                "params": params,
+            }
+
+            self._push_scope()
+            for param in params:
+                self._declare(
+                    param.name,
+                    param.declared_type,
+                    ctx,
+                    duplicate_code="LCK306",
+                    kind=f"param:{param.modifier}",
+                )
+            result = self.visitChildren(ctx)
+            self._pop_scope()
+            return result
+
+        def _resolve_expr_type(self, ctx):
+            if ctx is None:
+                return None
+
+            if hasattr(ctx, "declared_type"):
+                return ctx.declared_type
+
+            if hasattr(ctx, "INT") and callable(ctx.INT) and ctx.INT() is not None:
+                return "int"
+            if hasattr(ctx, "FLOAT") and callable(ctx.FLOAT) and ctx.FLOAT() is not None:
+                return "float"
+            if hasattr(ctx, "BOOL") and callable(ctx.BOOL) and ctx.BOOL() is not None:
+                return "bool"
+
+            if hasattr(ctx, "lvalue") and callable(ctx.lvalue) and ctx.lvalue() is not None:
+                return self._resolve_lvalue_type(ctx.lvalue())
+
+            if hasattr(ctx, "ID") and callable(ctx.ID) and ctx.ID() is not None:
+                if hasattr(ctx, "exprList") and callable(ctx.exprList) and ctx.exprList() is not None:
+                    function_name = ctx.ID().getText()
+                    function_signature = self.pure_functions.get(function_name)
+                    if function_signature is not None:
+                        return function_signature["return_type"]
+                    return None
+                return self._check_expression_identifier(ctx.ID().getText(), ctx)
+
+            if hasattr(ctx, "primaryExpr") and callable(ctx.primaryExpr) and ctx.primaryExpr() is not None:
+                return self._resolve_expr_type(ctx.primaryExpr())
+
+            if hasattr(ctx, "expr") and callable(ctx.expr):
+                child_expr = ctx.expr()
+                if isinstance(child_expr, list):
+                    if len(child_expr) == 1:
+                        return self._resolve_expr_type(child_expr[0])
+                    return None
+                if child_expr is not None:
+                    return self._resolve_expr_type(child_expr)
+
+            return None
+
+        def _type_check_pure_call(self, ctx):
+            callee_name = ctx.ID().getText()
+            signature = self.pure_functions.get(callee_name)
+            if signature is None:
+                self._add_diagnostic(
+                    severity="error",
+                    code="LCK410",
+                    message=f"Undefined pure function '{callee_name}'.",
+                    ctx=ctx,
+                    hint="Declare the pure function before calling it.",
+                )
+                return
+
+            expected_params: list[SemanticKernelParam] = signature["params"]
+            actual_args = []
+            if ctx.exprList() is not None:
+                actual_args = ctx.exprList().expr()
+
+            if len(actual_args) != len(expected_params):
+                self._add_diagnostic(
+                    severity="error",
+                    code="LCK411",
+                    message=(
+                        f"Pure function '{callee_name}' expects {len(expected_params)} argument(s), "
+                        f"but got {len(actual_args)}."
+                    ),
+                    ctx=ctx,
+                    hint="Pass the exact number of arguments declared in the pure function signature.",
+                )
+                return
+
+            for index, (arg_expr, expected) in enumerate(zip(actual_args, expected_params), start=1):
+                actual_type = self._resolve_expr_type(arg_expr)
+                if actual_type != expected.declared_type:
+                    resolved_actual = actual_type if actual_type is not None else "<unresolved>"
+                    self._add_diagnostic(
+                        severity="error",
+                        code="LCK412",
+                        message=(
+                            f"Type mismatch for argument {index} in pure call '{callee_name}': "
+                            f"expected {expected.declared_type}, got {resolved_actual}."
+                        ),
+                        ctx=ctx,
+                        hint="Ensure each argument type matches the pure function parameter type.",
+                    )
+
         def visitVarDecl(self, ctx):
             self._declare(ctx.ID().getText(), ctx.typeName().getText(), ctx, duplicate_code="LCK306", kind="local")
             return self.visitChildren(ctx)
@@ -638,6 +759,8 @@ def build_semantic_validator(base_visitor_cls):
             if ctx.ID():
                 if ctx.exprList() is None:
                     self._check_expression_identifier(ctx.ID().getText(), ctx)
+                else:
+                    self._type_check_pure_call(ctx)
                 return self.visitChildren(ctx)
             return self.visitChildren(ctx)
 

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1225,6 +1225,143 @@ def test_semantic_validator_fold_declares_target_uniform_without_scope(debug_com
     assert validator.scopes[-1]["u1"] == SemanticSymbol(name="u1", declared_type="float", kind="uniform")
 
 
+def test_semantic_validator_records_pure_signature_from_declaration(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    pure_param_list_ctx = _ctx(
+        typeName=lambda: [_token("float"), _token("int")],
+        ID=lambda: [_token("left"), _token("right")],
+    )
+    pure_decl_ctx = _ctx(
+        ID=lambda: _token("blend"),
+        typeName=lambda: _token("float"),
+        pureParamList=lambda: pure_param_list_ctx,
+    )
+
+    validator.visitPureDecl(pure_decl_ctx)
+
+    assert validator.pure_functions == {
+        "blend": {
+            "return_type": "float",
+            "params": [
+                SemanticKernelParam(name="left", declared_type="float", modifier="value"),
+                SemanticKernelParam(name="right", declared_type="int", modifier="value"),
+            ],
+        }
+    }
+
+
+def test_semantic_validator_reports_undefined_pure_function_call(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    call_ctx = _ctx(
+        start_line=36,
+        start_col=3,
+        ID=lambda: _token("missing_pure"),
+        exprList=lambda: _ctx(expr=lambda: []),
+    )
+
+    validator.visitPrimaryExpr(call_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK410",
+            message="Undefined pure function 'missing_pure'.",
+            line=36,
+            column=3,
+            hint="Declare the pure function before calling it.",
+        )
+    ]
+
+
+def test_semantic_validator_reports_pure_call_arity_mismatch(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator.pure_functions = {
+        "mix": {
+            "return_type": "float",
+            "params": [
+                SemanticKernelParam(name="a", declared_type="float", modifier="value"),
+                SemanticKernelParam(name="b", declared_type="float", modifier="value"),
+            ],
+        }
+    }
+
+    call_ctx = _ctx(
+        start_line=37,
+        start_col=3,
+        ID=lambda: _token("mix"),
+        exprList=lambda: _ctx(expr=lambda: [_ctx(declared_type="float")]),
+    )
+
+    validator.visitPrimaryExpr(call_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK411",
+            message="Pure function 'mix' expects 2 argument(s), but got 1.",
+            line=37,
+            column=3,
+            hint="Pass the exact number of arguments declared in the pure function signature.",
+        )
+    ]
+
+
+def test_semantic_validator_reports_pure_call_argument_type_mismatch(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator.pure_functions = {
+        "negate": {
+            "return_type": "float",
+            "params": [SemanticKernelParam(name="value", declared_type="float", modifier="value")],
+        }
+    }
+
+    call_ctx = _ctx(
+        start_line=38,
+        start_col=3,
+        ID=lambda: _token("negate"),
+        exprList=lambda: _ctx(expr=lambda: [_ctx(declared_type="int")]),
+    )
+
+    validator.visitPrimaryExpr(call_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK412",
+            message="Type mismatch for argument 1 in pure call 'negate': expected float, got int.",
+            line=38,
+            column=3,
+            hint="Ensure each argument type matches the pure function parameter type.",
+        )
+    ]
+
+
+def test_semantic_validator_accepts_valid_pure_call(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator.pure_functions = {
+        "dot": {
+            "return_type": "float",
+            "params": [
+                SemanticKernelParam(name="x", declared_type="float", modifier="value"),
+                SemanticKernelParam(name="y", declared_type="float", modifier="value"),
+            ],
+        }
+    }
+
+    call_ctx = _ctx(
+        start_line=39,
+        start_col=3,
+        ID=lambda: _token("dot"),
+        exprList=lambda: _ctx(expr=lambda: [_ctx(declared_type="float"), _ctx(declared_type="float")]),
+    )
+
+    validator.visitPrimaryExpr(call_ctx)
+
+    assert validator.diagnostics == []
+
+
 def test_semantic_validator_nested_lvalue_reports_single_undefined_identifier(
     debug_compiler_module,
 ):


### PR DESCRIPTION
### Motivation

- Introduce semantic checks for `pure` functions so calls like `ID(exprList?)` are validated for existence, arity, and argument types.

### Description

- Add a `self.pure_functions` registry to `LockstepSemanticValidator.__init__` to store pure signatures.
- Implement `visitPureDecl` to record pure function `name`, `return_type`, and parameter `SemanticKernelParam` entries and declare params in the function scope.
- Add `_resolve_expr_type` and `_type_check_pure_call` helpers used from `visitPrimaryExpr` to validate pure-call callee existence, argument count, and per-argument type compatibility.
- Emit stable diagnostics for pure-call errors using codes `LCK410` (undefined pure function), `LCK411` (arity mismatch), and `LCK412` (argument type mismatch), and wire the check into `visitPrimaryExpr` when `ID '(' exprList? ')'` is encountered.
- Add focused tests in `tests/test_debug_compiler.py` to assert signature recording and the three failure cases plus a valid-call success case.

### Testing

- Ran `pytest -q -o addopts='' tests/test_debug_compiler.py` which executed the test suite containing the new cases and reported `41 passed`.
- An initial `pytest -q tests/test_debug_compiler.py` invocation failed due to project `addopts` requiring coverage plugins not present in the environment, so the `-o addopts=''` override was used to run the tests successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a328c88d38832895c5b128dc304abe)