### PR TITLE
Add semantic type checks for assignments, initializers, and pure returns

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -254,6 +254,7 @@ def build_semantic_validator(base_visitor_cls):
             self.pure_functions: dict[str, dict[str, Any]] = {}
             self.structs: dict[str, dict[str, SemanticStructField]] = {}
             self._primitive_types = {"int", "float", "bool"}
+            self._current_pure_function: dict[str, str] | None = None
 
         def _line_col(self, ctx) -> tuple[int, int]:
             token = getattr(ctx, "start", None)
@@ -600,12 +601,19 @@ def build_semantic_validator(base_visitor_cls):
 
         def visitPureDecl(self, ctx):
             name = ctx.ID().getText()
+            return_type = ctx.typeName().getText()
+            self._validate_declared_type(return_type, ctx.typeName(), "LCK310")
             params = []
             if ctx.pureParamList() is not None:
                 param_list = ctx.pureParamList()
                 param_types = param_list.typeName()
                 param_names = param_list.ID()
                 for index, param_name in enumerate(param_names):
+                    self._validate_declared_type(
+                        param_types[index].getText(),
+                        param_types[index],
+                        "LCK310",
+                    )
                     params.append(
                         SemanticKernelParam(
                             name=param_name.getText(),
@@ -615,11 +623,13 @@ def build_semantic_validator(base_visitor_cls):
                     )
 
             self.pure_functions[name] = {
-                "return_type": ctx.typeName().getText(),
+                "return_type": return_type,
                 "params": params,
             }
 
             self._push_scope()
+            previous_pure_function = self._current_pure_function
+            self._current_pure_function = {"name": name, "return_type": return_type}
             for param in params:
                 self._declare(
                     param.name,
@@ -629,6 +639,7 @@ def build_semantic_validator(base_visitor_cls):
                     kind=f"param:{param.modifier}",
                 )
             result = self.visitChildren(ctx)
+            self._current_pure_function = previous_pure_function
             self._pop_scope()
             return result
 
@@ -719,8 +730,66 @@ def build_semantic_validator(base_visitor_cls):
                     )
 
         def visitVarDecl(self, ctx):
-            self._validate_declared_type(ctx.typeName().getText(), ctx.typeName(), "LCK310")
-            self._declare(ctx.ID().getText(), ctx.typeName().getText(), ctx, duplicate_code="LCK306", kind="local")
+            declared_type = ctx.typeName().getText()
+            self._validate_declared_type(declared_type, ctx.typeName(), "LCK310")
+            self._declare(ctx.ID().getText(), declared_type, ctx, duplicate_code="LCK306", kind="local")
+
+            has_initializer = hasattr(ctx, "expr") and callable(ctx.expr) and ctx.expr() is not None
+            if has_initializer:
+                initializer_type = self._resolve_expr_type(ctx.expr())
+                if initializer_type is not None and initializer_type != declared_type:
+                    self._add_diagnostic(
+                        severity="error",
+                        code="LCK414",
+                        message=(
+                            f"Type mismatch in initializer for '{ctx.ID().getText()}': "
+                            f"expected {declared_type}, got {initializer_type}."
+                        ),
+                        ctx=ctx,
+                        hint="Use an initializer expression with the same type as the declared variable.",
+                    )
+            return self.visitChildren(ctx)
+
+        def visitAssignStmt(self, ctx):
+            lvalue_ctx = ctx.lvalue() if hasattr(ctx, "lvalue") and callable(ctx.lvalue) else None
+            expr_ctx = ctx.expr() if hasattr(ctx, "expr") and callable(ctx.expr) else None
+
+            lvalue_type = self._resolve_lvalue_type(lvalue_ctx) if lvalue_ctx is not None else None
+            expr_type = self._resolve_expr_type(expr_ctx)
+
+            if lvalue_type is not None and expr_type is not None and lvalue_type != expr_type:
+                self._add_diagnostic(
+                    severity="error",
+                    code="LCK413",
+                    message=(
+                        "Type mismatch in assignment: "
+                        f"left-hand side expects {lvalue_type}, got {expr_type}."
+                    ),
+                    ctx=ctx,
+                    hint="Assign expressions whose type matches the lvalue declaration.",
+                )
+
+            return self.visitChildren(ctx)
+
+        def visitReturnStmt(self, ctx):
+            if self._current_pure_function is None:
+                return self.visitChildren(ctx)
+
+            expected_type = self._current_pure_function["return_type"]
+            return_expr = ctx.expr() if hasattr(ctx, "expr") and callable(ctx.expr) else None
+            actual_type = self._resolve_expr_type(return_expr)
+            if actual_type is not None and actual_type != expected_type:
+                self._add_diagnostic(
+                    severity="error",
+                    code="LCK415",
+                    message=(
+                        f"Return type mismatch in pure function '{self._current_pure_function['name']}': "
+                        f"expected {expected_type}, got {actual_type}."
+                    ),
+                    ctx=ctx,
+                    hint="Return an expression whose type matches the pure function return type.",
+                )
+
             return self.visitChildren(ctx)
 
         def visitPipelineDecl(self, ctx):

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -84,6 +84,12 @@ def _install_fake_generated_modules(monkeypatch):
         class LvalueContext:
             pass
 
+        class AssignStmtContext:
+            pass
+
+        class ReturnStmtContext:
+            pass
+
         def __init__(self, stream):
             self.stream = stream
             self._listeners = []
@@ -1727,3 +1733,126 @@ def test_semantic_validator_lvalue_reports_unknown_struct_field(debug_compiler_m
             hint="Use one of the fields declared on this struct.",
         )
     ]
+
+
+def test_semantic_validator_reports_assignment_type_mismatch(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator._push_scope()
+    validator._declare("x", "int", _ctx(), duplicate_code="LCK306", kind="local")
+
+    assign_ctx = _ctx(
+        start_line=70,
+        start_col=3,
+        lvalue=lambda: _ctx(ID=lambda: [_token("x")]),
+        expr=lambda: _ctx(declared_type="float"),
+    )
+
+    validator.visitAssignStmt(assign_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK413",
+            message="Type mismatch in assignment: left-hand side expects int, got float.",
+            line=70,
+            column=3,
+            hint="Assign expressions whose type matches the lvalue declaration.",
+        )
+    ]
+
+
+def test_semantic_validator_reports_var_initializer_type_mismatch(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    var_decl_ctx = _ctx(
+        start_line=72,
+        start_col=1,
+        ID=lambda: _token("count"),
+        typeName=lambda: _token("int"),
+        expr=lambda: _ctx(declared_type="float"),
+    )
+
+    validator.visitVarDecl(var_decl_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK414",
+            message="Type mismatch in initializer for 'count': expected int, got float.",
+            line=72,
+            column=1,
+            hint="Use an initializer expression with the same type as the declared variable.",
+        )
+    ]
+
+
+def test_semantic_validator_reports_pure_return_type_mismatch(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    return_ctx = _ctx(start_line=74, start_col=5, expr=lambda: _ctx(declared_type="float"))
+    pure_ctx = _ctx(
+        ID=lambda: _token("compute"),
+        typeName=lambda: _token("int"),
+        pureParamList=lambda: None,
+        returnStmt=lambda: return_ctx,
+    )
+
+    original_visit_children = validator.visitChildren
+
+    def _visit_children(ctx):
+        if hasattr(ctx, "returnStmt") and callable(ctx.returnStmt) and ctx.returnStmt() is not None:
+            validator.visitReturnStmt(ctx.returnStmt())
+        return original_visit_children(ctx)
+
+    validator.visitChildren = _visit_children
+    validator.visitPureDecl(pure_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK415",
+            message="Return type mismatch in pure function 'compute': expected int, got float.",
+            line=74,
+            column=5,
+            hint="Return an expression whose type matches the pure function return type.",
+        )
+    ]
+
+
+def test_semantic_validator_accepts_matching_assignment_initializer_and_return(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator._push_scope()
+    validator._declare("x", "int", _ctx(), duplicate_code="LCK306", kind="local")
+
+    assign_ctx = _ctx(
+        lvalue=lambda: _ctx(ID=lambda: [_token("x")]),
+        expr=lambda: _ctx(declared_type="int"),
+    )
+    validator.visitAssignStmt(assign_ctx)
+
+    var_decl_ctx = _ctx(
+        ID=lambda: _token("count"),
+        typeName=lambda: _token("int"),
+        expr=lambda: _ctx(declared_type="int"),
+    )
+    validator.visitVarDecl(var_decl_ctx)
+
+    return_ctx = _ctx(expr=lambda: _ctx(declared_type="int"))
+    pure_ctx = _ctx(
+        ID=lambda: _token("compute"),
+        typeName=lambda: _token("int"),
+        pureParamList=lambda: None,
+        returnStmt=lambda: return_ctx,
+    )
+
+    original_visit_children = validator.visitChildren
+
+    def _visit_children(ctx):
+        if hasattr(ctx, "returnStmt") and callable(ctx.returnStmt) and ctx.returnStmt() is not None:
+            validator.visitReturnStmt(ctx.returnStmt())
+        return original_visit_children(ctx)
+
+    validator.visitChildren = _visit_children
+    validator.visitPureDecl(pure_ctx)
+
+    assert validator.diagnostics == []


### PR DESCRIPTION
### Motivation
- Strengthen the semantic validator to catch common type errors in imperative code paths: assignments, variable initializers, and pure function returns.
- Provide clearer diagnostics (LCK4xx-style) and hints so callers get actionable feedback when types disagree.

### Description
- Track the active pure-function context (`_current_pure_function` containing `name` and `return_type`) while entering/exiting `visitPureDecl` and validate pure return/parameter declared types via existing `LCK310` checks.
- Add `visitAssignStmt` to resolve the lvalue type and expression type and emit a new diagnostic `LCK413` when they differ, with a targeted hint.
- Extend `visitVarDecl` to type-check optional initializer expressions against the declared variable type and emit `LCK414` on mismatch.
- Add `visitReturnStmt` to compare the returned expression type with the active pure function return type and emit `LCK415` on mismatch, and add small parser-context stubs used by the tests.

### Testing
- Ran the new focused tests with `pytest -q -o addopts='' tests/test_debug_compiler.py -k "assignment_type_mismatch or var_initializer_type_mismatch or pure_return_type_mismatch or accepts_matching_assignment_initializer_and_return"` and they passed (4 passed, 48 deselected).
- Ran the broader semantic validator tests with `pytest -q -o addopts='' tests/test_debug_compiler.py -k "semantic_validator"` and they passed (24 passed, 28 deselected).
- All added tests are in `tests/test_debug_compiler.py` and validated the new diagnostics `LCK413`, `LCK414`, and `LCK415`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a36eafc8148328b9ba44607d40e5b7)