### PR TITLE
Enforce pure-function return diagnostics in semantic validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,11 @@ Each diagnostic includes:
 
 ### Behavior
 
-* **Non-fatal observations** (for example empty `bind` blocks or duplicate declarations) are returned in `LockstepCompileResult.diagnostics` and compilation still succeeds.
+* **Non-fatal observations** (for example empty `bind` blocks, duplicate declarations, or unreachable statements after a pure-function return) are returned in `LockstepCompileResult.diagnostics` and compilation still succeeds.
+* **Pure function return enforcement** is semantic and strict:
+  * `LCK413` (`error`) is emitted when a `pure` function body has no `return` statement.
+  * `LCK414` (`warning`) is emitted when a `pure` function body contains multiple `return` statements.
+  * `LCK415` (`warning`) is emitted for statements that appear after the first `return` in a `pure` function body.
 * **Fatal parse errors** still raise `LockstepCompileError`.
   * `LockstepCompileError.errors` contains parse diagnostics.
   * `LockstepCompileError.diagnostics` mirrors available pre-failure diagnostic context when parse fails.

--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -619,6 +619,55 @@ def build_semantic_validator(base_visitor_cls):
                 "params": params,
             }
 
+            statements = []
+            if hasattr(ctx, "statement") and callable(ctx.statement):
+                statement_nodes = ctx.statement() or []
+                if isinstance(statement_nodes, list):
+                    statements = statement_nodes
+                else:
+                    statements = [statement_nodes]
+
+            return_statements: list[tuple[int, Any]] = []
+            for index, statement in enumerate(statements):
+                if not hasattr(statement, "returnStmt") or not callable(statement.returnStmt):
+                    continue
+                return_stmt = statement.returnStmt()
+                if return_stmt is not None:
+                    return_statements.append((index, return_stmt))
+
+            if not return_statements:
+                self._add_diagnostic(
+                    severity="error",
+                    code="LCK413",
+                    message=f"Pure function '{name}' must include a return statement.",
+                    ctx=ctx,
+                    hint="Add a return statement that produces a value matching the declared return type.",
+                )
+            else:
+                if len(return_statements) > 1:
+                    self._add_diagnostic(
+                        severity="warning",
+                        code="LCK414",
+                        message=(
+                            f"Pure function '{name}' contains multiple return statements; "
+                            "only the first return is reachable in straight-line semantics."
+                        ),
+                        ctx=return_statements[1][1],
+                        hint="Keep a single terminal return to avoid dead code and ambiguous intent.",
+                    )
+
+                first_return_index = return_statements[0][0]
+                for unreachable_stmt in statements[first_return_index + 1 :]:
+                    self._add_diagnostic(
+                        severity="warning",
+                        code="LCK415",
+                        message=(
+                            f"Unreachable statement in pure function '{name}' after return statement."
+                        ),
+                        ctx=unreachable_stmt,
+                        hint="Remove or move statements before the return.",
+                    )
+
             self._push_scope()
             for param in params:
                 self._declare(

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1339,6 +1339,103 @@ def test_semantic_validator_records_pure_signature_from_declaration(debug_compil
     }
 
 
+def test_semantic_validator_reports_error_for_pure_function_without_return(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    non_return_stmt = _ctx(start_line=40, start_col=2, returnStmt=lambda: None)
+    pure_decl_ctx = _ctx(
+        start_line=39,
+        start_col=0,
+        ID=lambda: _token("blend"),
+        typeName=lambda: _token("float"),
+        pureParamList=lambda: None,
+        statement=lambda: [non_return_stmt],
+    )
+
+    validator.visitPureDecl(pure_decl_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK413",
+            message="Pure function 'blend' must include a return statement.",
+            line=39,
+            column=0,
+            hint="Add a return statement that produces a value matching the declared return type.",
+        )
+    ]
+
+
+def test_semantic_validator_accepts_pure_function_with_single_return(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    return_stmt = _ctx(start_line=42, start_col=4)
+    pure_decl_ctx = _ctx(
+        start_line=41,
+        start_col=0,
+        ID=lambda: _token("blend"),
+        typeName=lambda: _token("float"),
+        pureParamList=lambda: None,
+        statement=lambda: [_ctx(start_line=42, start_col=4, returnStmt=lambda: return_stmt)],
+    )
+
+    validator.visitPureDecl(pure_decl_ctx)
+
+    assert validator.diagnostics == []
+
+
+def test_semantic_validator_optional_multi_return_policy_warns_for_dead_code(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    first_return_stmt = _ctx(start_line=44, start_col=4)
+    second_return_stmt = _ctx(start_line=45, start_col=4)
+    unreachable_stmt = _ctx(start_line=46, start_col=4, returnStmt=lambda: None)
+    pure_decl_ctx = _ctx(
+        start_line=43,
+        start_col=0,
+        ID=lambda: _token("blend"),
+        typeName=lambda: _token("float"),
+        pureParamList=lambda: None,
+        statement=lambda: [
+            _ctx(start_line=44, start_col=4, returnStmt=lambda: first_return_stmt),
+            _ctx(start_line=45, start_col=4, returnStmt=lambda: second_return_stmt),
+            unreachable_stmt,
+        ],
+    )
+
+    validator.visitPureDecl(pure_decl_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="warning",
+            code="LCK414",
+            message=(
+                "Pure function 'blend' contains multiple return statements; "
+                "only the first return is reachable in straight-line semantics."
+            ),
+            line=45,
+            column=4,
+            hint="Keep a single terminal return to avoid dead code and ambiguous intent.",
+        ),
+        debug_compiler_module.LockstepDiagnostic(
+            severity="warning",
+            code="LCK415",
+            message="Unreachable statement in pure function 'blend' after return statement.",
+            line=45,
+            column=4,
+            hint="Remove or move statements before the return.",
+        ),
+        debug_compiler_module.LockstepDiagnostic(
+            severity="warning",
+            code="LCK415",
+            message="Unreachable statement in pure function 'blend' after return statement.",
+            line=46,
+            column=4,
+            hint="Remove or move statements before the return.",
+        ),
+    ]
+
+
 def test_semantic_validator_reports_undefined_pure_function_call(debug_compiler_module):
     validator = debug_compiler_module.LockstepSemanticValidator()
 


### PR DESCRIPTION
### Motivation

* Ensure `pure` functions follow deterministic, side-effect-free semantics by requiring a return statement and flagging unreachable/multiple returns as diagnostics.  This enforces clearer semantics and helps catch latent bugs in pure kernels.

### Description

* Updated `visitPureDecl` in `lockstep_compiler/visitors.py` to inspect the declared function `statement` nodes, collect `returnStmt` occurrences, and track their positions. 
* Emit `LCK413` (error) when a `pure` function body has no `return` statement, emit `LCK414` (warning) when multiple `return` statements are present, and emit `LCK415` (warning) for statements occurring after the first `return` (unreachable). 
* Added tests to `tests/test_debug_compiler.py` that verify: a pure function without a return produces `LCK413` (error); a pure function with a single return produces no diagnostics; and multi-return/unreachable statements produce `LCK414`/`LCK415` warnings. 
* Updated `README.md` diagnostics/behavior section to document the new pure-return rules and the identifiers `LCK413`, `LCK414`, and `LCK415`.

### Testing

* Ran targeted tests with `pytest -q -o addopts='' tests/test_debug_compiler.py -k "pure_function_without_return or pure_function_with_single_return or optional_multi_return_policy"` and observed `3 passed, 48 deselected`.
* Ran the full test file with `pytest -q -o addopts='' tests/test_debug_compiler.py` and observed `51 passed`.
* The changes produce error diagnostics for missing returns (which remain compilation-fatal) and warnings for multiple/unreachable returns (non-fatal).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a36eb1882c8328898026881468580c)