### PR TITLE
Validate bind assignment target against kernel out argument

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -451,6 +451,9 @@ def build_semantic_validator(base_visitor_cls):
                 )
                 return
 
+            out_param_index = next((index for index, param in enumerate(kernel) if param.modifier == "out"), None)
+            out_param = kernel[out_param_index] if out_param_index is not None else None
+
             target_symbol = self._lookup(target_name)
             if target_symbol is None:
                 self._add_diagnostic(
@@ -461,8 +464,7 @@ def build_semantic_validator(base_visitor_cls):
                     hint="Declare pipeline streams/accumulators/uniforms before binding.",
                 )
             else:
-                output_params = [param for param in kernel if param.modifier == "out"]
-                if not output_params:
+                if out_param is None:
                     self._add_diagnostic(
                         severity="error",
                         code="LCK309",
@@ -474,27 +476,39 @@ def build_semantic_validator(base_visitor_cls):
                         hint="Bind only kernels that declare an out parameter.",
                     )
                 else:
-                    expected_output = output_params[0]
-                    expected_output_kind = modifier_to_kind[expected_output.modifier]
+                    out_arg_name = arg_names[out_param_index]
+                    if out_arg_name != target_name:
+                        self._add_diagnostic(
+                            severity="error",
+                            code="LCK312",
+                            message=(
+                                f"Bind target '{target_name}' must match out argument "
+                                f"'{out_arg_name}' for parameter '{out_param.name}' in '{callee_name}'."
+                            ),
+                            ctx=ctx,
+                            hint="Use the same symbol for assignment target and out argument.",
+                        )
+
+                    expected_output_kind = modifier_to_kind[out_param.modifier]
                     if target_symbol.kind != expected_output_kind:
                         self._add_diagnostic(
                             severity="error",
                             code="LCK309",
                             message=(
                                 f"Bind target '{target_name}' for '{callee_name}' must be a "
-                                f"{expected_output_kind} for out parameter '{expected_output.name}', "
+                                f"{expected_output_kind} for out parameter '{out_param.name}', "
                                 f"got {target_symbol.kind}."
                             ),
                             ctx=ctx,
                             hint="Route kernel outputs to a stream-compatible bind target.",
                         )
-                    if target_symbol.declared_type != expected_output.declared_type:
+                    if target_symbol.declared_type != out_param.declared_type:
                         self._add_diagnostic(
                             severity="error",
                             code="LCK305",
                             message=(
                                 f"Type mismatch for bind target '{target_name}' in '{callee_name}': "
-                                f"expected {expected_output.declared_type}, got {target_symbol.declared_type}."
+                                f"expected {out_param.declared_type}, got {target_symbol.declared_type}."
                             ),
                             ctx=ctx,
                             hint="Align bind target type with the kernel out parameter type.",

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1208,8 +1208,84 @@ def test_semantic_validator_reports_bind_target_output_semantics(debug_compiler_
     )
     validator.visitBindStmt(mismatch_ctx)
 
+    assert [diag.code for diag in validator.diagnostics] == ["LCK312", "LCK309"]
+    assert "must match out argument" in validator.diagnostics[0].message
+    assert "must be a stream" in validator.diagnostics[1].message
+
+
+def test_semantic_validator_allows_bind_when_target_matches_out_argument(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator.shaders = {
+        "Apply": [
+            SemanticKernelParam(name="inp", declared_type="Vec3", modifier="in"),
+            SemanticKernelParam(name="outp", declared_type="Vec3", modifier="out"),
+        ]
+    }
+    validator._push_scope()
+    validator._declare("inp_stream", "Vec3", _ctx(), duplicate_code="LCK306", kind="stream")
+    validator._declare("out_stream", "Vec3", _ctx(), duplicate_code="LCK306", kind="stream")
+
+    bind_ctx = _ctx(
+        start_line=28,
+        start_col=2,
+        ID=lambda: [_token("out_stream"), _token("Apply"), _token("inp_stream"), _token("out_stream")],
+        argList=lambda: object(),
+        typeName=lambda: _token("float"),
+    )
+    validator.visitBindStmt(bind_ctx)
+
+    assert validator.diagnostics == []
+
+
+def test_semantic_validator_reports_mismatched_target_and_out_argument(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator.shaders = {
+        "Apply": [
+            SemanticKernelParam(name="inp", declared_type="Vec3", modifier="in"),
+            SemanticKernelParam(name="outp", declared_type="Vec3", modifier="out"),
+        ]
+    }
+    validator._push_scope()
+    validator._declare("inp_stream", "Vec3", _ctx(), duplicate_code="LCK306", kind="stream")
+    validator._declare("out_stream", "Vec3", _ctx(), duplicate_code="LCK306", kind="stream")
+    validator._declare("other_stream", "Vec3", _ctx(), duplicate_code="LCK306", kind="stream")
+
+    bind_ctx = _ctx(
+        start_line=29,
+        start_col=2,
+        ID=lambda: [_token("out_stream"), _token("Apply"), _token("inp_stream"), _token("other_stream")],
+        argList=lambda: object(),
+        typeName=lambda: _token("float"),
+    )
+    validator.visitBindStmt(bind_ctx)
+
+    assert [diag.code for diag in validator.diagnostics] == ["LCK312"]
+    assert "must match out argument 'other_stream'" in validator.diagnostics[0].message
+
+
+def test_semantic_validator_reports_bind_missing_out_parameter(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator.shaders = {
+        "Apply": [
+            SemanticKernelParam(name="inp", declared_type="Vec3", modifier="in"),
+            SemanticKernelParam(name="energy", declared_type="float", modifier="accum"),
+        ]
+    }
+    validator._push_scope()
+    validator._declare("s0", "Vec3", _ctx(), duplicate_code="LCK306", kind="stream")
+    validator._declare("acc", "float", _ctx(), duplicate_code="LCK306", kind="accumulator")
+
+    bind_ctx = _ctx(
+        start_line=30,
+        start_col=2,
+        ID=lambda: [_token("s0"), _token("Apply"), _token("s0"), _token("acc")],
+        argList=lambda: object(),
+        typeName=lambda: _token("float"),
+    )
+    validator.visitBindStmt(bind_ctx)
+
     assert [diag.code for diag in validator.diagnostics] == ["LCK309"]
-    assert "must be a stream" in validator.diagnostics[0].message
+    assert "kernel has no out parameter" in validator.diagnostics[0].message
 
 
 def test_semantic_validator_reports_duplicate_pipeline_symbols(debug_compiler_module):


### PR DESCRIPTION
### Motivation

- Make bind semantics explicit by locating the kernel `out` parameter by position and ensuring the pipeline assignment target corresponds to the argument passed for that `out` slot.

### Description

- In `lockstep_compiler/visitors.py` updated `_type_check_bind_call` to find the kernel `out` parameter index (`out_param_index`) and reuse that canonical slot for output checks instead of scanning a list later. 
- Added a new diagnostic `LCK312` emitted when the bind assignment target (`target_name`) does not match the symbol passed as the kernel `out` argument, with a hint to use the same symbol for assignment and the out argument. 
- Preserved existing behavior for kernels with no `out` parameter (`LCK309`) and kept the target kind/type checks wired through the resolved `out` parameter metadata. 
- Extended `tests/test_debug_compiler.py` with three new tests and adjusted one existing expectation to cover: matching target/out argument (no diagnostics), mismatched target/out argument (`LCK312`), and missing out-parameter behavior (`LCK309`).

### Testing

- Ran unit tests for the debug compiler file with `pytest -q -o addopts='' tests/test_debug_compiler.py` and received `51 passed`.
- Running `pytest -q tests/test_debug_compiler.py` without overriding `addopts` fails in this environment due to repository `addopts` referencing coverage plugins not available here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a36eb2d8f083288a1b4e0fc5ef177d)