### PR TITLE
Add installable `lockstepc` entrypoint and CLI wiring coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ The compiler generates a C-compatible header for the Host application (C/C++, Ru
 
 ## 6. Compiler Frontend Usage
 
+Install in editable mode to enable the packaged CLI entrypoint:
+
+```bash
+pip install -e .
+lockstepc path/to/program.lock
+# or read source from stdin
+cat path/to/program.lock | lockstepc --dump
+```
+
 `debug_compiler.py` exposes `compile_lockstep(source_code, verbose=True)` and returns a `LockstepCompileResult` containing:
 
 * `parse_tree`: ANTLR parse tree for the source.

--- a/debug_compiler.py
+++ b/debug_compiler.py
@@ -2,16 +2,10 @@ from antlr4 import CommonTokenStream
 import sys
 from pathlib import Path
 
-from lockstep_compiler import (
-    LockstepCompileError,
-    LockstepDiagnostic,
-    ParseErrorCollector,
-    build_arg_parser,
-    normalize_diagnostics,
-    run_cli,
-)
+from lockstep_compiler.cli import run_cli
+from lockstep_compiler.errors import LockstepCompileError, ParseErrorCollector
+from lockstep_compiler.models import LockstepCompileResult, LockstepDiagnostic, normalize_diagnostics
 from lockstep_compiler.compiler import _compile_lockstep_with_dependencies as _compile_lockstep
-from lockstep_compiler.models import LockstepCompileResult
 from lockstep_compiler.visitors import (
     build_debug_visitor,
     build_semantic_validator,

--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -118,3 +118,9 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
         print(json.dumps(entities, indent=2, sort_keys=True, default=str), file=stdout)
 
     return 0
+
+
+def main(argv=None):
+    from .compiler import compile_lockstep
+
+    return run_cli(argv, compiler=compile_lockstep)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ test = [
     "pytest-cov",
 ]
 
+[project.scripts]
+lockstepc = "lockstep_compiler.cli:main"
+
 [tool.pytest.ini_options]
 addopts = "-q -ra --cov=. --cov-branch --cov-report=term-missing --cov-report=xml:coverage.xml"
 testpaths = ["tests"]

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -82,3 +82,19 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
         "uniforms": [],
         "bind_routes": [],
     }
+
+
+def test_cli_main_wires_default_compiler(monkeypatch):
+    import lockstep_compiler.cli as cli_module
+
+    sentinel_compiler = object()
+
+    def fake_run_cli(argv, *, compiler):
+        assert argv == ["--dump"]
+        assert compiler is sentinel_compiler
+        return 7
+
+    monkeypatch.setattr(cli_module, "run_cli", fake_run_cli)
+    monkeypatch.setattr(compiler_module, "compile_lockstep", sentinel_compiler)
+
+    assert cli_module.main(["--dump"]) == 7


### PR DESCRIPTION
### Motivation

- Provide an installable CLI so users can invoke the compiler as a packaged script (e.g. `lockstepc`).
- Expose a small `main()` wrapper that wires the package-default `compile_lockstep` into the existing `run_cli()` routine.
- Avoid duplicate CLI wiring from package-level re-exports and make `debug_compiler.py` import the CLI runner and compiler pieces explicitly.
- Add a focused test to ensure the `main()` entry correctly passes the default compiler into `run_cli()` and document usage in the README.

### Description

- Added a `[project.scripts]` entry to `pyproject.toml`: `lockstepc = "lockstep_compiler.cli:main"` to register the CLI entrypoint.
- Added `main(argv=None)` to `lockstep_compiler/cli.py` that calls `run_cli(argv, compiler=compile_lockstep)` to wire the packaged entry to the default compiler callable.
- Adjusted `debug_compiler.py` imports to use `from lockstep_compiler.cli import run_cli` and explicit imports from `.errors` and `.models` to avoid duplicating CLI wiring via package re-exports.
- Added `test_cli_main_wires_default_compiler` to `tests/test_compiler_api.py` to verify `cli.main()` passes the package `compile_lockstep` into `run_cli()`.
- Updated `README.md` with install-and-run examples showing `pip install -e .` and usage examples for both file and stdin invocation.

### Testing

- Running `pytest tests/test_compiler_api.py tests/test_debug_compiler.py` with the repository `addopts` caused failure in this environment due to missing `pytest-cov` plugin support in the runner.
- Running `pytest -o addopts='' tests/test_compiler_api.py tests/test_debug_compiler.py` executed the test suite successfully and reported `51 passed`.
- The new `test_cli_main_wires_default_compiler` test passed as part of the validated test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a36eb6d71483288cb998892ae7302d)