### PR TITLE
Harden ANTLR parser generation with checksum verification and offline/jar-path support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 .PHONY: generate-parser check-generated-parser
 
+ANTLR_JAR_PATH ?= tools/antlr-4.13.2-complete.jar
+
 generate-parser:
-	python scripts/generate_parser.py
+	python scripts/generate_parser.py --jar-path $(ANTLR_JAR_PATH)
 
 check-generated-parser:
-	python scripts/generate_parser.py
+	python scripts/generate_parser.py --offline --jar-path $(ANTLR_JAR_PATH)
 	git diff --exit-code -- generated/parser/LockstepLexer.py generated/parser/LockstepListener.py generated/parser/LockstepParser.py generated/parser/LockstepVisitor.py

--- a/README.md
+++ b/README.md
@@ -132,4 +132,22 @@ Run the project-native generator target:
 make generate-parser
 ```
 
-Generated Python parser files are emitted to `generated/parser/` and committed to source control. CI enforces freshness via `make check-generated-parser`, which regenerates and fails when tracked generated files are stale.
+The parser generator script pins ANTLR `4.13.2` to a known SHA-256 and verifies integrity before use. By default it uses `tools/antlr-4.13.2-complete.jar`, downloading the jar only when missing.
+
+### Secure workflow
+
+For controlled or air-gapped environments, pre-provision the jar and run in offline mode:
+
+```bash
+python scripts/generate_parser.py --offline --jar-path /path/to/antlr-4.13.2-complete.jar
+```
+
+If the jar is missing in offline mode, or the checksum does not match the pinned value, generation fails with a clear error.
+
+CI should use:
+
+```bash
+make check-generated-parser
+```
+
+This target enforces offline generation with an explicit jar path and fails when tracked generated files are stale.

--- a/scripts/generate_parser.py
+++ b/scripts/generate_parser.py
@@ -2,31 +2,62 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import subprocess
 import urllib.request
 from pathlib import Path
 
 ANTLR_VERSION = "4.13.2"
-ANTLR_JAR = Path("tools") / f"antlr-{ANTLR_VERSION}-complete.jar"
+ANTLR_SHA256 = "eae2dfa119a64327444672aff63e9ec35a20180dc5b8090b7a6ab85125df4d76"
+DEFAULT_ANTLR_JAR = Path("tools") / f"antlr-{ANTLR_VERSION}-complete.jar"
 GRAMMAR_FILE = Path("Lockstep.g4")
 OUTPUT_DIR = Path("generated") / "parser"
 
 
-def ensure_antlr_jar() -> None:
-    if ANTLR_JAR.exists():
+class AntlrJarError(RuntimeError):
+    """Raised when the ANTLR JAR is missing or fails integrity checks."""
+
+
+def verify_antlr_jar(jar_path: Path) -> None:
+    sha256 = hashlib.sha256()
+    with jar_path.open("rb") as jar_file:
+        while chunk := jar_file.read(1024 * 1024):
+            sha256.update(chunk)
+
+    actual = sha256.hexdigest()
+    if actual != ANTLR_SHA256:
+        raise AntlrJarError(
+            "ANTLR JAR checksum mismatch for "
+            f"{jar_path}: expected {ANTLR_SHA256}, got {actual}. "
+            "Re-download the jar from https://www.antlr.org/download/ "
+            "or provide a trusted jar via --jar-path."
+        )
+
+
+def ensure_antlr_jar(jar_path: Path, offline: bool) -> None:
+    if jar_path.exists():
+        verify_antlr_jar(jar_path)
         return
-    ANTLR_JAR.parent.mkdir(parents=True, exist_ok=True)
+
+    if offline:
+        raise AntlrJarError(
+            f"ANTLR JAR not found at {jar_path} and --offline was set. "
+            "Provide the jar with --jar-path or disable --offline to allow download."
+        )
+
+    jar_path.parent.mkdir(parents=True, exist_ok=True)
     url = f"https://www.antlr.org/download/antlr-{ANTLR_VERSION}-complete.jar"
-    print(f"Downloading ANTLR {ANTLR_VERSION} from {url}...")
-    urllib.request.urlretrieve(url, ANTLR_JAR)
+    print(f"Downloading ANTLR {ANTLR_VERSION} from {url} to {jar_path}...")
+    urllib.request.urlretrieve(url, jar_path)
+    verify_antlr_jar(jar_path)
 
 
-def generate_parser() -> None:
+def generate_parser(jar_path: Path) -> None:
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     cmd = [
         "java",
         "-jar",
-        str(ANTLR_JAR),
+        str(jar_path),
         "-Dlanguage=Python3",
         "-visitor",
         "-o",
@@ -38,9 +69,25 @@ def generate_parser() -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Regenerate ANTLR parser files.")
-    parser.parse_args()
-    ensure_antlr_jar()
-    generate_parser()
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Do not download ANTLR jar; fail if it is missing.",
+    )
+    parser.add_argument(
+        "--jar-path",
+        type=Path,
+        default=DEFAULT_ANTLR_JAR,
+        help=f"Path to ANTLR {ANTLR_VERSION} complete jar (default: %(default)s).",
+    )
+    args = parser.parse_args()
+
+    try:
+        ensure_antlr_jar(args.jar_path, args.offline)
+        generate_parser(args.jar_path)
+    except AntlrJarError as exc:
+        parser.error(str(exc))
+
     return 0
 
 


### PR DESCRIPTION
### Motivation

- Ensure the ANTLR runtime used to generate the Python parser is integrity-checked and usable in controlled or air-gapped CI environments.
- Make parser regeneration deterministic for CI by preventing implicit network downloads and by allowing an explicit jar path.

### Description

- Added a pinned SHA-256 for ANTLR `4.13.2` and runtime verification in `scripts/generate_parser.py`, raising a clear error on mismatch.
- Implemented `--offline` to forbid downloads and `--jar-path` to override the jar location, and verify the jar after download when allowed.
- Updated `Makefile` to introduce `ANTLR_JAR_PATH` and to call the generator with `--jar-path` for `generate-parser` and with `--offline --jar-path` for `check-generated-parser`.
- Documented the secure generation workflow and CI guidance in `README.md` explaining checksum pinning and offline usage.

### Testing

- Ran `python scripts/generate_parser.py --help` and it displayed the new flags successfully.
- Executed `make generate-parser` which downloaded (when needed), verified the jar, and invoked generation successfully.
- Executed `make check-generated-parser` which ran in offline mode and the CI freshness check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a36eb8e4f08328b8d5ad27048f33e2)