### PR TITLE
Verify ANTLR jar integrity before parser generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
-.PHONY: generate-parser check-generated-parser
+.PHONY: verify-parser-toolchain generate-parser check-generated-parser
+
+verify-parser-toolchain:
+	python scripts/generate_parser.py --verify-toolchain
 
 generate-parser:
+	$(MAKE) verify-parser-toolchain
 	python scripts/generate_parser.py
 
 check-generated-parser:
+	$(MAKE) verify-parser-toolchain
 	python scripts/generate_parser.py
 	git diff --exit-code -- generated/parser/LockstepLexer.py generated/parser/LockstepListener.py generated/parser/LockstepParser.py generated/parser/LockstepVisitor.py

--- a/scripts/generate_parser.py
+++ b/scripts/generate_parser.py
@@ -2,23 +2,52 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import subprocess
 import urllib.request
 from pathlib import Path
 
 ANTLR_VERSION = "4.13.2"
 ANTLR_JAR = Path("tools") / f"antlr-{ANTLR_VERSION}-complete.jar"
+ANTLR_JAR_SHA256 = "eae2dfa119a64327444672aff63e9ec35a20180dc5b8090b7a6ab85125df4d76"
 GRAMMAR_FILE = Path("Lockstep.g4")
 OUTPUT_DIR = Path("generated") / "parser"
 
 
+def antlr_mismatch_message(actual_sha256: str) -> str:
+    return (
+        f"Integrity check failed for {ANTLR_JAR}.\n"
+        f"Expected SHA-256: {ANTLR_JAR_SHA256}\n"
+        f"Actual SHA-256:   {actual_sha256}\n"
+        "Delete the file and rerun this script to re-download the ANTLR jar.\n"
+        f"  rm -f {ANTLR_JAR}"
+    )
+
+
+def compute_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_antlr_jar(path: Path) -> None:
+    actual_sha256 = compute_sha256(path)
+    if actual_sha256 != ANTLR_JAR_SHA256:
+        raise RuntimeError(antlr_mismatch_message(actual_sha256))
+
+
 def ensure_antlr_jar() -> None:
     if ANTLR_JAR.exists():
+        verify_antlr_jar(ANTLR_JAR)
         return
+
     ANTLR_JAR.parent.mkdir(parents=True, exist_ok=True)
     url = f"https://www.antlr.org/download/antlr-{ANTLR_VERSION}-complete.jar"
     print(f"Downloading ANTLR {ANTLR_VERSION} from {url}...")
     urllib.request.urlretrieve(url, ANTLR_JAR)
+    verify_antlr_jar(ANTLR_JAR)
 
 
 def generate_parser() -> None:
@@ -38,8 +67,18 @@ def generate_parser() -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Regenerate ANTLR parser files.")
-    parser.parse_args()
+    parser.add_argument(
+        "--verify-toolchain",
+        action="store_true",
+        help="Only verify ANTLR jar integrity and exit.",
+    )
+    args = parser.parse_args()
+
     ensure_antlr_jar()
+    if args.verify_toolchain:
+        print(f"ANTLR toolchain verified: {ANTLR_JAR}")
+        return 0
+
     generate_parser()
     return 0
 


### PR DESCRIPTION
### Motivation

- Ensure the ANTLR tool used to generate the parser is the expected binary and prevent silent corruption or supply-chain issues by verifying the downloaded JAR's SHA-256.

### Description

- Add `ANTLR_JAR_SHA256` constant in `scripts/generate_parser.py` to pin the expected SHA-256 and implement `compute_sha256` and `verify_antlr_jar` helpers to compute and check the hash.
- Verify the JAR both when an existing `tools/antlr-4.13.2-complete.jar` is reused and immediately after a fresh download, failing with a clear remediation message on mismatch that instructs to run `rm -f tools/antlr-4.13.2-complete.jar`.
- Add `--verify-toolchain` CLI flag to `scripts/generate_parser.py` to run integrity checks without generating sources and print a verification success message when OK.
- Add a `verify-parser-toolchain` Makefile target and invoke it from `generate-parser` and `check-generated-parser` to validate the toolchain before generation or checks.

### Testing

- Ran `python scripts/generate_parser.py --verify-toolchain` which downloaded the JAR and printed a successful verification message (succeeded).
- Ran `make verify-parser-toolchain` which invoked the script and returned success (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a427a9b0832880f9ed30b0bc56aa)