### PR TITLE
Fix coverage omit patterns for generated parser files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,10 @@ branch = true
 source = ["."]
 omit = [
     "tests/*",
-    "LockstepLexer.py",
-    "LockstepListener.py",
-    "LockstepParser.py",
-    "LockstepVisitor.py",
+    "generated/parser/LockstepLexer.py",
+    "generated/parser/LockstepListener.py",
+    "generated/parser/LockstepParser.py",
+    "generated/parser/LockstepVisitor.py",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
### Motivation
- Update coverage omit patterns to precisely exclude generated parser artifacts under `generated/parser/` so filename-only patterns don't inadvertently omit first-party modules in `lockstep_compiler/`.

### Description
- Replace unscoped omit entries in `pyproject.toml` with path-aware entries targeting `generated/parser/LockstepLexer.py`, `generated/parser/LockstepListener.py`, `generated/parser/LockstepParser.py`, and `generated/parser/LockstepVisitor.py`.

### Testing
- Running `pytest -q` failed due to the configured `--cov` addopts requiring the `pytest-cov` plugin which is unavailable in the environment, and running `pytest -q -o addopts=''` succeeded with `61 passed, 6 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a42a7bb0832892707b9bd5df47e3)