### PR TITLE
Default run_cli compiler to compile_lockstep when none is injected

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -58,11 +58,9 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
         source = stdin.read()
 
     if compiler is None:
-        print(
-            "Compiler configuration error: no compiler callable was provided.",
-            file=stderr,
-        )
-        return 1
+        from .compiler import compile_lockstep
+
+        compiler = compile_lockstep
 
     if not callable(compiler):
         print(

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1076,19 +1076,41 @@ def test_run_cli_returns_non_zero_for_invalid_utf8(debug_compiler_module, tmp_pa
     assert f"Unable to read '{bad_source}': invalid UTF-8" in stderr.getvalue()
 
 
-def test_run_cli_returns_non_zero_when_compiler_missing(debug_compiler_module):
-    stderr = io.StringIO()
+def test_run_cli_uses_default_compiler_when_compiler_missing(
+    debug_compiler_module, monkeypatch
+):
+    captured = {}
+
+    def fake_compiler(source):
+        captured["source"] = source
+
+    import lockstep_compiler.compiler as compiler_module
+
+    monkeypatch.setattr(compiler_module, "compile_lockstep", fake_compiler)
 
     exit_code = debug_compiler_module.run_cli(
         [],
         stdin=io.StringIO("pipeline MissingCompiler { }"),
-        stderr=stderr,
         compiler=None,
+    )
+
+    assert exit_code == 0
+    assert captured["source"] == "pipeline MissingCompiler { }"
+
+
+def test_run_cli_returns_non_zero_when_compiler_not_callable(debug_compiler_module):
+    stderr = io.StringIO()
+
+    exit_code = debug_compiler_module.run_cli(
+        [],
+        stdin=io.StringIO("pipeline InvalidCompiler { }"),
+        stderr=stderr,
+        compiler=object(),
     )
 
     assert exit_code == 1
     assert stderr.getvalue().splitlines() == [
-        "Compiler configuration error: no compiler callable was provided.",
+        "Compiler configuration error: compiler must be callable.",
     ]
 
 


### PR DESCRIPTION
### Motivation

- Make the CLI more user-friendly by using the package's default compiler when callers omit the `compiler` argument instead of failing with a configuration error. 

### Description

- Change `run_cli` in `lockstep_compiler/cli.py` so that when `compiler is None` it lazily imports `compile_lockstep` with `from .compiler import compile_lockstep` and assigns it to `compiler`, preserving the `compiler` parameter override for tests and callers. 
- Preserve validation for invalid injected values by keeping the `if not callable(compiler)` guard and returning the existing error when a non-callable is provided. 
- Update tests in `tests/test_debug_compiler.py` to reflect the new default behavior by replacing the old missing-compiler assertion with `test_run_cli_uses_default_compiler_when_compiler_missing` (which monkeypatches `compile_lockstep`) and adding `test_run_cli_returns_non_zero_when_compiler_not_callable` to assert non-callable handling.

### Testing

- Ran targeted tests with `pytest -q -o addopts='' tests/test_debug_compiler.py::test_run_cli_uses_default_compiler_when_compiler_missing tests/test_debug_compiler.py::test_run_cli_returns_non_zero_when_compiler_not_callable tests/test_compiler_api.py::test_cli_main_wires_default_compiler` and they passed.
- Ran the entire debug-compiler test module with `pytest -q -o addopts='' tests/test_debug_compiler.py` and observed all tests in that module passed (`59 passed`).
- The test run used `-o addopts=''` to avoid repository `addopts` coverage flags that are not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a42b31808328817bc678b902fe9b)