### PR TITLE
Disable verbose compiler output in CLI by default

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import inspect
 import json
 import sys
 import traceback
@@ -69,8 +70,24 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
         )
         return 1
 
+    supports_verbose = False
     try:
-        result = compiler(source)
+        signature = inspect.signature(compiler)
+    except (TypeError, ValueError):
+        signature = None
+
+    if signature is not None:
+        supports_verbose = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            or parameter.name == "verbose"
+            for parameter in signature.parameters.values()
+        )
+
+    try:
+        if supports_verbose:
+            result = compiler(source, verbose=False)
+        else:
+            result = compiler(source)
     except LockstepCompileError as err:
         count = len(err.errors)
         suffix = "" if count == 1 else "s"

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -646,8 +646,9 @@ def test_run_cli_uses_default_compiler_when_compiler_missing(
 ):
     captured = {}
 
-    def fake_compiler(source):
+    def fake_compiler(source, *, verbose=True):
         captured["source"] = source
+        captured["verbose"] = verbose
 
     import lockstep_compiler.compiler as compiler_module
 
@@ -660,7 +661,52 @@ def test_run_cli_uses_default_compiler_when_compiler_missing(
     )
 
     assert exit_code == 0
-    assert captured["source"] == "pipeline MissingCompiler { }"
+    assert captured == {
+        "source": "pipeline MissingCompiler { }",
+        "verbose": False,
+    }
+
+
+def test_run_cli_preserves_injected_compiler_without_verbose_parameter(
+    debug_compiler_module,
+):
+    captured = {}
+
+    def fake_compiler(source):
+        captured["source"] = source
+
+    exit_code = debug_compiler_module.run_cli(
+        [],
+        stdin=io.StringIO("pipeline CustomCompiler { }"),
+        compiler=fake_compiler,
+    )
+
+    assert exit_code == 0
+    assert captured == {"source": "pipeline CustomCompiler { }"}
+
+
+def test_run_cli_default_execution_suppresses_verbose_visitor_logs(
+    debug_compiler_module, monkeypatch
+):
+    stderr = io.StringIO()
+
+    def fake_compiler(_source, *, verbose=True):
+        if verbose:
+            print("Visiting node: pipeline", file=stderr)
+
+    import lockstep_compiler.compiler as compiler_module
+
+    monkeypatch.setattr(compiler_module, "compile_lockstep", fake_compiler)
+
+    exit_code = debug_compiler_module.run_cli(
+        [],
+        stdin=io.StringIO("pipeline QuietByDefault { }"),
+        stderr=stderr,
+        compiler=None,
+    )
+
+    assert exit_code == 0
+    assert stderr.getvalue() == ""
 
 
 def test_run_cli_returns_non_zero_when_compiler_not_callable(debug_compiler_module):


### PR DESCRIPTION
### Motivation

- The CLI previously invoked the compiler as `compiler(source)` which allowed debug/visitor logs to be emitted by default; the change aims to make CLI runs non-verbose unless explicitly requested.
- Tests inject compiler callables in various shapes (some accept a `verbose` keyword, some do not), so the CLI must remain compatible with both styles.

### Description

- Updated `run_cli` in `lockstep_compiler/cli.py` to introspect the configured compiler callable using `inspect.signature` and detect whether it supports a `verbose` parameter or `**kwargs`, and when supported invoke it as `compiler(source, verbose=False)` instead of `compiler(source)`.
- Preserved behavior for injected compilers that only accept a single positional `source` by falling back to `compiler(source)` when `verbose` is not supported.
- Added/updated tests in `tests/test_debug_compiler.py` to assert that the default CLI path passes `verbose=False` to the package compiler, that injected compilers without a `verbose` parameter still work, and that normal CLI execution does not print debug/visitor logs by default.

### Testing

- Ran a focused pytest invocation with repository addopts disabled: `pytest -q -o addopts='' tests/test_debug_compiler.py -k 'run_cli_uses_default_compiler_when_compiler_missing or preserves_injected_compiler_without_verbose_parameter or default_execution_suppresses_verbose_visitor_logs'` which passed (`3 passed`).
- Ran the full debug compiler test module with repo addopts disabled: `pytest -q -o addopts='' tests/test_debug_compiler.py` which passed (`57 passed`).
- An initial `pytest` run failed due to repository `addopts` injecting unsupported coverage flags in this environment, so the subsequent runs used `-o addopts=''` to disable those flags and complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5980eb92c8328a6f97cfdb733cca4)