### PR TITLE
Fix bind diagnostic code mapping for semantic validator

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -460,7 +460,7 @@ def build_semantic_validator(base_visitor_cls):
             if kernel is None:
                 self._add_diagnostic(
                     severity="error",
-                    code=SEMANTIC_DIAGNOSTIC_CODES["bind_argument_count_mismatch"],
+                    code=SEMANTIC_DIAGNOSTIC_CODES["bind_unknown_target"],
                     message=f"Undefined shader/filter '{callee_name}' in bind statement.",
                     ctx=ctx,
                     hint="Declare the shader/filter before using it in bind.",
@@ -472,7 +472,7 @@ def build_semantic_validator(base_visitor_cls):
             if expected_arity != actual_arity:
                 self._add_diagnostic(
                     severity="error",
-                    code=SEMANTIC_DIAGNOSTIC_CODES["bind_unknown_target"],
+                    code=SEMANTIC_DIAGNOSTIC_CODES["bind_argument_count_mismatch"],
                     message=(
                         f"Invocation of '{callee_name}' expects {expected_arity} argument(s), "
                         f"but got {actual_arity}."

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -742,12 +742,55 @@ def test_semantic_validator_reports_bind_arity_and_type_errors(debug_compiler_mo
     )
     validator.visitBindStmt(type_ctx)
 
-    assert validator.diagnostics[0].code == "LCK304"
+    assert validator.diagnostics[0].code == "LCK303"
     assert "expects 2 argument(s), but got 1" in validator.diagnostics[0].message
     assert validator.diagnostics[1].code == "LCK309"
     assert "kernel has no out parameter" in validator.diagnostics[1].message
     assert validator.diagnostics[2].code == "LCK305"
     assert "expected float, got int" in validator.diagnostics[2].message
+
+
+def test_semantic_validator_reports_bind_unknown_target_code(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator._push_scope()
+    validator._declare("s0", "Vec3", _ctx(), duplicate_code="LCK306", kind="stream")
+
+    bind_ctx = _ctx(
+        start_line=22,
+        start_col=2,
+        ID=lambda: [_token("s0"), _token("MissingKernel"), _token("s0")],
+        argList=lambda: object(),
+        typeName=lambda: _token("float"),
+    )
+
+    validator.visitBindStmt(bind_ctx)
+
+    assert [diag.code for diag in validator.diagnostics] == ["LCK304"]
+
+
+def test_semantic_validator_bind_failure_modes_keep_dedicated_codes(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator.shaders = {
+        "Apply": [
+            SemanticKernelParam(name="inp", declared_type="Vec3", modifier="in"),
+            SemanticKernelParam(name="energy", declared_type="float", modifier="accum"),
+        ]
+    }
+    validator._push_scope()
+    validator._declare("s0", "Vec3", _ctx(), duplicate_code="LCK306", kind="stream")
+    validator._declare("dt", "int", _ctx(), duplicate_code="LCK306", kind="uniform")
+
+    bind_ctx = _ctx(
+        start_line=23,
+        start_col=2,
+        ID=lambda: [_token("s0"), _token("Apply"), _token("s0"), _token("dt")],
+        argList=lambda: object(),
+        typeName=lambda: _token("float"),
+    )
+
+    validator.visitBindStmt(bind_ctx)
+
+    assert [diag.code for diag in validator.diagnostics] == ["LCK309", "LCK308", "LCK305"]
 
 
 def test_semantic_validator_reports_bind_modifier_kind_mismatches(debug_compiler_module):


### PR DESCRIPTION
### Motivation
- Correct mismatches between failure cases in bind validation and the canonical keys in `SEMANTIC_DIAGNOSTIC_CODES` so diagnostics report the intended code IDs.
- Ensure undefined callee and wrong argument count emit their dedicated codes instead of being swapped, while preserving existing modifier/type mismatch codes.

### Description
- In `lockstep_compiler/visitors.py` updated `_type_check_bind_call` so an undefined shader/filter callee emits `SEMANTIC_DIAGNOSTIC_CODES["bind_unknown_target"]` and an arity mismatch emits `SEMANTIC_DIAGNOSTIC_CODES["bind_argument_count_mismatch"]`.
- Updated the existing bind arity/type unit to expect `LCK303` for arity mismatch by changing the assertion in `tests/test_debug_compiler.py`.
- Added two focused unit tests in `tests/test_debug_compiler.py`: `test_semantic_validator_reports_bind_unknown_target_code` to assert undefined callee emits `LCK304`, and `test_semantic_validator_bind_failure_modes_keep_dedicated_codes` to assert that modifier/type mismatch diagnostics continue to use `LCK308`/`LCK305` and that bind-output/arity errors use their dedicated codes.

### Testing
- Ran `pytest -q -o addopts='' tests/test_debug_compiler.py -k "bind_arity_and_type_errors or bind_unknown_target_code or bind_failure_modes_keep_dedicated_codes"` which resulted in `3 passed, 54 deselected`.
- Ran `pytest -q -o addopts='' tests/test_debug_compiler.py -k "semantic_validator_reports_bind"` which resulted in `5 passed, 52 deselected`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5980fb5b88328a72e484c62ec2106)