### PR TITLE
Validate uniform initializer types in pipeline declarations

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -36,6 +36,7 @@ SEMANTIC_DIAGNOSTIC_CODES = {
     "var_initializer_type_mismatch": "LCK416",
     "assignment_type_mismatch": "LCK417",
     "pure_return_type_mismatch": "LCK418",
+    "uniform_initializer_type_mismatch": "LCK419",
 }
 
 
@@ -913,8 +914,24 @@ def build_semantic_validator(base_visitor_cls):
             return self.visitChildren(ctx)
 
         def visitUniformDecl(self, ctx):
-            self._validate_declared_type(ctx.typeName().getText(), ctx.typeName(), "LCK310")
-            self._declare(ctx.ID().getText(), ctx.typeName().getText(), ctx, duplicate_code="LCK306", kind="uniform")
+            declared_type = ctx.typeName().getText()
+            self._validate_declared_type(declared_type, ctx.typeName(), "LCK310")
+            self._declare(ctx.ID().getText(), declared_type, ctx, duplicate_code="LCK306", kind="uniform")
+
+            has_initializer = hasattr(ctx, "expr") and callable(ctx.expr) and ctx.expr() is not None
+            if has_initializer:
+                initializer_type = self._resolve_expr_type(ctx.expr())
+                if initializer_type is not None and initializer_type != declared_type:
+                    self._add_diagnostic(
+                        severity="error",
+                        code=SEMANTIC_DIAGNOSTIC_CODES["uniform_initializer_type_mismatch"],
+                        message=(
+                            f"Type mismatch in uniform initializer for '{ctx.ID().getText()}': "
+                            f"expected {declared_type}, got {initializer_type}."
+                        ),
+                        ctx=ctx,
+                        hint="Use an initializer expression with the same type as the declared uniform.",
+                    )
             return self.visitChildren(ctx)
 
         def visitBindStmt(self, ctx):

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1546,6 +1546,32 @@ def test_semantic_validator_reports_var_initializer_type_mismatch(debug_compiler
     ]
 
 
+def test_semantic_validator_reports_pipeline_uniform_initializer_type_mismatch(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator._push_scope()
+
+    uniform_decl_ctx = _ctx(
+        start_line=73,
+        start_col=2,
+        ID=lambda: _token("u_count"),
+        typeName=lambda: _token("int"),
+        expr=lambda: _ctx(declared_type="float"),
+    )
+
+    validator.visitUniformDecl(uniform_decl_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK419",
+            message="Type mismatch in uniform initializer for 'u_count': expected int, got float.",
+            line=73,
+            column=2,
+            hint="Use an initializer expression with the same type as the declared uniform.",
+        )
+    ]
+
+
 def test_semantic_validator_reports_pure_return_type_mismatch(debug_compiler_module):
     validator = debug_compiler_module.LockstepSemanticValidator()
 
@@ -1596,6 +1622,13 @@ def test_semantic_validator_accepts_matching_assignment_initializer_and_return(d
         expr=lambda: _ctx(declared_type="int"),
     )
     validator.visitVarDecl(var_decl_ctx)
+
+    uniform_decl_ctx = _ctx(
+        ID=lambda: _token("u_count"),
+        typeName=lambda: _token("int"),
+        expr=lambda: _ctx(declared_type="int"),
+    )
+    validator.visitUniformDecl(uniform_decl_ctx)
 
     return_ctx = _ctx(expr=lambda: _ctx(declared_type="int"))
     pure_ctx = _ctx(


### PR DESCRIPTION
### Motivation
- Ensure uniform declarations with initializer expressions have their initializer types validated against the declared uniform type.
- Provide a clear, dedicated semantic diagnostic when a uniform initializer type does not match the declared type.

### Description
- Add a new semantic diagnostic mapping `"uniform_initializer_type_mismatch" -> "LCK419"` in `lockstep_compiler/visitors.py`.
- Update the semantic `visitUniformDecl` to resolve an initializer expression type (when present) and compare it to the declared uniform type, emitting an error diagnostic with expected vs actual type text on mismatch.
- Add `test_semantic_validator_reports_pipeline_uniform_initializer_type_mismatch` to `tests/test_debug_compiler.py` to assert the `LCK419` error is produced for a mismatch.
- Extend the existing acceptance test to include a matching uniform initializer case to ensure no diagnostic is produced for correct types.

### Testing
- Ran `pytest -q tests/test_debug_compiler.py -k "uniform_initializer or matching_assignment_initializer_and_return or var_initializer_type_mismatch"` which initially failed due to project `addopts` (coverage flags) in the test config causing unrecognized arguments.
- Re-ran with `-o addopts=''` to override the config and executed the same selection of tests, and they passed: `3 passed, 53 deselected`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a59817e8bc83288bd886bfd4fe1e9f)