### PR TITLE
Refactor fold diagnostics in visitBindStmt and add tests for each failure path

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -931,21 +931,31 @@ def build_semantic_validator(base_visitor_cls):
             fold_source = id_tokens[1].getText()
             declared_type = ctx.typeName().getText()
 
-            self._validate_declared_type(declared_type, ctx.typeName(), "LCK310")
+            self._validate_declared_type(declared_type, ctx.typeName(), SEMANTIC_DIAGNOSTIC_CODES["fold_unknown_target"])
 
             self._declare(
                 fold_target,
                 declared_type,
                 ctx,
-                duplicate_code="LCK306",
+                duplicate_code=SEMANTIC_DIAGNOSTIC_CODES["fold_unknown_target"],
                 kind="uniform",
             )
+
+            if fold_operator not in {"sum", "avg", "min", "max"}:
+                self._add_diagnostic(
+                    severity="error",
+                    code=SEMANTIC_DIAGNOSTIC_CODES["unknown_fold_operator"],
+                    message=f"Unsupported fold operator '{fold_operator}'.",
+                    ctx=ctx,
+                    hint="Use a valid fold operator such as sum, avg, min, or max.",
+                )
+                return self.visitChildren(ctx)
 
             fold_source_symbol = self._lookup(fold_source)
             if fold_source_symbol is None:
                 self._add_diagnostic(
                     severity="error",
-                    code=SEMANTIC_DIAGNOSTIC_CODES["unknown_fold_operator"],
+                    code=SEMANTIC_DIAGNOSTIC_CODES["fold_unknown_source"],
                     message=f"Fold source accumulator '{fold_source}' is undefined.",
                     ctx=ctx,
                     hint="Declare an accumulator and use it as the fold source.",
@@ -961,18 +971,10 @@ def build_semantic_validator(base_visitor_cls):
                     ctx=ctx,
                     hint="Use an accumulator as the input to fold.",
                 )
-            elif fold_operator not in {"sum", "avg", "min", "max"}:
-                self._add_diagnostic(
-                    severity="error",
-                    code=SEMANTIC_DIAGNOSTIC_CODES["fold_type_mismatch"],
-                    message=f"Unsupported fold operator '{fold_operator}'.",
-                    ctx=ctx,
-                    hint="Use a valid fold operator such as sum, avg, min, or max.",
-                )
             elif fold_source_symbol.declared_type != declared_type:
                 self._add_diagnostic(
                     severity="error",
-                    code=SEMANTIC_DIAGNOSTIC_CODES["fold_unknown_target"],
+                    code=SEMANTIC_DIAGNOSTIC_CODES["fold_type_mismatch"],
                     message=(
                         f"Fold target '{fold_target}' has type {declared_type}, but fold source "
                         f"'{fold_source}' has accumulator type {fold_source_symbol.declared_type}."

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -901,14 +901,31 @@ def test_semantic_validator_reports_duplicate_pipeline_symbols(debug_compiler_mo
     ]
 
 
-def test_semantic_validator_reports_fold_reference_errors(debug_compiler_module):
+def test_semantic_validator_reports_fold_source_missing_error_code(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator._push_scope()
+
+    missing_source_ctx = _ctx(
+        start_line=30,
+        start_col=6,
+        ID=lambda: [_token("u0"), _token("missing_acc")],
+        foldOperator=lambda: _token("sum"),
+        argList=lambda: None,
+        typeName=lambda: _token("float"),
+    )
+    validator.visitBindStmt(missing_source_ctx)
+
+    assert validator.diagnostics[0].code == "LCK403"
+    assert "is undefined" in validator.diagnostics[0].message
+
+
+def test_semantic_validator_reports_fold_source_kind_error_code(debug_compiler_module):
     validator = debug_compiler_module.LockstepSemanticValidator()
     validator._push_scope()
     validator._declare("not_acc", "float", _ctx(), duplicate_code="LCK306", kind="uniform")
-    validator._declare("acc_energy", "float", _ctx(), duplicate_code="LCK306", kind="accumulator")
 
     non_acc_fold_ctx = _ctx(
-        start_line=30,
+        start_line=31,
         start_col=6,
         ID=lambda: [_token("u0"), _token("not_acc")],
         foldOperator=lambda: _token("sum"),
@@ -917,8 +934,36 @@ def test_semantic_validator_reports_fold_reference_errors(debug_compiler_module)
     )
     validator.visitBindStmt(non_acc_fold_ctx)
 
+    assert validator.diagnostics[0].code == "LCK403"
+    assert "must reference an accumulator" in validator.diagnostics[0].message
+
+
+def test_semantic_validator_reports_fold_operator_error_code(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator._push_scope()
+    validator._declare("acc_energy", "float", _ctx(), duplicate_code="LCK306", kind="accumulator")
+
+    invalid_operator_ctx = _ctx(
+        start_line=32,
+        start_col=6,
+        ID=lambda: [_token("u1"), _token("acc_energy")],
+        foldOperator=lambda: _token("median"),
+        argList=lambda: None,
+        typeName=lambda: _token("float"),
+    )
+    validator.visitBindStmt(invalid_operator_ctx)
+
+    assert validator.diagnostics[0].code == "LCK401"
+    assert "Unsupported fold operator 'median'" in validator.diagnostics[0].message
+
+
+def test_semantic_validator_reports_fold_type_mismatch_error_code(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator._push_scope()
+    validator._declare("acc_energy", "float", _ctx(), duplicate_code="LCK306", kind="accumulator")
+
     mismatched_type_ctx = _ctx(
-        start_line=31,
+        start_line=33,
         start_col=6,
         ID=lambda: [_token("u1"), _token("acc_energy")],
         foldOperator=lambda: _token("sum"),
@@ -927,13 +972,11 @@ def test_semantic_validator_reports_fold_reference_errors(debug_compiler_module)
     )
     validator.visitBindStmt(mismatched_type_ctx)
 
-    assert validator.diagnostics[0].code == "LCK403"
-    assert "must reference an accumulator" in validator.diagnostics[0].message
-    assert validator.diagnostics[1].code == "LCK404"
-    assert "has type int" in validator.diagnostics[1].message
+    assert validator.diagnostics[0].code == "LCK402"
+    assert "has type int" in validator.diagnostics[0].message
 
 
-def test_semantic_validator_reports_duplicate_fold_target(debug_compiler_module):
+def test_semantic_validator_reports_duplicate_fold_target_with_target_code(debug_compiler_module):
     validator = debug_compiler_module.LockstepSemanticValidator()
     validator._push_scope()
     validator._declare("acc_energy", "float", _ctx(), duplicate_code="LCK306", kind="accumulator")
@@ -953,7 +996,7 @@ def test_semantic_validator_reports_duplicate_fold_target(debug_compiler_module)
     assert validator.diagnostics == [
         debug_compiler_module.LockstepDiagnostic(
             severity="error",
-            code="LCK306",
+            code="LCK404",
             message="Duplicate declaration for 'u0' in the same scope.",
             line=33,
             column=4,
@@ -1340,7 +1383,9 @@ def test_semantic_validator_reports_unknown_declared_type_with_hint(debug_compil
     )
 
     type_errors = [diag for diag in validator.diagnostics if diag.code == "LCK310"]
-    assert len(type_errors) == 7
+    fold_target_errors = [diag for diag in validator.diagnostics if diag.code == "LCK404"]
+    assert len(type_errors) == 6
+    assert len(fold_target_errors) == 1
     assert all(diag.message == "Unknown declared type 'flaot'." for diag in type_errors)
     assert any(diag.hint is not None and "Did you mean float?" in diag.hint for diag in type_errors)
 


### PR DESCRIPTION
### Motivation
- The fold validation logic in `visitBindStmt` emitted diagnostic codes that did not consistently match the actual failure conditions; the goal is to make each fold error produce the intended diagnostic code and clearer messages.
- Tests needed to explicitly cover each fold failure path and assert that the diagnostic `code` and representative message text are exact.

### Description
- Reordered and refactored fold checks in `visitBindStmt` so operator validation runs before source lookup and so each branch emits the intended code; changed the fold target declaration / duplicate handling to use the fold-target diagnostic code. (modified `lockstep_compiler/visitors.py`)
- Remapped diagnostic codes for fold failures as follows: unsupported operator -> `LCK401`, missing source accumulator -> `LCK403`, non-accumulator source kind -> `LCK403`, fold target/source type mismatch -> `LCK402`, and invalid/duplicate target declaration -> `LCK404`.
- Added focused unit tests that assert exact diagnostic `code` values and representative messages for each fold failure path (missing source, wrong source kind, unsupported operator, type mismatch, duplicate target) and adjusted an aggregate unknown-type expectation to account for the reclassified fold-target error. (modified `tests/test_debug_compiler.py`)

### Testing
- Ran `pytest -q -o addopts='' tests/test_debug_compiler.py -k fold` and observed `6 passed, 52 deselected`.
- Ran full validator tests with `pytest -q -o addopts='' tests/test_debug_compiler.py` and observed `58 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a59812e6d08328bfeb37151de60596)