### PR TITLE
Enhance expression inference and semantic operand checks

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -37,6 +37,7 @@ SEMANTIC_DIAGNOSTIC_CODES = {
     "assignment_type_mismatch": "LCK417",
     "pure_return_type_mismatch": "LCK418",
     "uniform_initializer_type_mismatch": "LCK419",
+    "invalid_operand_types": "LCK420",
 }
 
 
@@ -751,6 +752,118 @@ def build_semantic_validator(base_visitor_cls):
         def _resolve_expr_type(self, ctx):
             if ctx is None:
                 return None
+
+            def _as_list(value):
+                if value is None:
+                    return []
+                return value if isinstance(value, list) else [value]
+
+            def _child_text(index: int) -> str | None:
+                if not hasattr(ctx, "getChild"):
+                    return None
+                try:
+                    child = ctx.getChild(index)
+                except Exception:
+                    return None
+                return child.getText() if child is not None and hasattr(child, "getText") else None
+
+            def _report_operand_error(operator: str, expected: str, actual_types: list[str | None]):
+                rendered_types = ", ".join(type_name if type_name is not None else "<unresolved>" for type_name in actual_types)
+                self._add_diagnostic(
+                    severity="error",
+                    code=SEMANTIC_DIAGNOSTIC_CODES["invalid_operand_types"],
+                    message=(
+                        f"Operator '{operator}' expects {expected} operand type(s), "
+                        f"but got [{rendered_types}]."
+                    ),
+                    ctx=ctx,
+                    hint="Adjust operand types so they match the operator semantics.",
+                )
+
+            def _resolve_numeric_sequence(operator: str, operand_contexts: list[Any]):
+                operand_types = [self._resolve_expr_type(operand_ctx) for operand_ctx in operand_contexts]
+                known = [operand_type for operand_type in operand_types if operand_type is not None]
+                if any(operand_type not in {"int", "float"} for operand_type in known):
+                    _report_operand_error(operator, "numeric", operand_types)
+                    return None
+                if len(known) != len(operand_contexts):
+                    return None
+                return "float" if "float" in known else "int"
+
+            def _resolve_boolean_sequence(operator: str, operand_contexts: list[Any]):
+                operand_types = [self._resolve_expr_type(operand_ctx) for operand_ctx in operand_contexts]
+                known = [operand_type for operand_type in operand_types if operand_type is not None]
+                if any(operand_type != "bool" for operand_type in known):
+                    _report_operand_error(operator, "bool", operand_types)
+                    return None
+                if len(known) != len(operand_contexts):
+                    return None
+                return "bool"
+
+            if hasattr(ctx, "logicalAndExpr") and callable(ctx.logicalAndExpr):
+                operands = _as_list(ctx.logicalAndExpr())
+                if len(operands) > 1:
+                    return _resolve_boolean_sequence("||", operands)
+                if len(operands) == 1:
+                    return self._resolve_expr_type(operands[0])
+
+            if hasattr(ctx, "equalityExpr") and callable(ctx.equalityExpr):
+                operands = _as_list(ctx.equalityExpr())
+                if len(operands) > 1:
+                    return _resolve_boolean_sequence("&&", operands)
+                if len(operands) == 1:
+                    return self._resolve_expr_type(operands[0])
+
+            if hasattr(ctx, "relExpr") and callable(ctx.relExpr):
+                operands = _as_list(ctx.relExpr())
+                if len(operands) > 1:
+                    operand_types = [self._resolve_expr_type(operand_ctx) for operand_ctx in operands]
+                    known = [operand_type for operand_type in operand_types if operand_type is not None]
+                    if any(operand_type not in {"int", "float", "bool"} for operand_type in known):
+                        operator = _child_text(1) or "=="
+                        _report_operand_error(operator, "comparable", operand_types)
+                        return None
+                    if len(set(known)) > 1:
+                        operator = _child_text(1) or "=="
+                        _report_operand_error(operator, "matching", operand_types)
+                        return None
+                    if len(known) != len(operands):
+                        return None
+                    return "bool"
+                if len(operands) == 1:
+                    return self._resolve_expr_type(operands[0])
+
+            if hasattr(ctx, "addExpr") and callable(ctx.addExpr):
+                operands = _as_list(ctx.addExpr())
+                if len(operands) > 1:
+                    operator = _child_text(1) or ">"
+                    numeric_type = _resolve_numeric_sequence(operator, operands)
+                    return "bool" if numeric_type is not None else None
+                if len(operands) == 1:
+                    return self._resolve_expr_type(operands[0])
+
+            if hasattr(ctx, "mulExpr") and callable(ctx.mulExpr):
+                operands = _as_list(ctx.mulExpr())
+                if len(operands) > 1:
+                    operator = _child_text(1) or "+"
+                    return _resolve_numeric_sequence(operator, operands)
+                if len(operands) == 1:
+                    return self._resolve_expr_type(operands[0])
+
+            if hasattr(ctx, "unaryExpr") and callable(ctx.unaryExpr) and ctx.unaryExpr() is not None:
+                operator = _child_text(0) or ""
+                operand_type = self._resolve_expr_type(ctx.unaryExpr())
+                if operator == "-":
+                    if operand_type is not None and operand_type not in {"int", "float"}:
+                        _report_operand_error(operator, "numeric", [operand_type])
+                        return None
+                    return operand_type
+                if operator == "!":
+                    if operand_type is not None and operand_type != "bool":
+                        _report_operand_error(operator, "bool", [operand_type])
+                        return None
+                    return "bool" if operand_type is not None else None
+                return operand_type
 
             if hasattr(ctx, "declared_type"):
                 return ctx.declared_type

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1783,3 +1783,57 @@ def test_semantic_validator_accepts_matching_assignment_initializer_and_return(d
     validator.visitPureDecl(pure_ctx)
 
     assert validator.diagnostics == []
+
+
+def test_semantic_validator_infers_arithmetic_and_relational_expression_types(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    add_ctx = _ctx(mulExpr=lambda: [_ctx(declared_type="int"), _ctx(declared_type="float")], getChild=lambda i: _token("+"))
+    rel_ctx = _ctx(addExpr=lambda: [add_ctx, _ctx(declared_type="float")], getChild=lambda i: _token(">"))
+
+    assert validator._resolve_expr_type(add_ctx) == "float"
+    assert validator._resolve_expr_type(rel_ctx) == "bool"
+    assert validator.diagnostics == []
+
+
+def test_semantic_validator_reports_invalid_logical_operand_types(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    logical_and_ctx = _ctx(equalityExpr=lambda: [_ctx(declared_type="bool"), _ctx(declared_type="int")])
+
+    resolved_type = validator._resolve_expr_type(logical_and_ctx)
+
+    assert resolved_type is None
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK420",
+            message="Operator '&&' expects bool operand type(s), but got [bool, int].",
+            line=0,
+            column=0,
+            hint="Adjust operand types so they match the operator semantics.",
+        )
+    ]
+
+
+def test_semantic_validator_reports_invalid_unary_operand_types(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    unary_not_ctx = _ctx(
+        unaryExpr=lambda: _ctx(declared_type="float"),
+        getChild=lambda i: _token("!" if i == 0 else "value"),
+    )
+
+    resolved_type = validator._resolve_expr_type(unary_not_ctx)
+
+    assert resolved_type is None
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK420",
+            message="Operator '!' expects bool operand type(s), but got [float].",
+            line=0,
+            column=0,
+            hint="Adjust operand types so they match the operator semantics.",
+        )
+    ]


### PR DESCRIPTION
### Motivation
- Improve the compiler's type inference for expressions so arithmetic, relational and logical expressions produce correct result types and produce actionable diagnostics when operand types are incompatible.
- Catch operator-specific misuse (e.g. using non-bools with `&&`/`||`, non-numeric operands with `+`/`-`/`*`/`/`, or applying `!` to non-bool) and emit a dedicated diagnostic code for these cases.

### Description
- Added a new semantic diagnostic code `LCK420` (`"invalid_operand_types"`) to signal invalid operand-type usage in expressions.
- Enhanced `_resolve_expr_type` with small helpers (`_as_list`, `_child_text`, `_report_operand_error`, `_resolve_numeric_sequence`, `_resolve_boolean_sequence`) to infer types over logical, equality, relational, additive, multiplicative, and unary expression contexts and to validate operand compatibility.
- Implemented operator-aware checks and promotion (numeric promotion of `int` + `float` → `float`, relational/equality checks yielding `bool`, boolean combinators requiring `bool`) and emit `LCK420` with a clear message and hint when checks fail.
- Added unit tests exercising arithmetic/relational inference and invalid operand diagnostics in `tests/test_debug_compiler.py`.

### Testing
- Ran `pytest -q -o addopts='' tests/test_debug_compiler.py -k "inference or operand or assignment_type_mismatch"`, which passed (`3 passed, 63 deselected`).
- Ran full test file with `pytest -q -o addopts='' tests/test_debug_compiler.py`, which passed (`66 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a59c4b99fc8328ad376c319ea12843)