### PR TITLE
Fix semantic codes for fold target declared type and duplicate declarations

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -1061,13 +1061,17 @@ def build_semantic_validator(base_visitor_cls):
             fold_source = id_tokens[1].getText()
             declared_type = ctx.typeName().getText()
 
-            self._validate_declared_type(declared_type, ctx.typeName(), SEMANTIC_DIAGNOSTIC_CODES["fold_unknown_target"])
+            self._validate_declared_type(
+                declared_type,
+                ctx.typeName(),
+                SEMANTIC_DIAGNOSTIC_CODES["unknown_declared_type"],
+            )
 
             self._declare(
                 fold_target,
                 declared_type,
                 ctx,
-                duplicate_code=SEMANTIC_DIAGNOSTIC_CODES["fold_unknown_target"],
+                duplicate_code=SEMANTIC_DIAGNOSTIC_CODES["duplicate_declaration"],
                 kind="uniform",
             )
 

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1065,7 +1065,7 @@ def test_semantic_validator_reports_fold_type_mismatch_error_code(debug_compiler
     assert "has type int" in validator.diagnostics[0].message
 
 
-def test_semantic_validator_reports_duplicate_fold_target_with_target_code(debug_compiler_module):
+def test_semantic_validator_reports_duplicate_fold_target_with_duplicate_declaration_code(debug_compiler_module):
     validator = debug_compiler_module.LockstepSemanticValidator()
     validator._push_scope()
     validator._declare("acc_energy", "float", _ctx(), duplicate_code="LCK306", kind="accumulator")
@@ -1085,7 +1085,7 @@ def test_semantic_validator_reports_duplicate_fold_target_with_target_code(debug
     assert validator.diagnostics == [
         debug_compiler_module.LockstepDiagnostic(
             severity="error",
-            code="LCK404",
+            code="LCK306",
             message="Duplicate declaration for 'u0' in the same scope.",
             line=33,
             column=4,
@@ -1473,8 +1473,8 @@ def test_semantic_validator_reports_unknown_declared_type_with_hint(debug_compil
 
     type_errors = [diag for diag in validator.diagnostics if diag.code == "LCK310"]
     fold_target_errors = [diag for diag in validator.diagnostics if diag.code == "LCK404"]
-    assert len(type_errors) == 6
-    assert len(fold_target_errors) == 1
+    assert len(type_errors) == 7
+    assert len(fold_target_errors) == 0
     assert all(diag.message == "Unknown declared type 'flaot'." for diag in type_errors)
     assert any(diag.hint is not None and "Did you mean float?" in diag.hint for diag in type_errors)
 


### PR DESCRIPTION
### Motivation
- The fold-target validation in `visitBindStmt` was emitting `fold_unknown_target` (`LCK404`) for unrelated cases (unknown declared type and duplicate declarations), which is semantically incorrect and collides with the true meaning of `LCK404`.
- The goal is to emit the correct semantic diagnostic codes for declared-type errors and duplicate declarations so diagnostics are precise and actionable.

### Description
- Change declared-type validation for fold targets in `visitBindStmt` to call `_validate_declared_type` with `SEMANTIC_DIAGNOSTIC_CODES["unknown_declared_type"]` (`LCK310`) instead of `fold_unknown_target`.
- Change the duplicate-declaration code used when declaring a fold target to `SEMANTIC_DIAGNOSTIC_CODES["duplicate_declaration"]` (`LCK306`) instead of `fold_unknown_target` and keep `LCK404` reserved for true unknown fold-target semantics.
- Update tests in `tests/test_debug_compiler.py` to assert the updated diagnostic codes and counts for the affected fold scenarios.

### Testing
- Ran `pytest -q -o addopts='' tests/test_debug_compiler.py -k "duplicate_fold_target_with_duplicate_declaration_code or unknown_declared_type_with_hint or fold_type_mismatch or fold_operator_error_code"` and the selected tests passed: `4 passed, 62 deselected`.
- An initial `pytest -q tests/test_debug_compiler.py -k "..."` run failed due to test runner ini addopts in the project config, so the tests were rerun with `-o addopts=''` to override and validate the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a08b986c83289cbbe23e4c887df6)