### PR TITLE
Detect duplicate struct declarations in semantic validator

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -609,6 +609,16 @@ def build_semantic_validator(base_visitor_cls):
 
         def visitStructDecl(self, ctx):
             struct_name = ctx.ID().getText()
+            if struct_name in self.structs:
+                self._add_diagnostic(
+                    severity="error",
+                    code=SEMANTIC_DIAGNOSTIC_CODES["duplicate_declaration"],
+                    message=f"Duplicate struct declaration for '{struct_name}'.",
+                    ctx=ctx,
+                    hint="Rename one struct declaration to keep type names unique.",
+                )
+                return self.visitChildren(ctx)
+
             fields = {}
             seen_field_names: set[str] = set()
             for member in ctx.structMember() or []:

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1595,6 +1595,46 @@ def test_semantic_validator_struct_decl_keeps_first_duplicate_member(debug_compi
     }
 
 
+def test_semantic_validator_struct_decl_reports_duplicate_struct_and_keeps_original(
+    debug_compiler_module,
+):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    first_struct_ctx = _ctx(
+        start_line=70,
+        start_col=1,
+        ID=lambda: _token("Particle"),
+        structMember=lambda: [
+            _ctx(typeName=lambda: _token("Vec3"), ID=lambda: _token("position")),
+        ],
+    )
+    duplicate_struct_ctx = _ctx(
+        start_line=74,
+        start_col=1,
+        ID=lambda: _token("Particle"),
+        structMember=lambda: [
+            _ctx(typeName=lambda: _token("float"), ID=lambda: _token("mass")),
+        ],
+    )
+
+    validator.visitStructDecl(first_struct_ctx)
+    validator.visitStructDecl(duplicate_struct_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK306",
+            message="Duplicate struct declaration for 'Particle'.",
+            line=74,
+            column=1,
+            hint="Rename one struct declaration to keep type names unique.",
+        )
+    ]
+    assert validator.structs["Particle"] == {
+        "position": SemanticStructField(name="position", declared_type="Vec3")
+    }
+
+
 def test_semantic_validator_lvalue_reports_unknown_struct_field(debug_compiler_module):
     validator = debug_compiler_module.LockstepSemanticValidator()
 


### PR DESCRIPTION
### Motivation
- Prevent later struct declarations from silently replacing earlier ones in the semantic model by detecting duplicates before mutating `self.structs`.
- Surface a clear semantic error when a struct name is reused to help users fix duplicate type declarations.

### Description
- Add a duplicate check at the start of `LockstepSemanticValidator.visitStructDecl` in `lockstep_compiler/visitors.py` that emits an error diagnostic using `SEMANTIC_DIAGNOSTIC_CODES["duplicate_declaration"]` and returns early to avoid replacing the original struct definition.
- Implement a deterministic policy of "first declaration wins" by preserving the first observed struct entry in `self.structs` and skipping subsequent redefinitions.
- Add a unit test `test_semantic_validator_struct_decl_reports_duplicate_struct_and_keeps_original` in `tests/test_debug_compiler.py` that declares the same struct twice and asserts the emitted `LCK306` diagnostic and that the original struct body remains unchanged.

### Testing
- An initial `pytest` invocation failed due to repository `addopts` requiring coverage plugins (error from pytest about unrecognized `--cov` options).
- Re-ran the focused tests with `pytest -q tests/test_debug_compiler.py -k "struct_decl_reports_duplicate_struct_and_keeps_original or struct_decl_keeps_first_duplicate_member or struct_decl_reports_duplicate_member" -o addopts=''` which completed successfully with `3 passed, 64 deselected`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a08eec788328b81bd51b48523e62)