### PR TITLE
Refactor expression identifier lookup in semantic visitor

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -382,7 +382,8 @@ def build_semantic_validator(base_visitor_cls):
             return name, params
 
         def _check_expression_identifier(self, name: str, ctx):
-            if self._lookup(name) is None:
+            symbol = self._lookup(name)
+            if symbol is None:
                 self._add_diagnostic(
                     severity="error",
                     code=SEMANTIC_DIAGNOSTIC_CODES["undefined_identifier"],
@@ -391,8 +392,7 @@ def build_semantic_validator(base_visitor_cls):
                     hint="Declare the identifier in scope before using it.",
                 )
                 return None
-            symbol = self._lookup(name)
-            return symbol.declared_type if symbol else None
+            return symbol.declared_type
 
         def _collect_id_tokens(self, ctx):
             id_tokens = ctx.ID()


### PR DESCRIPTION
### Motivation
- Reduce duplicated work and clarify intent by avoiding multiple calls to `self._lookup(name)` in the expression identifier checker while preserving existing behavior.

### Description
- In `lockstep_compiler/visitors.py` refactored `_check_expression_identifier` to call `self._lookup(name)` once, store the result in a local `symbol` variable, check `symbol is None` for the undefined-identifier diagnostic, and return `symbol.declared_type` when present.

### Testing
- Ran `pytest -q -o addopts=''` which passed (`69 passed, 6 skipped`); running `pytest -q` in this environment fails due to `pytest-cov` options configured in `pyproject.toml` that are not available here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a09537508328a69a7f4f59b9ebb0)