### PR TITLE
Cache default parser class loading in compiler module

### DIFF
--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Any
 
 from antlr4 import CommonTokenStream, InputStream
@@ -64,7 +65,13 @@ def _compile_lockstep_with_dependencies(
     )
 
 
+@functools.lru_cache(maxsize=1)
 def load_default_parser_classes() -> tuple[Any, Any, Any]:
+    """Load and cache the default generated parser classes.
+
+    The first call imports generated parser modules; subsequent calls reuse the
+    cached class tuple to avoid repeated import work.
+    """
     from generated.parser.LockstepLexer import LockstepLexer
     from generated.parser.LockstepParser import LockstepParser
     from generated.parser.LockstepVisitor import LockstepVisitor

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -1,5 +1,6 @@
 import pathlib
 import sys
+import builtins
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -98,3 +99,24 @@ def test_cli_main_wires_default_compiler(monkeypatch):
     monkeypatch.setattr(compiler_module, "compile_lockstep", sentinel_compiler)
 
     assert cli_module.main(["--dump"]) == 7
+
+
+def test_load_default_parser_classes_is_cached(monkeypatch):
+    compiler_module.load_default_parser_classes.cache_clear()
+    import_count = 0
+    original_import = builtins.__import__
+
+    def tracking_import(name, globals=None, locals=None, fromlist=(), level=0):
+        nonlocal import_count
+        if name.startswith("generated.parser"):
+            import_count += 1
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", tracking_import)
+
+    first = compiler_module.load_default_parser_classes()
+    first_import_count = import_count
+    second = compiler_module.load_default_parser_classes()
+
+    assert first == second
+    assert import_count == first_import_count


### PR DESCRIPTION
### Motivation
- Avoid re-importing generated parser modules on every call to the default loader to reduce overhead.
- Make the default parser-class retrieval cheap and idempotent while preserving existing API and behavior.
- Document the cached behavior so future readers understand the first-call import side effect.

### Description
- Add `import functools` and decorate `load_default_parser_classes` with `@functools.lru_cache(maxsize=1)` to cache the returned `(Lexer, Parser, Visitor)` tuple.
- Add a docstring to `load_default_parser_classes` clarifying that the first call imports generated parser modules and subsequent calls return the cached tuple.
- Add `test_load_default_parser_classes_is_cached` which clears the cache, monkeypatches `builtins.__import__` to count imports of `generated.parser*`, and asserts a second call does not increase the import count.
- Preserve the original return type/shape and the backward-compatible alias `_load_default_parser_classes`.

### Testing
- Running `pytest -q -o addopts=''` executed the full test suite and succeeded with `70 passed, 6 skipped` including the new caching test.
- Running plain `pytest -q` initially failed due to repository `addopts` in `pyproject.toml` injecting coverage flags not available in the environment, so tests were run with `-o addopts=''` to override those options.
- The added unit test `test_load_default_parser_classes_is_cached` passed as part of the successful test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a0985af88328a5670ac49ac96c7b)