### PR TITLE
Preserve canonical kernel signatures across duplicate declarations

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -355,14 +355,6 @@ def build_semantic_validator(base_visitor_cls):
 
         def _record_kernel_signature(self, ctx, target: dict[str, list[SemanticKernelParam]]):
             name = ctx.ID().getText()
-            if name in target:
-                self._add_diagnostic(
-                    severity="error",
-                    code=SEMANTIC_DIAGNOSTIC_CODES["duplicate_kernel_declaration"],
-                    message=f"Duplicate shader/filter declaration for '{name}'.",
-                    ctx=ctx,
-                    hint="Rename one declaration to avoid symbol collisions.",
-                )
             params = []
             if ctx.paramList():
                 for param in ctx.paramList().param():
@@ -378,6 +370,17 @@ def build_semantic_validator(base_visitor_cls):
                             modifier=param.getChild(0).getText(),
                         )
                     )
+
+            if name in target:
+                self._add_diagnostic(
+                    severity="error",
+                    code=SEMANTIC_DIAGNOSTIC_CODES["duplicate_kernel_declaration"],
+                    message=f"Duplicate shader/filter declaration for '{name}'.",
+                    ctx=ctx,
+                    hint="Rename one declaration to avoid symbol collisions.",
+                )
+                return name, params
+
             target[name] = params
             return name, params
 

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1140,6 +1140,60 @@ def test_semantic_validator_records_pure_signature_from_declaration(debug_compil
     }
 
 
+def test_semantic_validator_preserves_first_kernel_signature_on_duplicate(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    canonical_decl_ctx = _ctx(
+        ID=lambda: _token("shade"),
+        paramList=lambda: _ctx(
+            param=lambda: [
+                _ctx(
+                    ID=lambda: _token("inp_stream"),
+                    typeName=lambda: _token("float"),
+                    getChild=lambda _index: _token("in"),
+                ),
+                _ctx(
+                    ID=lambda: _token("out_stream"),
+                    typeName=lambda: _token("float"),
+                    getChild=lambda _index: _token("out"),
+                ),
+            ]
+        ),
+    )
+    duplicate_decl_ctx = _ctx(
+        start_line=52,
+        start_col=1,
+        ID=lambda: _token("shade"),
+        paramList=lambda: _ctx(
+            param=lambda: [
+                _ctx(
+                    ID=lambda: _token("intensity"),
+                    typeName=lambda: _token("float"),
+                    getChild=lambda _index: _token("uniform"),
+                )
+            ]
+        ),
+    )
+
+    validator.visitShaderDecl(canonical_decl_ctx)
+    validator.visitShaderDecl(duplicate_decl_ctx)
+
+    assert validator.shaders["shade"] == [
+        SemanticKernelParam(name="inp_stream", declared_type="float", modifier="in"),
+        SemanticKernelParam(name="out_stream", declared_type="float", modifier="out"),
+    ]
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK307",
+            message="Duplicate shader/filter declaration for 'shade'.",
+            line=52,
+            column=1,
+            hint="Rename one declaration to avoid symbol collisions.",
+        )
+    ]
+
+
 def test_semantic_validator_reports_error_for_pure_function_without_return(debug_compiler_module):
     validator = debug_compiler_module.LockstepSemanticValidator()
 


### PR DESCRIPTION
### Motivation

- Duplicate shader/filter declarations were overwriting the original kernel signature in the semantic registry, which broke downstream bind/type checks that should use the first (canonical) declaration.

### Description

- Reworked `_record_kernel_signature` in `lockstep_compiler/visitors.py` to build and validate parameter metadata first and then, if a name is already present, emit the duplicate-kernel diagnostic and return early without overwriting the existing `target` entry. 
- This preserves the first-declared (canonical) `SemanticKernelParam` list for shaders/filters while still validating subsequent declarations and emitting the duplicate diagnostic `LCK307`.
- Added a regression test `test_semantic_validator_preserves_first_kernel_signature_on_duplicate` in `tests/test_debug_compiler.py` that asserts the first signature is preserved and the duplicate declaration produces the expected diagnostic.

### Testing

- Ran the new regression test with `pytest -q -o addopts='' tests/test_debug_compiler.py::test_semantic_validator_preserves_first_kernel_signature_on_duplicate`, which passed. 
- Ran the full test suite with `pytest -q -o addopts=''`, which completed successfully with `72 passed, 6 skipped`.
- Note that running `pytest -q` without overriding `addopts` fails in this environment due to the configured coverage plugin options, so tests were executed with `-o addopts=''` to disable those extra options.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5fe446ff4832899febe92ad495501)