### PR TITLE
Implement LLVM IR code generation phase in compiler pipeline

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+_PRIMITIVE_TYPE_MAP = {
+    "bool": "i1",
+    "int": "i32",
+    "uint": "i32",
+    "float": "float",
+    "double": "double",
+}
+
+
+def _sanitize_symbol(name: str) -> str:
+    return "".join(ch if (ch.isalnum() or ch == "_") else "_" for ch in name)
+
+
+def _llvm_type(type_name: str, known_structs: set[str]) -> str:
+    if type_name in _PRIMITIVE_TYPE_MAP:
+        return _PRIMITIVE_TYPE_MAP[type_name]
+    if type_name in known_structs:
+        return f"%struct.{_sanitize_symbol(type_name)}"
+    return "i8*"
+
+
+def emit_llvm_ir(entities: dict[str, Any]) -> str:
+    """Generate a baseline LLVM IR module for frontend-discovered entities."""
+
+    structs = entities.get("structs", [])
+    shaders = entities.get("shaders", [])
+    filters = entities.get("filters", [])
+    pure_functions = entities.get("pure_functions", [])
+    streams = entities.get("streams", [])
+    accumulators = entities.get("accumulators", [])
+    uniforms = entities.get("uniforms", [])
+    bind_routes = entities.get("bind_routes", [])
+
+    known_structs = set(structs)
+    lines: list[str] = [
+        '; ModuleID = "lockstep"',
+        'source_filename = "lockstep"',
+        "",
+    ]
+
+    for struct_name in structs:
+        safe_name = _sanitize_symbol(struct_name)
+        lines.append(f"%struct.{safe_name} = type {{ i8 }}")
+
+    if structs:
+        lines.append("")
+
+    for pure in pure_functions:
+        name = _sanitize_symbol(pure["name"])
+        return_type = _llvm_type(pure["return_type"], known_structs)
+        lines.append(f"declare {return_type} @pure_{name}()")
+
+    for shader in shaders:
+        lines.append(f"declare void @shader_{_sanitize_symbol(shader['name'])}()")
+
+    for flt in filters:
+        lines.append(f"declare void @filter_{_sanitize_symbol(flt['name'])}()")
+
+    if pure_functions or shaders or filters:
+        lines.append("")
+
+    for stream in streams:
+        stream_name = _sanitize_symbol(stream["name"])
+        stream_type = _llvm_type(stream["type"], known_structs)
+        lines.append(f"@stream_{stream_name} = external global {stream_type}")
+
+    for accum in accumulators:
+        accum_name = _sanitize_symbol(accum["name"])
+        accum_type = _llvm_type(accum["type"], known_structs)
+        lines.append(f"@accum_{accum_name} = external global {accum_type}")
+
+    for uniform in uniforms:
+        uniform_name = _sanitize_symbol(uniform["name"])
+        uniform_type = _llvm_type(uniform["type"], known_structs)
+        lines.append(f"@uniform_{uniform_name} = external global {uniform_type}")
+
+    if streams or accumulators or uniforms:
+        lines.append("")
+
+    lines.extend(
+        [
+            "define void @Lockstep_Tick() {",
+            "entry:",
+        ]
+    )
+
+    for route in bind_routes:
+        route_text = str(route).replace("\\", "\\\\").replace('"', '\\"')
+        lines.append(f'  call void asm sideeffect "; bind: {route_text}", ""()')
+
+    lines.extend(["  ret void", "}"])
+
+    return "\n".join(lines) + "\n"

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from antlr4 import CommonTokenStream, InputStream
 
+from .codegen import emit_llvm_ir
 from .errors import LockstepCompileError, ParseErrorCollector
 from .models import LockstepCompileResult, normalize_diagnostics
 from .visitors import build_debug_visitor, validate_semantics as _validate_semantics
@@ -34,7 +35,9 @@ def _compile_lockstep_with_dependencies(
     if error_listener.errors:
         raise LockstepCompileError(error_listener.errors, diagnostics=error_listener.errors)
 
-    semantic_validator = semantic_validator or (lambda parse_tree: validate_semantics(parse_tree, visitor_cls))
+    semantic_validator = semantic_validator or (
+        lambda parse_tree: validate_semantics(parse_tree, visitor_cls)
+    )
     semantic_diagnostics = normalize_diagnostics(semantic_validator(tree))
     semantic_errors = [d for d in semantic_diagnostics if d.severity == "error"]
     if semantic_errors:
@@ -49,18 +52,21 @@ def _compile_lockstep_with_dependencies(
     visitor.visit(tree)
     all_diagnostics = normalize_diagnostics([*semantic_diagnostics, *visitor.diagnostics])
 
+    entities = {
+        "structs": visitor.structs,
+        "shaders": visitor.shaders,
+        "filters": visitor.filters,
+        "pure_functions": visitor.pure_functions,
+        "streams": visitor.streams,
+        "accumulators": visitor.accumulators,
+        "uniforms": visitor.uniforms,
+        "bind_routes": visitor.bind_routes,
+    }
+
     return LockstepCompileResult(
         parse_tree=tree,
-        entities={
-            "structs": visitor.structs,
-            "shaders": visitor.shaders,
-            "filters": visitor.filters,
-            "pure_functions": visitor.pure_functions,
-            "streams": visitor.streams,
-            "accumulators": visitor.accumulators,
-            "uniforms": visitor.uniforms,
-            "bind_routes": visitor.bind_routes,
-        },
+        entities=entities,
+        llvm_ir=emit_llvm_ir(entities),
         diagnostics=all_diagnostics,
     )
 

--- a/lockstep_compiler/models.py
+++ b/lockstep_compiler/models.py
@@ -16,6 +16,7 @@ class LockstepDiagnostic:
 class LockstepCompileResult:
     parse_tree: Any
     entities: dict[str, Any]
+    llvm_ir: str = ""
     diagnostics: list[LockstepDiagnostic] = field(default_factory=list)
 
 

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -8,6 +8,7 @@ if str(REPO_ROOT) not in sys.path:
 
 import lockstep_compiler
 import lockstep_compiler.compiler as compiler_module
+from lockstep_compiler.codegen import emit_llvm_ir
 
 
 def test_package_exports_user_friendly_compile_function():
@@ -83,6 +84,33 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
         "uniforms": [],
         "bind_routes": [],
     }
+
+    assert result.llvm_ir.startswith('; ModuleID = "lockstep"\n')
+    assert "define void @Lockstep_Tick()" in result.llvm_ir
+
+
+def test_emit_llvm_ir_generates_expected_declarations():
+    llvm_ir = emit_llvm_ir(
+        {
+            "structs": ["Vec3"],
+            "shaders": [{"name": "ApplyGravity"}],
+            "filters": [{"name": "Cull"}],
+            "pure_functions": [{"name": "mix", "return_type": "float"}],
+            "streams": [{"name": "raw_positions", "type": "Vec3"}],
+            "accumulators": [{"name": "energy", "type": "float"}],
+            "uniforms": [{"name": "dt", "type": "float", "initializer": "0.016"}],
+            "bind_routes": ["out = ApplyGravity(inp, out, energy, dt);"],
+        }
+    )
+
+    assert "%struct.Vec3 = type { i8 }" in llvm_ir
+    assert "declare float @pure_mix()" in llvm_ir
+    assert "declare void @shader_ApplyGravity()" in llvm_ir
+    assert "declare void @filter_Cull()" in llvm_ir
+    assert "@stream_raw_positions = external global %struct.Vec3" in llvm_ir
+    assert "@accum_energy = external global float" in llvm_ir
+    assert "@uniform_dt = external global float" in llvm_ir
+    assert '; bind: out = ApplyGravity(inp, out, energy, dt);' in llvm_ir
 
 
 def test_cli_main_wires_default_compiler(monkeypatch):


### PR DESCRIPTION
### Motivation

- Provide a first-class code generation phase that lowers frontend-discovered entities into a baseline LLVM IR module for downstream optimization and tooling.
- Expose emitted IR through the compile result so CLI and other consumers can inspect generated code without running further backend steps.
- Add a minimal, well-specified IR emitter to make bind routing and external symbols visible to tests and future lowering passes.

### Description

- Add a new module `lockstep_compiler.codegen` with `emit_llvm_ir(entities)` that maps primitive and struct types, emits struct type declarations, declares pure/shader/filter symbols, emits `@stream_*`, `@accum_*`, and `@uniform_*` globals, and defines a `@Lockstep_Tick` function containing asm-sideeffect markers for each bind route.
- Wire the code generation phase into the compilation pipeline in `compile_lockstep` so that after semantic validation and frontend entity extraction the compiler calls `emit_llvm_ir(entities)` and stores the result.
- Extend `LockstepCompileResult` in `lockstep_compiler.models` with a new `llvm_ir` field to carry emitted IR alongside `parse_tree`, `entities`, and `diagnostics`.
- Update tests in `tests/test_compiler_api.py` to assert that `llvm_ir` is populated and to validate specific IR declarations produced by `emit_llvm_ir`.

### Testing

- Running the test suite with `pytest -q -o addopts=''` executed the full automated tests and produced `73 passed, 6 skipped`.
- A plain `pytest -q` run failed in the environment due to project `pyproject.toml` addopts requiring coverage plugins, which is unrelated to the changes and was worked around by clearing `addopts` as shown above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6009af2ac8328b99e727e8e98d1b0)