### PR TITLE
Add Lockstep source formatter and `--format` CLI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ pip install -e .
 lockstepc path/to/program.lock
 # or read source from stdin
 cat path/to/program.lock | lockstepc --dump
+# canonical straight-line formatting
+lockstepc path/to/program.lock --format
 ```
 
 `debug_compiler.py` exposes `compile_lockstep(source_code, verbose=True)` and returns a `LockstepCompileResult` containing:

--- a/lockstep_compiler/__init__.py
+++ b/lockstep_compiler/__init__.py
@@ -1,6 +1,7 @@
 from .cli import build_arg_parser, run_cli
 from .compiler import compile_lockstep, load_default_parser_classes, validate_semantics
 from .errors import LockstepCompileError, ParseErrorCollector
+from .formatter import format_lockstep_source
 from .models import LockstepCompileResult, LockstepDiagnostic, normalize_diagnostics
 from .visitors import build_debug_visitor, build_semantic_validator
 
@@ -13,6 +14,7 @@ __all__ = [
     "build_debug_visitor",
     "build_semantic_validator",
     "compile_lockstep",
+    "format_lockstep_source",
     "load_default_parser_classes",
     "normalize_diagnostics",
     "run_cli",

--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -6,6 +6,7 @@ import traceback
 from pathlib import Path
 
 from .errors import LockstepCompileError
+from .formatter import format_lockstep_source
 
 
 def build_arg_parser():
@@ -17,10 +18,16 @@ def build_arg_parser():
         nargs="?",
         help="Optional path to a Lockstep source file. Reads from stdin when omitted.",
     )
-    parser.add_argument(
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
         "--dump",
         action="store_true",
         help="Print compiled entities (pipeline topology and bounds) as JSON.",
+    )
+    mode_group.add_argument(
+        "--format",
+        action="store_true",
+        help="Format Lockstep source code into canonical straight-line style.",
     )
     parser.add_argument(
         "--debug",
@@ -57,6 +64,10 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
             return 1
     else:
         source = stdin.read()
+
+    if args.format:
+        print(format_lockstep_source(source), end="", file=stdout)
+        return 0
 
     if compiler is None:
         from .compiler import compile_lockstep

--- a/lockstep_compiler/formatter.py
+++ b/lockstep_compiler/formatter.py
@@ -1,0 +1,69 @@
+def _tokenize(source):
+    tokens = []
+    current = []
+
+    for char in source:
+        if char in {"{", "}", ";", "\n"}:
+            if current:
+                token = "".join(current).strip()
+                if token:
+                    tokens.append(token)
+                current = []
+            tokens.append(char)
+        else:
+            current.append(char)
+
+    if current:
+        token = "".join(current).strip()
+        if token:
+            tokens.append(token)
+
+    return tokens
+
+
+def format_lockstep_source(source, *, indent="    "):
+    tokens = _tokenize(source)
+    lines = []
+    current = ""
+    depth = 0
+
+    def flush_current():
+        nonlocal current
+        if current.strip():
+            lines.append(f"{indent * depth}{current.strip()}")
+        current = ""
+
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+
+        if token == "{":
+            if current.strip():
+                lines.append(f"{indent * depth}{current.strip()} {{")
+            else:
+                lines.append(f"{indent * depth}{{")
+            current = ""
+            depth += 1
+        elif token == "}":
+            flush_current()
+            depth = max(depth - 1, 0)
+            closing = "}"
+            if index + 1 < len(tokens) and tokens[index + 1] == ";":
+                closing += ";"
+                index += 1
+            lines.append(f"{indent * depth}{closing}")
+        elif token == ";":
+            current = f"{current.strip()};"
+            flush_current()
+        elif token == "\n":
+            flush_current()
+        else:
+            if current:
+                current = f"{current} {token}"
+            else:
+                current = token
+
+        index += 1
+
+    flush_current()
+    return "\n".join(lines) + "\n"

--- a/tests/test_cli_format.py
+++ b/tests/test_cli_format.py
@@ -1,0 +1,22 @@
+import io
+
+from lockstep_compiler.cli import run_cli
+
+
+def test_run_cli_format_outputs_formatted_source_without_compiling():
+    called = {"compiler": False}
+
+    def fake_compiler(_source):
+        called["compiler"] = True
+
+    stdout = io.StringIO()
+    exit_code = run_cli(
+        ["--format"],
+        stdin=io.StringIO("pipeline P{stream<float,4> in0;}"),
+        stdout=stdout,
+        compiler=fake_compiler,
+    )
+
+    assert exit_code == 0
+    assert called["compiler"] is False
+    assert stdout.getvalue() == "pipeline P {\n    stream<float,4> in0;\n}\n"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,26 @@
+from lockstep_compiler.formatter import format_lockstep_source
+
+
+def test_format_lockstep_source_normalizes_indentation_and_spacing():
+    source = "pipeline Physics{stream<Vec3,1000> particles;bind{particles=Integrate(particles);}}"
+
+    assert format_lockstep_source(source) == (
+        "pipeline Physics {\n"
+        "    stream<Vec3,1000> particles;\n"
+        "    bind {\n"
+        "        particles=Integrate(particles);\n"
+        "    }\n"
+        "}\n"
+    )
+
+
+def test_format_lockstep_source_preserves_struct_terminator():
+    source = "struct Vec3{float x;float y;float z;};"
+
+    assert format_lockstep_source(source) == (
+        "struct Vec3 {\n"
+        "    float x;\n"
+        "    float y;\n"
+        "    float z;\n"
+        "};\n"
+    )


### PR DESCRIPTION
### Motivation
- Provide a simple, dedicated formatter to normalize Lockstep source into the project’s canonical straight-line style for improved readability and tooling.
- Allow formatting from the CLI without invoking the full compile pipeline to make quick reformatting convenient and safe.

### Description
- Add a new formatter utility `format_lockstep_source` implemented in `lockstep_compiler/formatter.py` that tokenizes source and emits normalized braces, statement layout, and indentation while preserving `};` struct terminators.
- Extend the CLI (`run_cli` / `build_arg_parser` in `lockstep_compiler/cli.py`) with a mutually exclusive `--format` mode (alongside `--dump`) that prints formatted source to stdout and returns early without calling the compiler.
- Export the formatter from the package public API via `lockstep_compiler.__init__` and document CLI usage in `README.md` (adds the example `lockstepc path/to/program.lock --format`).
- Add unit tests `tests/test_formatter.py` and `tests/test_cli_format.py` to verify formatting output and that `--format` does not invoke the compiler.

### Testing
- Running `pytest -q` in this environment initially fails due to project `pyproject.toml` `addopts` requiring the `pytest-cov` plugin which is not present here. 
- Running `PYTHONPATH=. pytest -q -o addopts=''` executes the full test suite and passes with `75 passed, 6 skipped`, including the newly added formatter tests which validate formatting and CLI behavior.
- The CLI test asserts that `run_cli([... "--format" ...])` prints the formatted source and does not call the injected compiler, and this test succeeded under the adjusted `pytest` invocation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a600e2cc808328819bc3c6b8ef4af5)