### PR TITLE
Enhance bind diagnostics with actionable fix-it hints

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -461,20 +461,33 @@ def build_semantic_validator(base_visitor_cls):
                 "accum": "accumulator",
             }
 
+            def bind_fixit(action: str) -> str:
+                return f"Fix-it: {action}."
+
+            known_kernels = sorted(set(self.shaders.keys()) | set(self.filters.keys()))
+            kernel_suggestions = get_close_matches(callee_name, known_kernels, n=2, cutoff=0.3)
+
             kernel = self.shaders.get(callee_name) or self.filters.get(callee_name)
             if kernel is None:
+                hint = "Declare the shader/filter before using it in bind."
+                if kernel_suggestions:
+                    suggestion = kernel_suggestions[0]
+                    fix = bind_fixit(f"replace '{callee_name}' with '{suggestion}'")
+                    hint = f"Did you mean '{suggestion}'? {fix} {hint}"
                 self._add_diagnostic(
                     severity="error",
                     code=SEMANTIC_DIAGNOSTIC_CODES["bind_unknown_target"],
                     message=f"Undefined shader/filter '{callee_name}' in bind statement.",
                     ctx=ctx,
-                    hint="Declare the shader/filter before using it in bind.",
+                    hint=hint,
                 )
                 return
 
             expected_arity = len(kernel)
             actual_arity = len(arg_names)
             if expected_arity != actual_arity:
+                parameter_names = [param.name for param in kernel]
+                call_example = f"{target_name} = {callee_name}({', '.join(parameter_names)});"
                 self._add_diagnostic(
                     severity="error",
                     code=SEMANTIC_DIAGNOSTIC_CODES["bind_argument_count_mismatch"],
@@ -483,7 +496,10 @@ def build_semantic_validator(base_visitor_cls):
                         f"but got {actual_arity}."
                     ),
                     ctx=ctx,
-                    hint="Match bind arguments to the shader/filter parameter list.",
+                    hint=(
+                        f"{bind_fixit(f'use the full signature `{call_example}`')} "
+                        "Match bind arguments to the shader/filter parameter list."
+                    ),
                 )
                 return
 
@@ -522,7 +538,10 @@ def build_semantic_validator(base_visitor_cls):
                                 f"'{out_arg_name}' for parameter '{out_param.name}' in '{callee_name}'."
                             ),
                             ctx=ctx,
-                            hint="Use the same symbol for assignment target and out argument.",
+                            hint=(
+                                f"{bind_fixit(f'change the bind target to \'{out_arg_name}\' or the out argument to \'{target_name}\'')} "
+                                "Use the same symbol for assignment target and out argument."
+                            ),
                         )
 
                     expected_output_kind = modifier_to_kind[out_param.modifier]
@@ -536,7 +555,10 @@ def build_semantic_validator(base_visitor_cls):
                                 f"got {target_symbol.kind}."
                             ),
                             ctx=ctx,
-                            hint="Route kernel outputs to a stream-compatible bind target.",
+                            hint=(
+                                f"{bind_fixit(f"bind output to a '{expected_output_kind}' symbol")} "
+                                "Route kernel outputs to a stream-compatible bind target."
+                            ),
                         )
                     if target_symbol.declared_type != out_param.declared_type:
                         self._add_diagnostic(
@@ -558,7 +580,10 @@ def build_semantic_validator(base_visitor_cls):
                         code=SEMANTIC_DIAGNOSTIC_CODES["undefined_identifier"],
                         message=f"Undefined identifier '{arg_name}'.",
                         ctx=ctx,
-                        hint="Declare pipeline symbols before passing them to bind.",
+                        hint=(
+                            f"{bind_fixit(f'declare `{arg_name}` in the pipeline block')} "
+                            "Declare pipeline symbols before passing them to bind."
+                        ),
                     )
                     continue
 
@@ -573,7 +598,10 @@ def build_semantic_validator(base_visitor_cls):
                             f"({expected_kind}), got {actual_symbol.kind}."
                         ),
                         ctx=ctx,
-                        hint="Pass a symbol with the kind required by the parameter modifier.",
+                        hint=(
+                            f"{bind_fixit(f'replace `{arg_name}` with a {expected_kind} symbol')} "
+                            "Pass a symbol with the kind required by the parameter modifier."
+                        ),
                     )
 
                 actual_type = actual_symbol.declared_type

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -753,7 +753,10 @@ def test_semantic_validator_reports_undefined_identifier_in_bind(debug_compiler_
             message="Undefined identifier 'missing_stream'.",
             line=12,
             column=3,
-            hint="Declare pipeline symbols before passing them to bind.",
+            hint=(
+                "Fix-it: declare `missing_stream` in the pipeline block. "
+                "Declare pipeline symbols before passing them to bind."
+            ),
         )
     ]
 
@@ -790,6 +793,7 @@ def test_semantic_validator_reports_bind_arity_and_type_errors(debug_compiler_mo
 
     assert validator.diagnostics[0].code == "LCK303"
     assert "expects 2 argument(s), but got 1" in validator.diagnostics[0].message
+    assert "Fix-it: use the full signature" in validator.diagnostics[0].hint
     assert validator.diagnostics[1].code == "LCK309"
     assert "kernel has no out parameter" in validator.diagnostics[1].message
     assert validator.diagnostics[2].code == "LCK305"
@@ -798,6 +802,11 @@ def test_semantic_validator_reports_bind_arity_and_type_errors(debug_compiler_mo
 
 def test_semantic_validator_reports_bind_unknown_target_code(debug_compiler_module):
     validator = debug_compiler_module.LockstepSemanticValidator()
+    validator.shaders = {
+        "KnownKernel": [
+            SemanticKernelParam(name="inp", declared_type="Vec3", modifier="in"),
+        ]
+    }
     validator._push_scope()
     validator._declare("s0", "Vec3", _ctx(), duplicate_code="LCK306", kind="stream")
 
@@ -812,6 +821,7 @@ def test_semantic_validator_reports_bind_unknown_target_code(debug_compiler_modu
     validator.visitBindStmt(bind_ctx)
 
     assert [diag.code for diag in validator.diagnostics] == ["LCK304"]
+    assert "Fix-it: replace 'MissingKernel' with 'KnownKernel'." in validator.diagnostics[0].hint
 
 
 def test_semantic_validator_bind_failure_modes_keep_dedicated_codes(debug_compiler_module):
@@ -943,6 +953,7 @@ def test_semantic_validator_reports_mismatched_target_and_out_argument(debug_com
 
     assert [diag.code for diag in validator.diagnostics] == ["LCK312"]
     assert "must match out argument 'other_stream'" in validator.diagnostics[0].message
+    assert "Fix-it: change the bind target to 'other_stream'" in validator.diagnostics[0].hint
 
 
 def test_semantic_validator_reports_bind_missing_out_parameter(debug_compiler_module):


### PR DESCRIPTION
### Motivation
- Provide more actionable diagnostics for complex `bind` failures so users get precise, repairable guidance instead of only descriptive errors.
- Surface likely fixes (e.g. replacing a mis-typed kernel name or declaring a missing pipeline symbol) to speed up debugging of bind statements.

### Description
- Added a `bind_fixit` helper and close-match lookup using `get_close_matches` to produce kernel-name suggestions and `Fix-it:` hint strings in `lockstep_compiler/visitors.py` for bind-related checks.
- Extended bind diagnostics to include actionable hints for unknown kernel targets, argument arity mismatches (with an example call signature), missing bind symbols, out-argument/target mismatches, output-kind mismatches, and modifier-kind mismatches.
- Tuned suggestion cutoff and assembled human-readable hint text so existing diagnostic messages remain intact while adding fix-it guidance.
- Updated `tests/test_debug_compiler.py` to assert the new `Fix-it:` hint content for the affected bind-focused test cases.

### Testing
- Ran `python -m py_compile lockstep_compiler/visitors.py` which succeeded.
- Ran `pytest -q -o addopts='' tests/test_debug_compiler.py -k "bind_"` and the relevant bind-focused tests passed (`8 passed` for the `bind_` selection and targeted selections also passed).
- Verified the smaller selection of bind-related tests also passed during iterative runs (all targeted tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a600ea63488328bbc84c09d2943f42)