### PR TITLE
Fix nested f-string hints in semantic visitor

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -532,7 +532,7 @@ def build_semantic_validator(base_visitor_cls):
                     ),
                     ctx=ctx,
                     hint=(
-                        f"{bind_fixit(f'use the full signature `{call_example}`')} "
+                        bind_fixit(f'use the full signature `{call_example}`') + " "
                         "Match bind arguments to the shader/filter parameter list."
                     ),
                 )
@@ -574,7 +574,7 @@ def build_semantic_validator(base_visitor_cls):
                             ),
                             ctx=ctx,
                             hint=(
-                                f"{bind_fixit(f'change the bind target to \'{out_arg_name}\' or the out argument to \'{target_name}\'')} "
+                                bind_fixit(f"change the bind target to '{out_arg_name}' or the out argument to '{target_name}'") + " "
                                 "Use the same symbol for assignment target and out argument."
                             ),
                         )
@@ -594,7 +594,7 @@ def build_semantic_validator(base_visitor_cls):
                             ),
                             ctx=ctx,
                             hint=(
-                                f"{bind_fixit(f"bind output to a '{expected_output_kind}' symbol")} "
+                                bind_fixit(f"bind output to a '{expected_output_kind}' symbol") + " "
                                 "Route kernel outputs to a stream-compatible bind target."
                             ),
                         )
@@ -619,7 +619,7 @@ def build_semantic_validator(base_visitor_cls):
                         message=f"Undefined identifier '{arg_name}'.",
                         ctx=ctx,
                         hint=(
-                            f"{bind_fixit(f'declare `{arg_name}` in the pipeline block')} "
+                            bind_fixit(f'declare `{arg_name}` in the pipeline block') + " "
                             "Declare pipeline symbols before passing them to bind."
                         ),
                     )
@@ -640,7 +640,7 @@ def build_semantic_validator(base_visitor_cls):
                         ),
                         ctx=ctx,
                         hint=(
-                            f"{bind_fixit(f'replace `{arg_name}` with a {expected_kind} symbol')} "
+                            bind_fixit(f'replace `{arg_name}` with a {expected_kind} symbol') + " "
                             "Pass a symbol with the kind required by the parameter modifier."
                         ),
                     )


### PR DESCRIPTION
### Motivation
- Nested/double f-strings in diagnostic hint expressions produced Python parse/build issues when the inner formatted text contained quotes or special characters, breaking builds.

### Description
- Replaced nested f-string interpolation wrappers in `lockstep_compiler/visitors.py` with direct concatenation using `bind_fixit(...) + " "` to preserve inner formatting without nesting.
- Updated all affected diagnostic hint expressions (several bind-related hints) to use the non-nested form so inner backticks, quotes, and slashes remain intact.

### Testing
- Ran `python -m py_compile lockstep_compiler/visitors.py`, which succeeded.
- Ran `python -m compileall -q lockstep_compiler`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a603cd457c832884d84ac45049ee7e)