### PR TITLE
Use semantic bind route IR in simulator

### DIFF
--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -67,6 +67,7 @@ def _compile_lockstep_with_dependencies(
         "accumulators": visitor.accumulators,
         "uniforms": visitor.uniforms,
         "bind_routes": visitor.bind_routes,
+        "bind_routes_ir": getattr(visitor, "bind_routes_ir", []),
     }
 
     return LockstepCompileResult(
@@ -80,6 +81,7 @@ def _compile_lockstep_with_dependencies(
             "accumulators": visitor.accumulators,
             "uniforms": visitor.uniforms,
             "bind_routes": visitor.bind_routes,
+            "bind_routes_ir": getattr(visitor, "bind_routes_ir", []),
             "optimized_bind_routes": bind_optimization["optimized_bind_routes"],
             "fused_bind_groups": bind_optimization["fused_groups"],
         },        

--- a/lockstep_compiler/simulator.py
+++ b/lockstep_compiler/simulator.py
@@ -1,20 +1,8 @@
 import json
-import re
 from dataclasses import dataclass
 from typing import Any
 
 from .compiler import compile_lockstep
-
-
-_BIND_ROUTE_PATTERN = re.compile(
-    r"^\s*(?P<target>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
-    r"(?P<kernel>[A-Za-z_][A-Za-z0-9_]*)\s*\(\s*(?P<args>[^)]*)\s*\)\s*;\s*$"
-)
-_FOLD_ROUTE_PATTERN = re.compile(
-    r"^\s*uniform\s+(?P<type>[A-Za-z_][A-Za-z0-9_]*)\s+"
-    r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*fold\s+"
-    r"(?P<operator>sum|avg|min|max)\s*\(\s*(?P<source>[A-Za-z_][A-Za-z0-9_]*)\s*\)\s*;\s*$"
-)
 
 
 @dataclass
@@ -24,33 +12,6 @@ class RouteSimulation:
     input_count: int
     output_count: int
     notes: str | None = None
-
-
-def _parse_bind_route(route: str) -> dict[str, Any] | None:
-    match = _BIND_ROUTE_PATTERN.match(route)
-    if match is None:
-        return None
-
-    args = [arg.strip() for arg in match.group("args").split(",") if arg.strip()]
-    return {
-        "kind": "kernel",
-        "target": match.group("target"),
-        "kernel": match.group("kernel"),
-        "args": args,
-    }
-
-
-def _parse_fold_route(route: str) -> dict[str, Any] | None:
-    match = _FOLD_ROUTE_PATTERN.match(route)
-    if match is None:
-        return None
-    return {
-        "kind": "fold",
-        "uniform_type": match.group("type"),
-        "uniform_name": match.group("name"),
-        "operator": match.group("operator"),
-        "source": match.group("source"),
-    }
 
 
 def _fold_values(operator: str, values: list[Any]) -> Any:
@@ -66,6 +27,10 @@ def _fold_values(operator: str, values: list[Any]) -> Any:
     if operator == "max":
         return max(numeric)
     return None
+
+
+def _route_text(route_ir: dict[str, Any]) -> str:
+    return str(route_ir.get("route", ""))
 
 
 def simulate_pipeline_entities(
@@ -92,24 +57,30 @@ def simulate_pipeline_entities(
     kernels.update({flt["name"]: {"kind": "filter", "params": flt.get("params", [])} for flt in entities.get("filters", [])})
 
     routes: list[RouteSimulation] = []
-    for route_text in entities.get("bind_routes", []):
-        fold_route = _parse_fold_route(route_text)
-        if fold_route is not None:
-            source_values = accumulators.get(fold_route["source"], [])
-            uniforms[fold_route["uniform_name"]] = _fold_values(fold_route["operator"], source_values)
+    bind_routes_ir = entities.get("bind_routes_ir", [])
+
+    for route_ir in bind_routes_ir:
+        route_kind = route_ir.get("kind")
+        route_text = _route_text(route_ir)
+
+        if route_kind == "fold":
+            source_values = accumulators.get(str(route_ir.get("source", "")), [])
+            uniform_name = route_ir.get("uniform_name")
+            if isinstance(uniform_name, str) and uniform_name:
+                uniforms[uniform_name] = _fold_values(str(route_ir.get("operator", "")), source_values)
             routes.append(RouteSimulation(route=route_text, kind="fold", input_count=len(source_values), output_count=1))
             continue
 
-        kernel_route = _parse_bind_route(route_text)
-        if kernel_route is not None:
-            kernel = kernels.get(kernel_route["kernel"])
+        if route_kind == "kernel":
+            kernel = kernels.get(str(route_ir.get("kernel", "")))
             if kernel is None:
                 routes.append(RouteSimulation(route=route_text, kind="kernel", input_count=0, output_count=0, notes="Unknown kernel"))
                 continue
 
             source_count = 0
             rows: list[Any] = []
-            for index, arg_name in enumerate(kernel_route["args"]):
+            args = route_ir.get("args") if isinstance(route_ir.get("args"), list) else []
+            for index, arg_name in enumerate(args):
                 params = kernel["params"]
                 if index >= len(params):
                     break
@@ -121,13 +92,14 @@ def simulate_pipeline_entities(
             if kernel["kind"] == "filter":
                 output_rows = [row for row in rows if not isinstance(row, dict) or row.get("_keep", True)]
             else:
-                output_rows = [{"_source": row, "_kernel": kernel_route["kernel"]} for row in rows]
+                output_rows = [{"_source": row, "_kernel": route_ir.get("kernel")} for row in rows]
 
-            if kernel_route["target"] in streams:
-                cap = streams[kernel_route["target"]]["capacity"]
-                streams[kernel_route["target"]]["rows"] = output_rows[:cap]
+            target = route_ir.get("target")
+            if isinstance(target, str) and target in streams:
+                cap = streams[target]["capacity"]
+                streams[target]["rows"] = output_rows[:cap]
 
-            for index, arg_name in enumerate(kernel_route["args"]):
+            for index, arg_name in enumerate(args):
                 params = kernel["params"]
                 if index >= len(params):
                     break
@@ -137,7 +109,18 @@ def simulate_pipeline_entities(
             routes.append(RouteSimulation(route=route_text, kind=kernel["kind"], input_count=source_count, output_count=len(output_rows)))
             continue
 
-        routes.append(RouteSimulation(route=route_text, kind="unknown", input_count=0, output_count=0, notes="Unable to parse bind route"))
+        routes.append(RouteSimulation(route=route_text, kind="unknown", input_count=0, output_count=0, notes="Unknown bind route IR kind"))
+
+    if entities.get("bind_routes") and not bind_routes_ir:
+        routes.append(
+            RouteSimulation(
+                route="",
+                kind="unknown",
+                input_count=0,
+                output_count=0,
+                notes="Missing bind_routes_ir; simulator requires semantic bind route IR",
+            )
+        )
 
     return {
         "streams": {name: spec["rows"] for name, spec in streams.items()},

--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -59,6 +59,7 @@ def build_debug_visitor(base_visitor_cls):
             self.accumulators = []
             self.uniforms = []
             self.bind_routes = []
+            self.bind_routes_ir = []
             self.diagnostics: list[LockstepDiagnostic] = []
             self._seen_structs = set()
             self._seen_shaders = set()
@@ -271,8 +272,36 @@ def build_debug_visitor(base_visitor_cls):
                 if self.normalize_bind_routes:
                     route = " ".join(route.split())
                 self.bind_routes.append(route)
+                self.bind_routes_ir.append(self._build_bind_route_ir(stmt, route))
                 self._print(f"       {route}")
             return self.visitChildren(ctx)
+
+        def _build_bind_route_ir(self, stmt_ctx, route_text: str) -> dict[str, Any]:
+            id_tokens_getter = getattr(stmt_ctx, "ID", None)
+            id_tokens = id_tokens_getter() if callable(id_tokens_getter) else []
+            fold_operator_getter = getattr(stmt_ctx, "foldOperator", None)
+            fold_operator = fold_operator_getter() if callable(fold_operator_getter) else None
+            if fold_operator is not None and len(id_tokens) >= 2:
+                return {
+                    "kind": "fold",
+                    "uniform_type": stmt_ctx.typeName().getText() if getattr(stmt_ctx, "typeName", None) else "",
+                    "uniform_name": id_tokens[0].getText(),
+                    "operator": fold_operator.getText(),
+                    "source": id_tokens[1].getText(),
+                    "route": route_text,
+                }
+
+            if len(id_tokens) >= 2:
+                args = [token.getText() for token in id_tokens[2:]]
+                return {
+                    "kind": "kernel",
+                    "target": id_tokens[0].getText(),
+                    "kernel": id_tokens[1].getText(),
+                    "args": args,
+                    "route": route_text,
+                }
+
+            return {"kind": "unknown", "route": route_text}
 
     return LockstepDebugVisitor
 

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -83,6 +83,7 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
         "accumulators": [],
         "uniforms": [],
         "bind_routes": [],
+        "bind_routes_ir": [],
         "optimized_bind_routes": [],
         "fused_bind_groups": [],
     }

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -34,6 +34,23 @@ def test_simulate_pipeline_entities_tracks_route_cardinality_and_fold():
             "out_stream = Apply(in_stream, out_stream, energy);",
             "uniform float total = fold sum(energy);",
         ],
+        "bind_routes_ir": [
+            {
+                "kind": "kernel",
+                "target": "out_stream",
+                "kernel": "Apply",
+                "args": ["in_stream", "out_stream", "energy"],
+                "route": "out_stream = Apply(in_stream, out_stream, energy);",
+            },
+            {
+                "kind": "fold",
+                "uniform_type": "float",
+                "uniform_name": "total",
+                "operator": "sum",
+                "source": "energy",
+                "route": "uniform float total = fold sum(energy);",
+            },
+        ],
     }
 
     simulation = simulate_pipeline_entities(


### PR DESCRIPTION
### Motivation

- The simulator parsed bind-route source strings with fragile regexes which break on newlines or complex expressions, so it must consume a resolved semantic IR instead. 

### Description

- The debug visitor now emits structured bind-route IR in `bind_routes_ir` alongside the existing textual `bind_routes` by adding `_build_bind_route_ir` and populating `self.bind_routes_ir` for each bind statement. 
- The compiler includes `bind_routes_ir` in the returned `entities` and uses `getattr(..., [])` to remain compatible with stub/custom visitors that do not provide the field. 
- The simulator was rewritten to consume `entities["bind_routes_ir"]` instead of parsing strings: it handles `kernel` and `fold` route objects directly and updates streams/accumulators/uniforms accordingly, with a clear fallback note when only legacy `bind_routes` exist. 
- Tests were updated to reflect the new entity shape: `tests/test_simulator.py` and `tests/test_compiler_api.py` now expect/contain `bind_routes_ir` samples; debugging visitor behavior tests remain supported. 

### Testing

- Ran the modified tests with `PYTHONPATH=. pytest -q -o addopts='' tests/test_simulator.py tests/test_compiler_api.py tests/test_debug_compiler.py` and the targeted tests passed. 
- Executed the full test suite with `PYTHONPATH=. pytest -q -o addopts=''` and verified all unit tests passed (`80 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6fb5c77608328b91e251f36743e3e)