### PR TITLE
Tighten semantic typing for mixed numerics and uninitialized locals

### DIFF
--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -41,6 +41,8 @@ SEMANTIC_DIAGNOSTIC_CODES = {
     "unused_symbol": "LCK421",
     "unbound_pipeline_resource": "LCK422",
     "cannot_infer_type": "LCK423",
+    "implicit_numeric_widening": "LCK424",
+    "use_before_definition": "LCK425",
 }
 
 
@@ -286,6 +288,7 @@ def build_semantic_validator(base_visitor_cls):
             self.scopes: list[dict[str, SemanticSymbol]] = []
             self.scope_usages: list[dict[str, int]] = []
             self.scope_declaration_ctxs: list[dict[str, Any]] = []
+            self.scope_assignments: list[dict[str, bool]] = []
             self.shaders: dict[str, list[SemanticKernelParam]] = {}
             self.filters: dict[str, list[SemanticKernelParam]] = {}
             self.pure_functions: dict[str, dict[str, Any]] = {}
@@ -307,6 +310,7 @@ def build_semantic_validator(base_visitor_cls):
             self.scopes.append({})
             self.scope_usages.append({})
             self.scope_declaration_ctxs.append({})
+            self.scope_assignments.append({})
 
         def _pop_scope(self):
             if self.scopes:
@@ -328,8 +332,18 @@ def build_semantic_validator(base_visitor_cls):
                 self.scopes.pop()
                 self.scope_usages.pop()
                 self.scope_declaration_ctxs.pop()
+                self.scope_assignments.pop()
 
-        def _declare(self, name: str, declared_type: str, ctx, *, duplicate_code: str, kind: str = "symbol"):
+        def _declare(
+            self,
+            name: str,
+            declared_type: str,
+            ctx,
+            *,
+            duplicate_code: str,
+            kind: str = "symbol",
+            assigned: bool = True,
+        ):
             if not self.scopes:
                 self._push_scope()
             current_scope = self.scopes[-1]
@@ -345,7 +359,20 @@ def build_semantic_validator(base_visitor_cls):
             current_scope[name] = SemanticSymbol(name=name, declared_type=declared_type, kind=kind)
             self.scope_usages[-1][name] = 0
             self.scope_declaration_ctxs[-1][name] = ctx
+            self.scope_assignments[-1][name] = assigned
             return True
+
+        def _set_symbol_assigned(self, name: str):
+            for scope, assignments in zip(reversed(self.scopes), reversed(self.scope_assignments)):
+                if name in scope:
+                    assignments[name] = True
+                    return
+
+        def _is_symbol_assigned(self, name: str) -> bool:
+            for scope, assignments in zip(reversed(self.scopes), reversed(self.scope_assignments)):
+                if name in scope:
+                    return assignments.get(name, False)
+            return False
 
         def _mark_symbol_used(self, name: str):
             for scope, usage in zip(reversed(self.scopes), reversed(self.scope_usages)):
@@ -418,7 +445,7 @@ def build_semantic_validator(base_visitor_cls):
             target[name] = params
             return name, params
 
-        def _check_expression_identifier(self, name: str, ctx):
+        def _check_expression_identifier(self, name: str, ctx, *, require_assigned: bool = True):
             symbol = self._lookup(name)
             if symbol is None:
                 self._add_diagnostic(
@@ -427,6 +454,15 @@ def build_semantic_validator(base_visitor_cls):
                     message=f"Undefined identifier '{name}'.",
                     ctx=ctx,
                     hint="Declare the identifier in scope before using it.",
+                )
+                return None
+            if require_assigned and symbol.kind == "local" and not self._is_symbol_assigned(name):
+                self._add_diagnostic(
+                    severity="error",
+                    code=SEMANTIC_DIAGNOSTIC_CODES["use_before_definition"],
+                    message=f"Local variable '{name}' is used before it is assigned.",
+                    ctx=ctx,
+                    hint="Assign a value to the variable before reading it.",
                 )
                 return None
             self._mark_symbol_used(name)
@@ -450,13 +486,17 @@ def build_semantic_validator(base_visitor_cls):
                 index += 1
             return tokens or [id_tokens]
 
-        def _resolve_lvalue_type(self, ctx):
+        def _resolve_lvalue_type(self, ctx, *, for_write: bool = False):
             id_tokens = self._collect_id_tokens(ctx)
             if not id_tokens:
                 return None
 
             root_identifier = id_tokens[0].getText()
-            current_type = self._check_expression_identifier(root_identifier, ctx)
+            current_type = self._check_expression_identifier(
+                root_identifier,
+                ctx,
+                require_assigned=not for_write,
+            )
             if current_type is None:
                 return None
 
@@ -870,7 +910,18 @@ def build_semantic_validator(base_visitor_cls):
                     return None
                 if len(known) != len(operand_contexts):
                     return None
-                return "float" if "float" in known else "int"
+                if "int" in known and "float" in known:
+                    self._add_diagnostic(
+                        severity="error",
+                        code=SEMANTIC_DIAGNOSTIC_CODES["implicit_numeric_widening"],
+                        message=(
+                            f"Operator '{operator}' mixes int and float operands without an explicit cast."
+                        ),
+                        ctx=ctx,
+                        hint="Use explicit casts so numeric widening is intentional and target-compatible.",
+                    )
+                    return None
+                return known[0] if known else None
 
             def _resolve_boolean_sequence(operator: str, operand_contexts: list[Any]):
                 operand_types = [self._resolve_expr_type(operand_ctx) for operand_ctx in operand_contexts]
@@ -1076,7 +1127,14 @@ def build_semantic_validator(base_visitor_cls):
                     return self.visitChildren(ctx)
                 declared_type = initializer_type
 
-            self._declare(symbol_name, declared_type, ctx, duplicate_code="LCK306", kind="local")
+            self._declare(
+                symbol_name,
+                declared_type,
+                ctx,
+                duplicate_code="LCK306",
+                kind="local",
+                assigned=has_initializer,
+            )
 
             if has_initializer:
                 if initializer_type is not None and initializer_type != declared_type:
@@ -1096,7 +1154,7 @@ def build_semantic_validator(base_visitor_cls):
             lvalue_ctx = ctx.lvalue() if hasattr(ctx, "lvalue") and callable(ctx.lvalue) else None
             expr_ctx = ctx.expr() if hasattr(ctx, "expr") and callable(ctx.expr) else None
 
-            lvalue_type = self._resolve_lvalue_type(lvalue_ctx) if lvalue_ctx is not None else None
+            lvalue_type = self._resolve_lvalue_type(lvalue_ctx, for_write=True) if lvalue_ctx is not None else None
             expr_type = self._resolve_expr_type(expr_ctx)
 
             if lvalue_type is not None and expr_type is not None and lvalue_type != expr_type:
@@ -1110,6 +1168,11 @@ def build_semantic_validator(base_visitor_cls):
                     ctx=ctx,
                     hint="Assign expressions whose type matches the lvalue declaration.",
                 )
+
+            if lvalue_ctx is not None:
+                id_tokens = self._collect_id_tokens(lvalue_ctx)
+                if id_tokens:
+                    self._set_symbol_assigned(id_tokens[0].getText())
 
             return self.visitChildren(ctx)
 

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1981,14 +1981,73 @@ def test_semantic_validator_accepts_matching_assignment_initializer_and_return(d
     assert validator.diagnostics == []
 
 
-def test_semantic_validator_infers_arithmetic_and_relational_expression_types(debug_compiler_module):
+def test_semantic_validator_rejects_implicit_numeric_widening(debug_compiler_module):
     validator = debug_compiler_module.LockstepSemanticValidator()
 
     add_ctx = _ctx(mulExpr=lambda: [_ctx(declared_type="int"), _ctx(declared_type="float")], getChild=lambda i: _token("+"))
-    rel_ctx = _ctx(addExpr=lambda: [add_ctx, _ctx(declared_type="float")], getChild=lambda i: _token(">"))
 
-    assert validator._resolve_expr_type(add_ctx) == "float"
-    assert validator._resolve_expr_type(rel_ctx) == "bool"
+    assert validator._resolve_expr_type(add_ctx) is None
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK424",
+            message="Operator '+' mixes int and float operands without an explicit cast.",
+            line=0,
+            column=0,
+            hint="Use explicit casts so numeric widening is intentional and target-compatible.",
+        )
+    ]
+
+
+def test_semantic_validator_reports_use_before_definition(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator._push_scope()
+
+    validator.visitVarDecl(
+        _ctx(
+            start_line=90,
+            start_col=2,
+            ID=lambda: _token("count"),
+            typeName=lambda: _token("int"),
+            expr=lambda: None,
+        )
+    )
+
+    validator.visitPrimaryExpr(_ctx(start_line=91, start_col=4, ID=lambda: _token("count"), exprList=lambda: None))
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK425",
+            message="Local variable 'count' is used before it is assigned.",
+            line=91,
+            column=4,
+            hint="Assign a value to the variable before reading it.",
+        )
+    ]
+
+
+def test_semantic_validator_assignment_defines_local(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator._push_scope()
+
+    validator.visitVarDecl(
+        _ctx(
+            ID=lambda: _token("count"),
+            typeName=lambda: _token("int"),
+            expr=lambda: None,
+        )
+    )
+
+    validator.visitAssignStmt(
+        _ctx(
+            lvalue=lambda: _ctx(ID=lambda: [_token("count")]),
+            expr=lambda: _ctx(declared_type="int"),
+        )
+    )
+
+    validator.visitPrimaryExpr(_ctx(ID=lambda: _token("count"), exprList=lambda: None))
+
     assert validator.diagnostics == []
 
 


### PR DESCRIPTION
### Motivation
- The numeric-type inference was too permissive: mixed `int`/`float` arithmetic silently widened to `float` instead of requiring an explicit cast.
- The validator did not track whether local variables were assigned before they were read, allowing use-before-definition to go undetected.

### Description
- Added two new diagnostics: `LCK424` (`implicit_numeric_widening`) and `LCK425` (`use_before_definition`).
- Tracked per-scope assignment state with `scope_assignments`, added helpers `_set_symbol_assigned` and `_is_symbol_assigned`, and threaded this through `_push_scope`, `_pop_scope`, and `_declare` (now accepts `assigned` flag).
- Enforced use-before-assignment by changing `_check_expression_identifier` to accept `require_assigned` and emit `LCK425` when a local is read before being assigned, and made `_resolve_lvalue_type` accept `for_write` so writes don't trigger that check.
- Tightened numeric sequence resolution in `_resolve_numeric_sequence` to reject mixed `int`/`float` operands (emit `LCK424`) instead of implicitly widening, and mark lvalue roots as assigned in `visitAssignStmt` after a successful assignment.
- Updated tests in `tests/test_debug_compiler.py` to replace the previous implicit-widening expectation with a rejection and to add tests for use-before-definition and that assignment makes a local readable afterwards.

### Testing
- Ran the focused test file with `pytest -q -o addopts='' tests/test_debug_compiler.py`, which passed (`74 passed`).
- Attempted a full `pytest` run in this environment but collection failed due to local import/test environment differences (`ModuleNotFoundError: No module named 'lockstep_compiler'`), so full-suite verification was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6fb8d64848328855a697571343d06)