### PR TITLE
Support shared struct/pure libraries for pipeline compilation

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -10,6 +10,22 @@ from .simulator import parse_simulation_inputs, simulate_pipeline_entities
 from .formatter import format_lockstep_source
 
 
+def _read_source_file(path: Path, *, stderr) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(f"Unable to read '{path}': file not found.", file=stderr)
+    except PermissionError as err:
+        reason = err.strerror or "permission denied"
+        print(f"Unable to read '{path}': {reason}.", file=stderr)
+    except UnicodeDecodeError as err:
+        print(
+            f"Unable to read '{path}': invalid UTF-8 ({err.reason}).",
+            file=stderr,
+        )
+    return None
+
+
 def build_arg_parser():
     parser = argparse.ArgumentParser(
         description="Debug parser for Lockstep source files."
@@ -36,6 +52,13 @@ def build_arg_parser():
         help="Print detailed exception diagnostics and traceback on failures.",
     )
     parser.add_argument(
+        "--lib",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Path to a Lockstep source library file containing shared structs/pure functions.",
+    )
+    parser.add_argument(
         "--simulate",
         action="store_true",
         help="Simulate bind-route execution on small in-memory datasets.",
@@ -57,23 +80,18 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
 
     if args.path:
         source_path = Path(args.path)
-        try:
-            source = source_path.read_text(encoding="utf-8")
-        except FileNotFoundError:
-            print(f"Unable to read '{source_path}': file not found.", file=stderr)
-            return 1
-        except PermissionError as err:
-            reason = err.strerror or "permission denied"
-            print(f"Unable to read '{source_path}': {reason}.", file=stderr)
-            return 1
-        except UnicodeDecodeError as err:
-            print(
-                f"Unable to read '{source_path}': invalid UTF-8 ({err.reason}).",
-                file=stderr,
-            )
+        source = _read_source_file(source_path, stderr=stderr)
+        if source is None:
             return 1
     else:
         source = stdin.read()
+
+    library_sources = []
+    for library_path in args.lib:
+        library_source = _read_source_file(Path(library_path), stderr=stderr)
+        if library_source is None:
+            return 1
+        library_sources.append(library_source)
 
     if args.format:
         print(format_lockstep_source(source), end="", file=stdout)
@@ -92,6 +110,7 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
         return 1
 
     supports_verbose = False
+    supports_library_sources = False
     try:
         signature = inspect.signature(compiler)
     except (TypeError, ValueError):
@@ -103,10 +122,21 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
             or parameter.name == "verbose"
             for parameter in signature.parameters.values()
         )
+        supports_library_sources = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            or parameter.name == "library_sources"
+            for parameter in signature.parameters.values()
+        )
+
+    compile_kwargs = {}
+    if supports_verbose:
+        compile_kwargs["verbose"] = False
+    if supports_library_sources:
+        compile_kwargs["library_sources"] = library_sources
 
     try:
-        if supports_verbose:
-            result = compiler(source, verbose=False)
+        if compile_kwargs:
+            result = compiler(source, **compile_kwargs)
         else:
             result = compiler(source)
     except LockstepCompileError as err:

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -128,6 +128,7 @@ def compile_lockstep(
     source_code: str,
     *,
     verbose: bool = True,
+    library_sources: list[str] | None = None,
     lexer_cls=None,
     parser_cls=None,
     visitor_cls=None,
@@ -135,6 +136,9 @@ def compile_lockstep(
     token_stream_cls=CommonTokenStream,
     debug_visitor_cls=None,
 ) -> LockstepCompileResult:
+    if library_sources:
+        source_code = "\n\n".join([*library_sources, source_code])
+
     if lexer_cls is None or parser_cls is None or visitor_cls is None:
         default_lexer_cls, default_parser_cls, default_visitor_cls = (
             _load_default_parser_classes()

--- a/tests/test_cli_libraries.py
+++ b/tests/test_cli_libraries.py
@@ -1,0 +1,50 @@
+import io
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from lockstep_compiler.cli import run_cli
+
+
+def test_run_cli_passes_library_sources_to_compiler(tmp_path):
+    library = tmp_path / "math.lock"
+    library.write_text("pure float identity(float v) { return v; }", encoding="utf-8")
+
+    captured = {}
+
+    def fake_compiler(source, *, verbose=False, library_sources=None):
+        captured["source"] = source
+        captured["verbose"] = verbose
+        captured["library_sources"] = library_sources
+        return {"streams": [], "accumulators": [], "uniforms": [], "shaders": [], "filters": [], "bind_routes": []}
+
+    exit_code = run_cli(
+        ["--lib", str(library), "--simulate"],
+        stdin=io.StringIO("pipeline Main { bind { } }"),
+        stdout=io.StringIO(),
+        compiler=fake_compiler,
+    )
+
+    assert exit_code == 0
+    assert captured["source"] == "pipeline Main { bind { } }"
+    assert captured["verbose"] is False
+    assert captured["library_sources"] == ["pure float identity(float v) { return v; }"]
+
+
+def test_run_cli_reports_missing_library_file(tmp_path):
+    missing = tmp_path / "missing.lock"
+    stderr = io.StringIO()
+
+    exit_code = run_cli(
+        ["--lib", str(missing)],
+        stdin=io.StringIO("pipeline Main { bind { } }"),
+        stdout=io.StringIO(),
+        stderr=stderr,
+        compiler=lambda source: source,
+    )
+
+    assert exit_code == 1
+    assert f"Unable to read '{missing}': file not found." in stderr.getvalue()

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -153,3 +153,28 @@ def test_load_default_parser_classes_is_cached(monkeypatch):
 
     assert first == second
     assert import_count == first_import_count
+
+
+def test_compile_lockstep_accepts_library_sources(monkeypatch):
+    captured = {}
+
+    def fake_compile(source_code, **kwargs):
+        captured["source_code"] = source_code
+        captured["kwargs"] = kwargs
+        return "ok"
+
+    monkeypatch.setattr(compiler_module, "_compile_lockstep_with_dependencies", fake_compile)
+    monkeypatch.setattr(
+        compiler_module,
+        "_load_default_parser_classes",
+        lambda: ("Lexer", "Parser", "Visitor"),
+    )
+
+    result = compiler_module.compile_lockstep(
+        "pipeline Main { bind { } }",
+        library_sources=["struct Vec { float x; };", "pure float id(float v) { return v; }"],
+    )
+
+    assert result == "ok"
+    assert captured["source_code"].startswith("struct Vec { float x; };\n\npure float id(float v) { return v; }")
+    assert captured["source_code"].endswith("pipeline Main { bind { } }")


### PR DESCRIPTION
### Motivation
- Users should be able to keep reusable `struct` and `pure` function definitions in separate files and compile pipelines together with those library fragments. 
- The CLI should provide an ergonomic way to load repeatable library files and forward them to compilers that accept library inputs while remaining backward-compatible with simpler compile call signatures.

### Description
- Add an optional `library_sources: list[str] | None` parameter to `compile_lockstep` and, when provided, prepend joined library sources to the pipeline source before compilation using `"\n\n".join(...)`.
- Add a reusable `_read_source_file` helper to `lockstep_compiler/cli.py` and a repeatable `--lib PATH` CLI option that loads library files into a `library_sources` list.
- Detect whether the provided `compiler` supports `library_sources` (and `verbose`) via `inspect.signature` and forward `library_sources` only when the compiler advertises the parameter, preserving backwards compatibility.
- Add tests to cover CLI library passing and missing-file error handling in `tests/test_cli_libraries.py` and an API test `test_compile_lockstep_accepts_library_sources` in `tests/test_compiler_api.py`.

### Testing
- Ran `pytest -q tests/test_cli_libraries.py tests/test_compiler_api.py tests/test_cli_format.py tests/test_simulator.py`, and all tests completed successfully (all tests passed).
- Installed required runtime/test dependencies with `pip install llvmlite antlr4-python3-runtime pytest-cov`, which completed successfully and allowed the test run to proceed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a710ff9a208328b78fa795cb14d123)