### PR TITLE
Lower bind routes into executable Lockstep_Tick IR

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -272,6 +272,7 @@ def emit_llvm_ir(entities: dict[str, Any]) -> str:
     accumulators = entities.get("accumulators", [])
     uniforms = entities.get("uniforms", [])
     bind_routes = entities.get("bind_routes", [])
+    bind_routes_ir = entities.get("bind_routes_ir", [])
 
     module = ir.Module(name="lockstep")
     module.source_filename = "lockstep"
@@ -322,24 +323,73 @@ def emit_llvm_ir(entities: dict[str, Any]) -> str:
         fn = function_map[f"filter_{_sanitize_symbol(flt['name'])}"]
         lowerer.lower_function(fn, flt.get("body", []), ir.VoidType())
 
+    globals_by_name: dict[str, ir.GlobalVariable] = {}
+
     for stream in streams:
         gv = ir.GlobalVariable(module, lowerer._llvm_type(stream["type"], known_structs), name=f"stream_{_sanitize_symbol(stream['name'])}")
         gv.linkage = "external"
+        globals_by_name[stream["name"]] = gv
     for accum in accumulators:
         gv = ir.GlobalVariable(module, lowerer._llvm_type(accum["type"], known_structs), name=f"accum_{_sanitize_symbol(accum['name'])}")
         gv.linkage = "external"
+        globals_by_name[accum["name"]] = gv
     for uniform in uniforms:
         gv = ir.GlobalVariable(module, lowerer._llvm_type(uniform["type"], known_structs), name=f"uniform_{_sanitize_symbol(uniform['name'])}")
         gv.linkage = "external"
+        globals_by_name[uniform["name"]] = gv
+
+    kernel_params = {
+        shader["name"]: shader.get("params", [])
+        for shader in shaders
+    }
+    kernel_params.update({flt["name"]: flt.get("params", []) for flt in filters})
 
     tick = ir.Function(module, ir.FunctionType(ir.VoidType(), []), name="Lockstep_Tick")
     tick_entry = tick.append_basic_block("entry")
     tick_builder = ir.IRBuilder(tick_entry)
-    for route in bind_routes:
-        asm_ty = ir.FunctionType(ir.VoidType(), [])
-        escaped = str(route).replace("\\", "\\\\").replace('"', '\\"')
-        asm = ir.InlineAsm(asm_ty, f"; bind: {escaped}", "", side_effect=True)
-        tick_builder.call(asm, [])
+    if bind_routes_ir:
+        for route in bind_routes_ir:
+            if route.get("kind") == "kernel":
+                kernel_name = str(route.get("kernel", ""))
+                callee = function_map.get(f"shader_{_sanitize_symbol(kernel_name)}") or function_map.get(
+                    f"filter_{_sanitize_symbol(kernel_name)}"
+                )
+                if callee is None:
+                    continue
+
+                args = route.get("args", []) if isinstance(route.get("args", []), list) else []
+                params = kernel_params.get(kernel_name, [])
+                target_name = str(route.get("target", ""))
+                call_args: list[ir.Value] = []
+                for idx, param in enumerate(callee.args):
+                    arg_name = args[idx] if idx < len(args) else None
+                    source_name = arg_name if isinstance(arg_name, str) and arg_name else None
+                    if source_name is None and idx < len(params) and params[idx].get("modifier") == "out":
+                        source_name = target_name
+
+                    global_var = globals_by_name.get(source_name) if source_name else None
+                    if global_var is not None and global_var.type.pointee == param.type:
+                        call_args.append(tick_builder.load(global_var, name=f"load_{_sanitize_symbol(source_name)}"))
+                    else:
+                        call_args.append(ir.Constant(param.type, None))
+                tick_builder.call(callee, call_args)
+                continue
+
+            if route.get("kind") == "fold":
+                source_name = route.get("source")
+                uniform_name = route.get("uniform_name")
+                source_var = globals_by_name.get(source_name) if isinstance(source_name, str) else None
+                target_var = globals_by_name.get(uniform_name) if isinstance(uniform_name, str) else None
+                if source_var is None or target_var is None or source_var.type != target_var.type:
+                    continue
+                folded_value = tick_builder.load(source_var, name=f"fold_{_sanitize_symbol(source_name)}")
+                tick_builder.store(folded_value, target_var)
+    else:
+        for route in bind_routes:
+            asm_ty = ir.FunctionType(ir.VoidType(), [])
+            escaped = str(route).replace("\\", "\\\\").replace('"', '\\"')
+            asm = ir.InlineAsm(asm_ty, f"; bind: {escaped}", "", side_effect=True)
+            tick_builder.call(asm, [])
     tick_builder.ret_void()
 
     return str(module)

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -96,26 +96,64 @@ def test_emit_llvm_ir_generates_expected_declarations():
     llvm_ir = emit_llvm_ir(
         {
             "structs": ["Vec3"],
-            "shaders": [{"name": "ApplyGravity"}],
+            "shaders": [{"name": "ApplyGravity", "params": [{"modifier": "in", "type": "Vec3", "name": "src"}, {"modifier": "out", "type": "Vec3", "name": "dst"}, {"modifier": "accum", "type": "float", "name": "energy"}, {"modifier": "uniform", "type": "float", "name": "dt"}]}],
             "filters": [{"name": "Cull"}],
             "pure_functions": [{"name": "mix", "return_type": "float", "params": [], "body": ["returnmix(0.0,1.0,step(0.5,1.0));"]}],
             "streams": [{"name": "raw_positions", "type": "Vec3"}],
             "accumulators": [{"name": "energy", "type": "float"}],
             "uniforms": [{"name": "dt", "type": "float", "initializer": "0.016"}],
             "bind_routes": ["out = ApplyGravity(inp, out, energy, dt);"],
+            "bind_routes_ir": [
+                {
+                    "kind": "kernel",
+                    "target": "raw_positions",
+                    "kernel": "ApplyGravity",
+                    "args": ["raw_positions", "raw_positions", "energy", "dt"],
+                    "route": "raw_positions = ApplyGravity(raw_positions, raw_positions, energy, dt);",
+                }
+            ],
         }
     )
 
     assert "%\"struct.Vec3\" = type {i8}" in llvm_ir
     assert "define float @\"pure_mix\"()" in llvm_ir
-    assert "define void @\"shader_ApplyGravity\"()" in llvm_ir
+    assert 'define void @"shader_ApplyGravity"(%"struct.Vec3"' in llvm_ir
     assert "define void @\"filter_Cull\"()" in llvm_ir
     assert '@"stream_raw_positions" = external global %"struct.Vec3"' in llvm_ir
     assert '@"accum_energy" = external global float' in llvm_ir
     assert '@"uniform_dt" = external global float' in llvm_ir
-    assert '; bind: out = ApplyGravity(inp, out, energy, dt);' in llvm_ir
+    assert 'call void @"shader_ApplyGravity"' in llvm_ir
+    assert 'load %"struct.Vec3", %"struct.Vec3"* @"stream_raw_positions"' in llvm_ir
     assert "fmul float" in llvm_ir
     assert "uitofp i1" in llvm_ir
+
+
+def test_emit_llvm_ir_lowers_fold_routes_in_tick():
+    llvm_ir = emit_llvm_ir(
+        {
+            "structs": [],
+            "shaders": [],
+            "filters": [],
+            "pure_functions": [],
+            "streams": [],
+            "accumulators": [{"name": "energy", "type": "float"}],
+            "uniforms": [{"name": "total", "type": "float", "initializer": None}],
+            "bind_routes": ["uniform float total = fold sum(energy);"],
+            "bind_routes_ir": [
+                {
+                    "kind": "fold",
+                    "uniform_type": "float",
+                    "uniform_name": "total",
+                    "operator": "sum",
+                    "source": "energy",
+                    "route": "uniform float total = fold sum(energy);",
+                }
+            ],
+        }
+    )
+
+    assert 'load float, float* @"accum_energy"' in llvm_ir
+    assert 'store float %"fold_energy", float* @"uniform_total"' in llvm_ir
 
 
 def test_cli_main_wires_default_compiler(monkeypatch):


### PR DESCRIPTION
### Motivation
- Replace placeholder inline-asm bind comments with real lowering so the backend emits executable `Lockstep_Tick` instructions when semantic bind-route IR (`bind_routes_ir`) is available.
- Enable the backend to wire stream/accumulator/uniform globals into kernel calls and to materialize fold results into uniforms for accurate simulation and downstream codegen.

### Description
- Update `emit_llvm_ir` in `lockstep_compiler/codegen.py` to consume `bind_routes_ir` and build a `globals_by_name` table of `stream_*/accum_*/uniform_*` globals for argument resolution.
- Emit concrete kernel calls for `kernel` routes by locating the corresponding `shader_*`/`filter_*` function, loading matching globals for `in`/`accum`/`uniform` params and routing `out` params to the bind target when appropriate.
- Emit fold lowering for `fold` routes by loading the accumulator global and storing the folded value into the folded uniform global when types match.
- Preserve the legacy inline-asm `; bind: ...` comments as a fallback when structured `bind_routes_ir` is unavailable.
- Extend `tests/test_compiler_api.py` to include kernel parameter metadata for `ApplyGravity` and add a new test that verifies fold-route lowering is emitted in `Lockstep_Tick`.

### Testing
- Running `pytest -q` initially failed in this environment due to repository `addopts` coverage flags not recognized by the test runner.
- Installed dependency with `python -m pip install llvmlite` to enable `llvmlite` usage for IR emission.
- Executed `PYTHONPATH=. pytest -q -o addopts='' tests/test_compiler_api.py` to run the updated compiler API tests, which passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7111f7468832889903086554a25aa)