### PR TITLE
Refactor formatter to use ANTLR lexer tokens and accept structured bind-route IR in optimizer

### DIFF
--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -88,6 +88,7 @@ def _compile_lockstep_with_dependencies(
         entities["bind_routes"],
         shader_names={shader["name"] for shader in entities["shaders"]},
         filter_names={flt["name"] for flt in entities["filters"]},
+        bind_routes_ir=entities.get("bind_routes_ir"),
     )
     entities = {
         **entities,

--- a/lockstep_compiler/formatter.py
+++ b/lockstep_compiler/formatter.py
@@ -1,31 +1,43 @@
-def _tokenize(source):
-    tokens = []
-    current = []
+from __future__ import annotations
 
-    for char in source:
-        if char in {"{", "}", ";", "\n"}:
-            if current:
-                token = "".join(current).strip()
-                if token:
-                    tokens.append(token)
-                current = []
-            tokens.append(char)
-        else:
-            current.append(char)
+from antlr4 import CommonTokenStream, InputStream
 
-    if current:
-        token = "".join(current).strip()
-        if token:
-            tokens.append(token)
 
-    return tokens
+def _lex_tokens(source: str) -> list[str]:
+    from generated.parser.LockstepLexer import LockstepLexer
+
+    lexer = LockstepLexer(InputStream(source))
+    stream = CommonTokenStream(lexer)
+    stream.fill()
+    return [token.text for token in stream.tokens if token.type != -1]
+
+
+def _needs_space(previous: str, current: str) -> bool:
+    if not previous:
+        return False
+    if current in {")", "]", "}", ",", ";", "(", "<", ">", ".", "="}:
+        return False
+    if previous in {"(", "[", "{", ",", "<", ".", "="}:
+        return False
+    if previous[-1] == ">" and (current[0].isalnum() or current[0] == "_"):
+        return True
+    return (previous[-1].isalnum() or previous[-1] == "_") and (
+        current[0].isalnum() or current[0] == "_"
+    )
 
 
 def format_lockstep_source(source, *, indent="    "):
-    tokens = _tokenize(source)
+    tokens = _lex_tokens(source)
     lines = []
     current = ""
     depth = 0
+
+    def append_token(token: str):
+        nonlocal current
+        if _needs_space(current, token):
+            current = f"{current} {token}"
+        else:
+            current = f"{current}{token}"
 
     def flush_current():
         nonlocal current
@@ -53,15 +65,10 @@ def format_lockstep_source(source, *, indent="    "):
                 index += 1
             lines.append(f"{indent * depth}{closing}")
         elif token == ";":
-            current = f"{current.strip()};"
-            flush_current()
-        elif token == "\n":
+            append_token(token)
             flush_current()
         else:
-            if current:
-                current = f"{current} {token}"
-            else:
-                current = token
+            append_token(token)
 
         index += 1
 

--- a/lockstep_compiler/optimizer.py
+++ b/lockstep_compiler/optimizer.py
@@ -37,10 +37,28 @@ def optimize_bind_routes(
     *,
     shader_names: set[str],
     filter_names: set[str],
+    bind_routes_ir: list[dict] | None = None,
 ) -> dict[str, list]:
     """Fuse adjacent shader/filter bind routes that shuttle temporary SoA streams."""
 
-    parsed_routes = [_parse_bind_route(route) for route in bind_routes]
+    if bind_routes_ir:
+        parsed_routes = []
+        for index, route in enumerate(bind_routes_ir):
+            if route.get("kind") != "kernel":
+                parsed_routes.append(None)
+                continue
+            parsed_routes.append(
+                ParsedBindRoute(
+                    target=route.get("target", ""),
+                    callee=route.get("kernel", ""),
+                    args=tuple(route.get("args", [])),
+                    raw=route.get("route", bind_routes[index] if index < len(bind_routes) else ""),
+                )
+            )
+        if len(parsed_routes) < len(bind_routes):
+            parsed_routes.extend(_parse_bind_route(route) for route in bind_routes[len(parsed_routes) :])
+    else:
+        parsed_routes = [_parse_bind_route(route) for route in bind_routes]
     valid_kernel_names = shader_names | filter_names
 
     use_count: dict[str, int] = {}

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -24,3 +24,14 @@ def test_format_lockstep_source_preserves_struct_terminator():
         "    float z;\n"
         "};\n"
     )
+
+
+def test_format_lockstep_source_uses_lexer_tokens_for_nested_expressions():
+    source = "shader Integrate(in Vec3 p){Vec3 next=Step(p.x,p.y);return next;}"
+
+    assert format_lockstep_source(source) == (
+        "shader Integrate(in Vec3 p) {\n"
+        "    Vec3 next=Step(p.x,p.y);\n"
+        "    return next;\n"
+        "}\n"
+    )

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -54,3 +54,46 @@ def test_optimize_bind_routes_keeps_route_when_intermediate_has_multiple_uses():
         "echo = Keep(tmp, echo);",
     ]
     assert result["fused_groups"] == []
+
+
+def test_optimize_bind_routes_uses_structured_bind_route_ir_when_available():
+    result = optimize_bind_routes(
+        [
+            "tmp = Shade(inp, tmp);",
+            "uniform float u0 = fold sum(tmp);",
+            "out = Blur(tmp, out);",
+        ],
+        shader_names={"Shade"},
+        filter_names={"Blur"},
+        bind_routes_ir=[
+            {
+                "kind": "kernel",
+                "target": "tmp",
+                "kernel": "Shade",
+                "args": ["inp", "tmp"],
+                "route": "tmp = Shade(inp, tmp);",
+            },
+            {
+                "kind": "fold",
+                "uniform_type": "float",
+                "uniform_name": "u0",
+                "operator": "sum",
+                "source": "tmp",
+                "route": "uniform float u0 = fold sum(tmp);",
+            },
+            {
+                "kind": "kernel",
+                "target": "out",
+                "kernel": "Blur",
+                "args": ["tmp", "out"],
+                "route": "out = Blur(tmp, out);",
+            },
+        ],
+    )
+
+    assert result["optimized_bind_routes"] == [
+        "tmp = Shade(inp, tmp);",
+        "uniform float u0 = fold sum(tmp);",
+        "out = Blur(tmp, out);",
+    ]
+    assert result["fused_groups"] == []


### PR DESCRIPTION
### Motivation
- Formatting and bind-route fusion previously relied on ad-hoc character/token splitting and regexes which are fragile for nested expressions and mixed-route IR.
- Move toward structured parsing by leveraging the generated ANTLR lexer and the compiler's bind-route IR to make formatting and optimization robust against parser surface changes.

### Description
- Reworked `format_lockstep_source` to tokenise input using the ANTLR `LockstepLexer` via `CommonTokenStream` and reflow code with brace- and token-aware spacing logic instead of char-by-char tokenization (`lockstep_compiler/formatter.py`).
- Extended `optimize_bind_routes` to accept an optional `bind_routes_ir` parameter and to build `ParsedBindRoute` instances from structured `kernel` entries while falling back to the regex parser for any remaining unstructured routes (`lockstep_compiler/optimizer.py`).
- Wired the compiler to pass `bind_routes_ir` (when available from the visitor) into `optimize_bind_routes` so optimization uses structured IR where possible (`lockstep_compiler/compiler.py`).
- Added regression tests covering lexer-token-based formatting and optimizer behavior with mixed `kernel`/`fold` entries in structured bind-route IR (`tests/test_formatter.py`, `tests/test_optimizer.py`).

### Testing
- Ran `PYTHONPATH=. pytest -q -o addopts='' tests/test_formatter.py tests/test_optimizer.py` and observed all tests passed (6 passed).
- Ran `PYTHONPATH=. pytest -q -o addopts='' tests/test_compiler_api.py tests/test_cli_format.py` and observed all tests passed (6 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7112bbba88328bb5d2500896c7882)