### PR TITLE
Add liveness-driven bind-route fusion localization

### DIFF
--- a/lockstep_compiler/optimizer.py
+++ b/lockstep_compiler/optimizer.py
@@ -43,14 +43,17 @@ def optimize_bind_routes(
     parsed_routes = [_parse_bind_route(route) for route in bind_routes]
     valid_kernel_names = shader_names | filter_names
 
-    use_count: dict[str, int] = {}
-    for parsed in parsed_routes:
+    live_after_route: list[set[str]] = [set() for _ in bind_routes]
+    live: set[str] = set()
+    for idx in range(len(parsed_routes) - 1, -1, -1):
+        parsed = parsed_routes[idx]
+        live_after_route[idx] = set(live)
         if parsed is None:
             continue
-        for arg in parsed.args:
-            if arg == parsed.target:
-                continue
-            use_count[arg] = use_count.get(arg, 0) + 1
+        # target is defined by the route, so the previous value is dead unless
+        # the route reads it as an argument.
+        live.discard(parsed.target)
+        live.update(parsed.args)
 
     fused_groups: list[dict[str, object]] = []
     optimized_bind_routes: list[str] = []
@@ -71,9 +74,12 @@ def optimize_bind_routes(
             prev = chain[-1]
             if nxt is None or nxt.callee not in valid_kernel_names:
                 break
-            if use_count.get(prev.target, 0) != 1:
-                break
             if prev.target not in nxt.args:
+                break
+            # The stream produced by `prev` is only fuseable when its value is
+            # dead after `nxt`, i.e. its lifetime is strictly contained by the
+            # adjacent kernels.
+            if prev.target in live_after_route[chain_end + 1]:
                 break
             chain.append(nxt)
             chain_end += 1

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -54,3 +54,43 @@ def test_optimize_bind_routes_keeps_route_when_intermediate_has_multiple_uses():
         "echo = Keep(tmp, echo);",
     ]
     assert result["fused_groups"] == []
+
+
+def test_optimize_bind_routes_uses_liveness_not_global_use_count():
+    result = optimize_bind_routes(
+        [
+            "tmp = Shade(inp, tmp);",
+            "out = Blur(tmp, out);",
+            "tmp = Reset(seed, scratch);",
+            "final = Keep(tmp, final);",
+        ],
+        shader_names={"Shade", "Keep", "Reset"},
+        filter_names={"Blur"},
+    )
+
+    assert result["optimized_bind_routes"] == [
+        "out = FUSED[Shade -> Blur];",
+        "final = FUSED[Reset -> Keep];",
+    ]
+    assert result["fused_groups"] == [
+        {
+            "nodes": ["Shade", "Blur"],
+            "entry_args": ["inp", "tmp"],
+            "output": "out",
+            "eliminated_intermediates": ["tmp"],
+            "source_routes": [
+                "tmp = Shade(inp, tmp);",
+                "out = Blur(tmp, out);",
+            ],
+        },
+        {
+            "nodes": ["Reset", "Keep"],
+            "entry_args": ["seed", "scratch"],
+            "output": "final",
+            "eliminated_intermediates": ["tmp"],
+            "source_routes": [
+                "tmp = Reset(seed, scratch);",
+                "final = Keep(tmp, final);",
+            ],
+        },
+    ]


### PR DESCRIPTION
### Motivation
- Prevent incorrect fusion when a stream name is reused by ensuring temporary SoA streams are only fused when their lifetime is strictly contained by the adjacent kernels via liveness analysis.

### Description
- Replaced the global argument-use counting logic with a backward liveness pass (`live_after_route` / `live`) in `optimize_bind_routes` to compute which stream names are live after each route.
- Tightened the chain-extension condition so a producer is fuseable only when its `target` is not live after the adjacent consumer, thereby localizing temporaries to the fused kernel group.
- Preserved the `optimized_bind_routes` and `fused_groups` output shape and semantics while updating the fusion gate.
- Added a regression test `test_optimize_bind_routes_uses_liveness_not_global_use_count` demonstrating correct fusion behavior across redefinitions/shadowing.

### Testing
- Ran `pytest -q tests/test_optimizer.py -o addopts=''` and observed `3 passed`.
- Ran `pytest -q tests/test_compiler_api.py -o addopts=''` and observed `5 passed`.
- Installed `llvmlite` to satisfy runtime imports during test collection (installation succeeded), and an initial `pytest` invocation failed due to injected `addopts` in `pyproject.toml` which was worked around by passing `-o addopts=''`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71176e8f4832889c29220005ceb7a)