### PR TITLE
Add built-in prelude intrinsics for step/mix/clamp

### DIFF
--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -8,7 +8,16 @@ from .codegen import emit_llvm_ir
 from .errors import LockstepCompileError, ParseErrorCollector
 from .models import LockstepCompileResult, normalize_diagnostics
 from .optimizer import optimize_bind_routes
+from .prelude import load_intrinsics
 from .visitors import build_debug_visitor, validate_semantics as _validate_semantics
+
+
+def _merge_intrinsic_pure_functions(pure_functions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    merged = {fn.get("name"): fn for fn in pure_functions if isinstance(fn, dict) and fn.get("name")}
+    for name, intrinsic in load_intrinsics().items():
+        if name not in merged:
+            merged[name] = intrinsic
+    return list(merged.values())
 
 
 def _compile_lockstep_with_dependencies(
@@ -82,6 +91,8 @@ def _compile_lockstep_with_dependencies(
             "bind_routes": visitor.bind_routes,
             "bind_routes_ir": getattr(visitor, "bind_routes_ir", []),
         }
+
+    entities["pure_functions"] = _merge_intrinsic_pure_functions(entities.get("pure_functions", []))
 
     all_diagnostics = normalize_diagnostics([*semantic_diagnostics, *debug_diagnostics])
     bind_optimization = optimize_bind_routes(

--- a/lockstep_compiler/prelude.lock
+++ b/lockstep_compiler/prelude.lock
@@ -1,0 +1,6 @@
+// Standard prelude intrinsics available in every Lockstep compilation unit.
+// These declarations are semantic/runtime built-ins and do not require user definitions.
+
+intrinsic float step(float edge, float x);
+intrinsic float mix(float a, float b, float t);
+intrinsic float clamp(float x, float min_value, float max_value);

--- a/lockstep_compiler/prelude.py
+++ b/lockstep_compiler/prelude.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import functools
+import re
+from pathlib import Path
+from typing import Any
+
+_INTRINSIC_DECL_RE = re.compile(
+    r"^\s*intrinsic\s+(?P<return_type>[A-Za-z_][A-Za-z0-9_]*)\s+"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\((?P<params>[^)]*)\)\s*;\s*$"
+)
+_PARAM_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s*$")
+
+
+@functools.lru_cache(maxsize=1)
+def load_intrinsics() -> dict[str, dict[str, Any]]:
+    prelude_path = Path(__file__).with_name("prelude.lock")
+    intrinsics: dict[str, dict[str, Any]] = {}
+    for line in prelude_path.read_text(encoding="utf-8").splitlines():
+        match = _INTRINSIC_DECL_RE.match(line)
+        if match is None:
+            continue
+        params_raw = match.group("params").strip()
+        params: list[dict[str, str]] = []
+        if params_raw:
+            for piece in params_raw.split(","):
+                param_match = _PARAM_RE.match(piece)
+                if param_match is None:
+                    continue
+                params.append({"type": param_match.group(1), "name": param_match.group(2)})
+
+        intrinsics[match.group("name")] = {
+            "name": match.group("name"),
+            "return_type": match.group("return_type"),
+            "params": params,
+            "body": [],
+            "intrinsic": True,
+        }
+    return intrinsics

--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -1,6 +1,8 @@
 from difflib import get_close_matches
 from typing import Any
 
+from .prelude import load_intrinsics
+
 from .models import (
     LockstepDiagnostic,
     SemanticKernelParam,
@@ -335,7 +337,17 @@ def build_semantic_validator(base_visitor_cls):
             self.scope_assignments: list[dict[str, bool]] = []
             self.shaders: dict[str, list[SemanticKernelParam]] = {}
             self.filters: dict[str, list[SemanticKernelParam]] = {}
-            self.pure_functions: dict[str, dict[str, Any]] = {}
+            self.pure_functions: dict[str, dict[str, Any]] = {
+                name: {
+                    "return_type": signature["return_type"],
+                    "params": [
+                        SemanticKernelParam(name=param["name"], declared_type=param["type"], modifier="value")
+                        for param in signature["params"]
+                    ],
+                    "intrinsic": True,
+                }
+                for name, signature in load_intrinsics().items()
+            }
             self.structs: dict[str, dict[str, SemanticStructField]] = {}
             self._primitive_types = {"int", "float", "bool"}
             self._current_pure_function: dict[str, str] | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 py-modules = ["debug_compiler"]
 packages = ["lockstep_compiler"]
+
+[tool.setuptools.package-data]
+lockstep_compiler = ["prelude.lock"]

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -74,19 +74,17 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
     )
 
     assert result.parse_tree == "TREE"
-    assert result.entities == {
-        "structs": [],
-        "shaders": [],
-        "filters": [],
-        "pure_functions": [],
-        "streams": [],
-        "accumulators": [],
-        "uniforms": [],
-        "bind_routes": [],
-        "bind_routes_ir": [],
-        "optimized_bind_routes": [],
-        "fused_bind_groups": [],
-    }
+    assert result.entities["structs"] == []
+    assert result.entities["shaders"] == []
+    assert result.entities["filters"] == []
+    assert {fn["name"] for fn in result.entities["pure_functions"]} == {"step", "mix", "clamp"}
+    assert result.entities["streams"] == []
+    assert result.entities["accumulators"] == []
+    assert result.entities["uniforms"] == []
+    assert result.entities["bind_routes"] == []
+    assert result.entities["bind_routes_ir"] == []
+    assert result.entities["optimized_bind_routes"] == []
+    assert result.entities["fused_bind_groups"] == []
 
     assert result.llvm_ir.startswith('; ModuleID = "lockstep"\n')
     assert "define void @\"Lockstep_Tick\"()" in result.llvm_ir

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1142,14 +1142,18 @@ def test_semantic_validator_records_pure_signature_from_declaration(debug_compil
 
     validator.visitPureDecl(pure_decl_ctx)
 
-    assert validator.pure_functions == {
-        "blend": {
-            "return_type": "float",
-            "params": [
-                SemanticKernelParam(name="left", declared_type="float", modifier="value"),
-                SemanticKernelParam(name="right", declared_type="int", modifier="value"),
-            ],
-        }
+    assert "blend" in validator.pure_functions
+    assert validator.pure_functions["blend"] == {
+        "return_type": "float",
+        "params": [
+            SemanticKernelParam(name="left", declared_type="float", modifier="value"),
+            SemanticKernelParam(name="right", declared_type="int", modifier="value"),
+        ],
+    }
+    assert {name for name, signature in validator.pure_functions.items() if signature.get("intrinsic")} == {
+        "step",
+        "mix",
+        "clamp",
     }
 
 
@@ -1407,6 +1411,21 @@ def test_semantic_validator_accepts_valid_pure_call(debug_compiler_module):
         start_line=39,
         start_col=3,
         ID=lambda: _token("dot"),
+        exprList=lambda: _ctx(expr=lambda: [_ctx(declared_type="float"), _ctx(declared_type="float")]),
+    )
+
+    validator.visitPrimaryExpr(call_ctx)
+
+    assert validator.diagnostics == []
+
+
+def test_semantic_validator_accepts_intrinsic_pure_call(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    call_ctx = _ctx(
+        start_line=40,
+        start_col=3,
+        ID=lambda: _token("step"),
         exprList=lambda: _ctx(expr=lambda: [_ctx(declared_type="float"), _ctx(declared_type="float")]),
     )
 


### PR DESCRIPTION
### Motivation
- Make standard branchless math intrinsics (`step`, `mix`, `clamp`) first-class so the semantic validator and simulator recognize and treat them as built-in pure functions without requiring user declarations.
- Ensure compiled entity graphs include these intrinsics so downstream components (simulator, codegen) can rely on their presence.

### Description
- Added `lockstep_compiler/prelude.lock` declaring the intrinsics: `step`, `mix`, and `clamp` as `intrinsic` signatures.
- Added `lockstep_compiler/prelude.py` with `load_intrinsics()` to parse and cache intrinsic declarations from the prelude file.
- Seeded the semantic validator (`LockstepSemanticValidator`) with intrinsic pure function signatures at initialization so intrinsic calls validate like declared `pure` functions.
- Merged intrinsic signatures into compiled `entities["pure_functions"]` in compilation (`_merge_intrinsic_pure_functions` in `compiler.py`) and included `prelude.lock` as package data in `pyproject.toml`.
- Updated tests to assert intrinsic presence in compiled entities and to verify that intrinsic calls are accepted by the semantic validator.

### Testing
- Ran the test suite with `PYTHONPATH=. pytest -q -o addopts=''` and the suite completed successfully with `93 passed, 6 skipped`.
- Ran focused test runs during development (e.g. `pytest -q -o addopts='' tests/test_compiler_api.py tests/test_debug_compiler.py tests/test_simulator.py`) and resolved initial failures; the targeted suites passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7116db51c8328a66f2dd8a9a30aad)