### PR TITLE
Robustly import generated ANTLR parser, restore token-stream formatter, and include generated package

### DIFF
--- a/generated/__init__.py
+++ b/generated/__init__.py
@@ -1,0 +1,1 @@
+"""Generated parser package."""

--- a/generated/parser/__init__.py
+++ b/generated/parser/__init__.py
@@ -1,0 +1,1 @@
+"""ANTLR parser artifacts for Lockstep."""

--- a/lockstep_compiler/formatter.py
+++ b/lockstep_compiler/formatter.py
@@ -1,21 +1,25 @@
 from __future__ import annotations
+
+import sys
+from pathlib import Path
+
 from antlr4 import CommonTokenStream, InputStream
 
-from generated.parser.LockstepLexer import LockstepLexer
-from generated.parser.LockstepParser import LockstepParser
-from generated.parser.LockstepVisitor import LockstepVisitor
+try:
+    from generated.parser.LockstepLexer import LockstepLexer
+    from generated.parser.LockstepParser import LockstepParser
+    from generated.parser.LockstepVisitor import LockstepVisitor
+except ModuleNotFoundError:
+    repo_root = Path(__file__).resolve().parent.parent
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from generated.parser.LockstepLexer import LockstepLexer
+    from generated.parser.LockstepParser import LockstepParser
+    from generated.parser.LockstepVisitor import LockstepVisitor
 
 from .errors import ParseErrorCollector
 
-def _tokenize(source):
-    tokens = []
-    current = []
-
-from antlr4 import CommonTokenStream, InputStream
-
-
 def _lex_tokens(source: str) -> list[str]:
-    from generated.parser.LockstepLexer import LockstepLexer
 
     lexer = LockstepLexer(InputStream(source))
     stream = CommonTokenStream(lexer)
@@ -37,7 +41,7 @@ def _needs_space(previous: str, current: str) -> bool:
     )
 
 
-def format_lockstep_source(source, *, indent="    "):
+def _format_token_stream(source, *, indent="    "):
     tokens = _lex_tokens(source)
     lines = []
     current = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 py-modules = ["debug_compiler"]
-packages = ["lockstep_compiler"]
+packages = ["lockstep_compiler", "generated", "generated.parser"]
 
 [tool.setuptools.package-data]
 lockstep_compiler = ["prelude.lock"]


### PR DESCRIPTION
### Motivation
- Tests were failing because `lockstep_compiler.formatter` could not import the generated ANTLR parser modules when the project root was not on `sys.path`. 
- The formatter's fallback path expected a helper named `_format_token_stream` but the function was missing/renamed, preventing graceful fallback on parse errors. 
- The generated parser directory lacked package markers and was not listed in packaging, making imports and installation brittle. 

### Description
- Added a `ModuleNotFoundError` fallback in `lockstep_compiler/formatter.py` that prepends the repository root to `sys.path` and retries importing `generated.parser.LockstepLexer`, `LockstepParser`, and `LockstepVisitor`. 
- Restored the token-stream-based formatter helper by naming it `_format_token_stream` and wired `format_lockstep_source()` to call it when parse errors are detected. 
- Added `generated/__init__.py` and `generated/parser/__init__.py` package markers to make the generated parser a proper package. 
- Updated `pyproject.toml` to include `generated` and `generated.parser` in the `packages` list so the generated parser is included in installs. 

### Testing
- Ran `pytest tests/test_formatter.py tests/test_cli_format.py` and the targeted formatter/CLI tests passed. 
- Ran the full test suite with `pytest` and all tests passed (existing ANTLR toolchain skips remain unchanged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7463c64788328bed6f788bf3f0a50)