### PR TITLE
Lower user structs to real LLVM aggregates and member ops

### DIFF
--- a/lockstep_compiler/ast.py
+++ b/lockstep_compiler/ast.py
@@ -363,7 +363,16 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                 )
 
     return {
-        "structs": [decl.name for decl in program.structs],
+        "structs": [
+            {
+                "name": decl.name,
+                "fields": [
+                    {"type": field.declared_type, "name": field.name}
+                    for field in decl.fields
+                ],
+            }
+            for decl in program.structs
+        ],
         "shaders": [
             {
                 "name": shader.name,

--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -122,11 +122,70 @@ class _ExprParser:
 
 
 class _FunctionLowerer:
-    def __init__(self, module: ir.Module, function_map: dict[str, ir.Function]):
+    def __init__(
+        self,
+        module: ir.Module,
+        function_map: dict[str, ir.Function],
+        known_structs: dict[str, ir.IdentifiedStructType] | None = None,
+        struct_fields: dict[str, list[dict[str, str]]] | None = None,
+    ):
         self.module = module
         self.function_map = function_map
+        self.known_structs = known_structs or {}
+        self.struct_fields = struct_fields or {}
         self.builder: ir.IRBuilder | None = None
         self.locals: dict[str, ir.AllocaInstr] = {}
+
+    def _struct_name_for_type(self, llvm_type: ir.Type) -> str | None:
+        for name, known_ty in self.known_structs.items():
+            if llvm_type is known_ty:
+                return name
+        return None
+
+    def _field_index_and_type(self, llvm_type: ir.Type, field_name: str) -> tuple[int, ir.Type] | None:
+        struct_name = self._struct_name_for_type(llvm_type)
+        if struct_name is None:
+            return None
+        fields = self.struct_fields.get(struct_name, [])
+        for index, field in enumerate(fields):
+            if field.get("name") == field_name:
+                return index, self._llvm_type(field.get("type", "float"), self.known_structs)
+        return None
+
+    def _coerce_value_to_type(self, value: ir.Value, target_type: ir.Type) -> ir.Value:
+        if value.type == target_type:
+            return value
+        if isinstance(target_type, ir.FloatType):
+            return self._coerce_float(value)
+        if isinstance(target_type, ir.IntType) and isinstance(value.type, ir.IntType):
+            if value.type.width < target_type.width:
+                return self.builder.sext(value, target_type)
+            if value.type.width > target_type.width:
+                return self.builder.trunc(value, target_type)
+        return value
+
+    def _extract_field_path(self, value: ir.Value, path: list[str]) -> ir.Value:
+        current = value
+        for field_name in path:
+            field_info = self._field_index_and_type(current.type, field_name)
+            if field_info is None:
+                return ir.Constant(ir.FloatType(), 0.0)
+            index, _ = field_info
+            current = self.builder.extract_value(current, index, name=f"{field_name}_field")
+        return current
+
+    def _insert_field_path(self, aggregate: ir.Value, path: list[str], value: ir.Value) -> ir.Value:
+        field_info = self._field_index_and_type(aggregate.type, path[0])
+        if field_info is None:
+            return aggregate
+        index, field_type = field_info
+        if len(path) == 1:
+            coerced = self._coerce_value_to_type(value, field_type)
+            return self.builder.insert_value(aggregate, coerced, index, name=f"set_{path[0]}")
+
+        nested = self.builder.extract_value(aggregate, index, name=f"load_{path[0]}")
+        updated_nested = self._insert_field_path(nested, path[1:], value)
+        return self.builder.insert_value(aggregate, updated_nested, index, name=f"set_{path[0]}")
 
     def _llvm_type(self, type_name: str, known_structs: dict[str, ir.IdentifiedStructType]) -> ir.Type:
         if type_name in _PRIMITIVE_TYPE_MAP:
@@ -143,9 +202,13 @@ class _FunctionLowerer:
         return value
 
     def _load_var(self, name: str) -> ir.Value:
-        key = _sanitize_symbol(name.replace(".", "_"))
-        if key in self.locals:
-            return self.builder.load(self.locals[key], name=f"{key}_val")
+        parts = name.split(".")
+        base_key = _sanitize_symbol(parts[0])
+        if base_key in self.locals:
+            base_value = self.builder.load(self.locals[base_key], name=f"{base_key}_val")
+            if len(parts) == 1:
+                return base_value
+            return self._extract_field_path(base_value, parts[1:])
         return ir.Constant(ir.FloatType(), 0.0)
 
     def _parse_expr(self, expr: str):
@@ -221,22 +284,31 @@ class _FunctionLowerer:
             rhs = rhs.strip()
             lhs_parts = lhs.split()
             name = lhs_parts[-1]
-            key = _sanitize_symbol(name.replace(".", "_"))
+            base_name, *field_path = name.split(".")
+            key = _sanitize_symbol(base_name)
             value = self._lower_expr(self._parse_expr(rhs))
             if key not in self.locals:
                 slot = self.builder.alloca(value.type, name=key)
                 self.locals[key] = slot
-            self.builder.store(value, self.locals[key])
+            if not field_path:
+                self.builder.store(value, self.locals[key])
+                return
+
+            current = self.builder.load(self.locals[key], name=f"{key}_val")
+            updated = self._insert_field_path(current, field_path, value)
+            self.builder.store(updated, self.locals[key])
             return
 
         if statement.endswith(";"):
             maybe_decl = statement[:-1].split()
             if maybe_decl:
+                declared_type = maybe_decl[0] if len(maybe_decl) > 1 else "float"
                 key = _sanitize_symbol(maybe_decl[-1].replace(".", "_"))
                 if key not in self.locals:
-                    slot = self.builder.alloca(ir.FloatType(), name=key)
+                    llvm_type = self._llvm_type(declared_type, self.known_structs)
+                    slot = self.builder.alloca(llvm_type, name=key)
                     self.locals[key] = slot
-                    self.builder.store(ir.Constant(ir.FloatType(), 0.0), slot)
+                    self.builder.store(ir.Constant(llvm_type, None), slot)
 
     def lower_function(self, fn: ir.Function, statements: list[str], return_type: ir.Type):
         block = fn.append_basic_block("entry")
@@ -277,14 +349,48 @@ def emit_llvm_ir(entities: dict[str, Any]) -> str:
     module = ir.Module(name="lockstep")
     module.source_filename = "lockstep"
     known_structs: dict[str, ir.IdentifiedStructType] = {}
+    struct_fields: dict[str, list[dict[str, str]]] = {}
 
-    for struct_name in structs:
+    normalized_structs: list[dict[str, Any]] = []
+    for struct_decl in structs:
+        if isinstance(struct_decl, str):
+            normalized_structs.append({"name": struct_decl, "fields": []})
+        elif isinstance(struct_decl, dict) and struct_decl.get("name"):
+            fields = struct_decl.get("fields") if isinstance(struct_decl.get("fields"), list) else []
+            normalized_structs.append({"name": struct_decl["name"], "fields": fields})
+
+    for struct_decl in normalized_structs:
+        struct_name = struct_decl["name"]
         safe_name = _sanitize_symbol(struct_name)
         struct_ty = module.context.get_identified_type(f"struct.{safe_name}")
-        struct_ty.set_body(ir.IntType(8))
         known_structs[struct_name] = struct_ty
+        struct_fields[struct_name] = struct_decl["fields"]
 
-    lowerer = _FunctionLowerer(module, {})
+    lowerer = _FunctionLowerer(module, {}, known_structs, struct_fields)
+
+    unresolved = set(known_structs.keys())
+    while unresolved:
+        progress = False
+        for struct_name in list(unresolved):
+            field_types: list[ir.Type] = []
+            can_lower = True
+            for field in struct_fields.get(struct_name, []):
+                field_type_name = field.get("type", "float")
+                if field_type_name in known_structs and field_type_name in unresolved:
+                    can_lower = False
+                    break
+                field_types.append(lowerer._llvm_type(field_type_name, known_structs))
+            if not can_lower:
+                continue
+            if known_structs[struct_name].is_opaque:
+                known_structs[struct_name].set_body(*field_types)
+            unresolved.remove(struct_name)
+            progress = True
+        if not progress:
+            for struct_name in unresolved:
+                if known_structs[struct_name].is_opaque:
+                    known_structs[struct_name].set_body(ir.IntType(8))
+            break
 
     function_map: dict[str, ir.Function] = {}
     for pure in pure_functions:

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -93,7 +93,16 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
 def test_emit_llvm_ir_generates_expected_declarations():
     llvm_ir = emit_llvm_ir(
         {
-            "structs": ["Vec3"],
+            "structs": [
+                {
+                    "name": "Vec3",
+                    "fields": [
+                        {"type": "float", "name": "x"},
+                        {"type": "float", "name": "y"},
+                        {"type": "float", "name": "z"},
+                    ],
+                }
+            ],
             "shaders": [{"name": "ApplyGravity"}],
             "filters": [{"name": "Cull"}],
             "pure_functions": [{"name": "mix", "return_type": "float", "params": [], "body": ["returnmix(0.0,1.0,step(0.5,1.0));"]}],
@@ -104,7 +113,7 @@ def test_emit_llvm_ir_generates_expected_declarations():
         }
     )
 
-    assert "%\"struct.Vec3\" = type {i8}" in llvm_ir
+    assert "%\"struct.Vec3\" = type {float, float, float}" in llvm_ir
     assert "define float @\"pure_mix\"()" in llvm_ir
     assert "define void @\"shader_ApplyGravity\"()" in llvm_ir
     assert "define void @\"filter_Cull\"()" in llvm_ir
@@ -114,6 +123,40 @@ def test_emit_llvm_ir_generates_expected_declarations():
     assert '; bind: out = ApplyGravity(inp, out, energy, dt);' in llvm_ir
     assert "fmul float" in llvm_ir
     assert "uitofp i1" in llvm_ir
+
+
+def test_emit_llvm_ir_lowers_struct_member_extract_and_insert():
+    llvm_ir = emit_llvm_ir(
+        {
+            "structs": [
+                {
+                    "name": "Vec3",
+                    "fields": [
+                        {"type": "float", "name": "x"},
+                        {"type": "float", "name": "y"},
+                        {"type": "float", "name": "z"},
+                    ],
+                }
+            ],
+            "pure_functions": [
+                {
+                    "name": "set_and_get_x",
+                    "return_type": "float",
+                    "params": [],
+                    "body": ["Vec3 v;", "v.x = 1.0;", "return v.x;"],
+                }
+            ],
+            "shaders": [],
+            "filters": [],
+            "streams": [],
+            "accumulators": [],
+            "uniforms": [],
+            "bind_routes": [],
+        }
+    )
+
+    assert "insertvalue %\"struct.Vec3\"" in llvm_ir
+    assert "extractvalue %\"struct.Vec3\"" in llvm_ir
 
 
 def test_cli_main_wires_default_compiler(monkeypatch):


### PR DESCRIPTION
### Motivation
- User-defined structs were emitted as opaque `{ i8 }` (or `i8*`) which prevented correct lowering of Struct-of-Arrays memory accesses and prevented emitting field ops like `extractvalue`/`insertvalue`.
- The compiler needs explicit struct layout and field metadata to lower dotted member reads/writes and to allocate locals with correct aggregate types.

### Description
- Emit structured `entities["structs"]` from the AST containing `name` and `fields` metadata instead of only names by updating `ast_to_entities` in `lockstep_compiler/ast.py`.
- Normalize legacy string-style struct declarations and create `IdentifiedStructType` instances, then resolve and set real struct bodies from declared fields with a fallback to `i8` for unresolved/cyclic references in `emit_llvm_ir` in `lockstep_compiler/codegen.py`.
- Extend `_FunctionLowerer` to accept `known_structs` and `struct_fields`, add helpers `_struct_name_for_type`, `_field_index_and_type`, `_coerce_value_to_type`, `_extract_field_path`, and `_insert_field_path`, and lower dotted member expressions/assignments to use `extractvalue` and `insertvalue`.
- Allocate local variables using the declared LLVM type for typed declarations (e.g. `Vec3 v;`) and update variable load/store lowering to support member paths; preserve compatibility with legacy struct strings.
- Add/adjust tests in `tests/test_compiler_api.py` to assert concrete multi-field struct IR emission and generation of `insertvalue`/`extractvalue` ops.

### Testing
- Ran the targeted tests `pytest -q -o addopts='' tests/test_compiler_api.py::test_emit_llvm_ir_generates_expected_declarations tests/test_compiler_api.py::test_emit_llvm_ir_lowers_struct_member_extract_and_insert` and both tests passed.
- Ran the full `tests/test_compiler_api.py` file with `pytest -q -o addopts='' tests/test_compiler_api.py` and observed `8 passed`.
- The changes preserve backward compatibility for string-based `structs` entries while enabling full lowering for structured declarations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a753a1788c832882ae18504d0091a0)