### PR TITLE
Implement saturated stream write semantics in simulator

### DIFF
--- a/lockstep_compiler/simulator.py
+++ b/lockstep_compiler/simulator.py
@@ -33,6 +33,19 @@ def _route_text(route_ir: dict[str, Any]) -> str:
     return str(route_ir.get("route", ""))
 
 
+def _apply_saturated_writes(rows: list[Any], capacity: int) -> list[Any]:
+    if capacity <= 0:
+        return []
+
+    saturated_rows: list[Any] = []
+    for value in rows:
+        if len(saturated_rows) < capacity:
+            saturated_rows.append(value)
+            continue
+        saturated_rows[capacity - 1] = value
+    return saturated_rows
+
+
 def simulate_pipeline_entities(
     entities: dict[str, Any],
     *,
@@ -97,7 +110,7 @@ def simulate_pipeline_entities(
             target = route_ir.get("target")
             if isinstance(target, str) and target in streams:
                 cap = streams[target]["capacity"]
-                streams[target]["rows"] = output_rows[:cap]
+                streams[target]["rows"] = _apply_saturated_writes(output_rows, cap)
 
             for index, arg_name in enumerate(args):
                 params = kernel["params"]

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -113,3 +113,41 @@ def test_run_cli_simulate_reads_input_file(tmp_path):
     assert exit_code == 0
     payload = json.loads(stdout.getvalue())
     assert payload["streams"]["s"] == [1, 2, 3]
+
+
+def test_simulate_pipeline_entities_saturates_stream_writes_at_capacity():
+    entities = {
+        "streams": [
+            {"name": "in_stream", "type": "int", "capacity": "5"},
+            {"name": "out_stream", "type": "int", "capacity": "2"},
+        ],
+        "accumulators": [],
+        "uniforms": [],
+        "shaders": [
+            {
+                "name": "Project",
+                "params": [
+                    {"modifier": "in", "type": "int", "name": "src"},
+                    {"modifier": "out", "type": "int", "name": "dst"},
+                ],
+            }
+        ],
+        "filters": [],
+        "bind_routes": ["out_stream = Project(in_stream, out_stream);"],
+        "bind_routes_ir": [
+            {
+                "kind": "kernel",
+                "target": "out_stream",
+                "kernel": "Project",
+                "args": ["in_stream", "out_stream"],
+                "route": "out_stream = Project(in_stream, out_stream);",
+            }
+        ],
+    }
+
+    simulation = simulate_pipeline_entities(entities, stream_inputs={"in_stream": [1, 2, 3, 4]})
+
+    assert simulation["streams"]["out_stream"] == [
+        {"_source": 1, "_kernel": "Project"},
+        {"_source": 4, "_kernel": "Project"},
+    ]


### PR DESCRIPTION
### Motivation
- The README specifies "Saturated Writes" / "trash can" semantics for streams: when a stream capacity is exceeded, overflow writes should be absorbed by the final slot to avoid boundary checks or memory corruption.
- The simulator previously truncated outputs with slicing (`output_rows[:cap]`) which did not model the intended saturation behavior.

### Description
- Add a helper ` _apply_saturated_writes(rows, capacity)` in `lockstep_compiler/simulator.py` that appends values until capacity and then redirects further writes into the final slot.
- Replace the prior truncation assignment (`output_rows[:cap]`) with a call to `_apply_saturated_writes` when writing kernel outputs to a target stream in `simulate_pipeline_entities`.
- Add `test_simulate_pipeline_entities_saturates_stream_writes_at_capacity` to `tests/test_simulator.py` to assert overflow behavior where the output stream of capacity 2 becomes `[first, last]` after overflow.

### Testing
- Ran the simulator test suite with `python -m pytest -q -o addopts='' tests/test_simulator.py`, and all tests passed (`4 passed`).
- The new unit test `test_simulate_pipeline_entities_saturates_stream_writes_at_capacity` verifies the implemented saturation semantics.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7573638d88328a179701b00991153)