### PR TITLE
Preserve ANTLR expression trees in AST/codegen

### DIFF
--- a/lockstep_compiler/ast.py
+++ b/lockstep_compiler/ast.py
@@ -35,7 +35,7 @@ class AstPureDecl:
     name: str
     return_type: str
     params: tuple[AstKernelParam, ...] = ()
-    body: tuple[str, ...] = ()
+    body: tuple[AstStatement, ...] = ()
     location: AstLocation = AstLocation()
 
 
@@ -43,7 +43,7 @@ class AstPureDecl:
 class AstKernelDecl:
     name: str
     params: tuple[AstKernelParam, ...] = ()
-    body: tuple[str, ...] = ()
+    body: tuple[AstStatement, ...] = ()
     location: AstLocation = AstLocation()
 
 
@@ -66,7 +66,7 @@ class AstAccumulatorDecl:
 class AstUniformDecl:
     name: str
     declared_type: str
-    initializer: str | None = None
+    initializer: AstExpr | None = None
     location: AstLocation = AstLocation()
 
 
@@ -107,6 +107,85 @@ class AstProgram:
     filters: tuple[AstKernelDecl, ...] = ()
     pure_functions: tuple[AstPureDecl, ...] = ()
     pipelines: tuple[AstPipelineDecl, ...] = ()
+
+
+@dataclass(frozen=True)
+class AstLValue:
+    parts: tuple[str, ...]
+    location: AstLocation = AstLocation()
+
+
+@dataclass(frozen=True)
+class AstIntExpr:
+    value: int
+    location: AstLocation = AstLocation()
+
+
+@dataclass(frozen=True)
+class AstFloatExpr:
+    value: float
+    location: AstLocation = AstLocation()
+
+
+@dataclass(frozen=True)
+class AstBoolExpr:
+    value: bool
+    location: AstLocation = AstLocation()
+
+
+@dataclass(frozen=True)
+class AstLValueExpr:
+    lvalue: AstLValue
+    location: AstLocation = AstLocation()
+
+
+@dataclass(frozen=True)
+class AstUnaryExpr:
+    operator: str
+    operand: AstExpr
+    location: AstLocation = AstLocation()
+
+
+@dataclass(frozen=True)
+class AstBinaryExpr:
+    operator: str
+    left: AstExpr
+    right: AstExpr
+    location: AstLocation = AstLocation()
+
+
+@dataclass(frozen=True)
+class AstCallExpr:
+    name: str
+    args: tuple[AstExpr, ...] = ()
+    location: AstLocation = AstLocation()
+
+
+AstExpr = AstIntExpr | AstFloatExpr | AstBoolExpr | AstLValueExpr | AstUnaryExpr | AstBinaryExpr | AstCallExpr
+
+
+@dataclass(frozen=True)
+class AstVarDeclStmt:
+    name: str
+    declared_type: str | None = None
+    initializer: AstExpr | None = None
+    location: AstLocation = AstLocation()
+
+
+@dataclass(frozen=True)
+class AstAssignStmt:
+    target: AstLValue = AstLValue(())
+    value: AstExpr = AstIntExpr(0)
+    location: AstLocation = AstLocation()
+
+
+@dataclass(frozen=True)
+class AstReturnStmt:
+    value: AstExpr = AstIntExpr(0)
+    location: AstLocation = AstLocation()
+
+
+AstStatement = AstVarDeclStmt | AstAssignStmt | AstReturnStmt
 
 
 class _AstBuilderMixin:
@@ -155,9 +234,107 @@ class AstBuilder(_AstBuilderMixin):
             params.append(AstKernelParam(modifier=modifier, declared_type=declared_type, name=name))
         return tuple(params)
 
-    def _parse_statement_text(self, ctx: Any) -> tuple[str, ...]:
+    def _parse_lvalue(self, ctx: Any) -> AstLValue:
+        tokens = self._call(ctx, "ID", []) or []
+        return AstLValue(parts=tuple(token.getText() for token in tokens), location=self._location(ctx))
+
+    def _parse_left_associative(self, ctx: Any, child_attr: str, child_parser) -> AstExpr:
+        operands_ctx = self._call(ctx, child_attr, []) or []
+        node = child_parser(operands_ctx[0])
+        children = getattr(ctx, "children", []) or []
+        operators = [children[index].getText() for index in range(1, len(children), 2)]
+        for operator, operand_ctx in zip(operators, operands_ctx[1:]):
+            node = AstBinaryExpr(operator=operator, left=node, right=child_parser(operand_ctx), location=self._location(ctx))
+        return node
+
+    def _parse_expr(self, ctx: Any) -> AstExpr:
+        return self._parse_logical_or_expr(self._call(self._call(ctx, "logicalExpr"), "logicalOrExpr"))
+
+    def _parse_logical_or_expr(self, ctx: Any) -> AstExpr:
+        return self._parse_left_associative(ctx, "logicalAndExpr", self._parse_logical_and_expr)
+
+    def _parse_logical_and_expr(self, ctx: Any) -> AstExpr:
+        return self._parse_left_associative(ctx, "equalityExpr", self._parse_equality_expr)
+
+    def _parse_equality_expr(self, ctx: Any) -> AstExpr:
+        return self._parse_left_associative(ctx, "relExpr", self._parse_rel_expr)
+
+    def _parse_rel_expr(self, ctx: Any) -> AstExpr:
+        return self._parse_left_associative(ctx, "addExpr", self._parse_add_expr)
+
+    def _parse_add_expr(self, ctx: Any) -> AstExpr:
+        return self._parse_left_associative(ctx, "mulExpr", self._parse_mul_expr)
+
+    def _parse_mul_expr(self, ctx: Any) -> AstExpr:
+        return self._parse_left_associative(ctx, "unaryExpr", self._parse_unary_expr)
+
+    def _parse_unary_expr(self, ctx: Any) -> AstExpr:
+        unary_ctx = self._call(ctx, "unaryExpr")
+        if unary_ctx is not None:
+            return AstUnaryExpr(operator=ctx.getChild(0).getText(), operand=self._parse_unary_expr(unary_ctx), location=self._location(ctx))
+        return self._parse_primary_expr(self._call(ctx, "primaryExpr"))
+
+    def _parse_primary_expr(self, ctx: Any) -> AstExpr:
+        int_token = self._call(ctx, "INT")
+        if int_token is not None:
+            return AstIntExpr(value=int(int_token.getText()), location=self._location(ctx))
+        float_token = self._call(ctx, "FLOAT")
+        if float_token is not None:
+            return AstFloatExpr(value=float(float_token.getText()), location=self._location(ctx))
+        bool_token = self._call(ctx, "BOOL")
+        if bool_token is not None:
+            return AstBoolExpr(value=bool_token.getText() == "true", location=self._location(ctx))
+
+        lvalue_ctx = self._call(ctx, "lvalue")
+        if lvalue_ctx is not None:
+            return AstLValueExpr(lvalue=self._parse_lvalue(lvalue_ctx), location=self._location(ctx))
+
+        call_id = self._call(ctx, "ID")
+        if call_id is not None:
+            expr_list = self._call(ctx, "exprList")
+            args = ()
+            if expr_list is not None:
+                args = tuple(self._parse_expr(expr_ctx) for expr_ctx in self._call(expr_list, "expr", []) or [])
+            return AstCallExpr(name=call_id.getText(), args=args, location=self._location(ctx))
+
+        grouped = self._call(ctx, "expr")
+        if grouped is not None:
+            return self._parse_expr(grouped)
+
+        return AstIntExpr(value=0, location=self._location(ctx))
+
+    def _parse_statement(self, ctx: Any) -> AstStatement:
+        var_decl = self._call(ctx, "varDecl")
+        if var_decl is not None:
+            declared_type_ctx = self._call(var_decl, "typeName")
+            initializer_ctx = self._call(var_decl, "expr")
+            return AstVarDeclStmt(
+                name=self._call(var_decl, "ID").getText(),
+                declared_type=declared_type_ctx.getText() if declared_type_ctx is not None else None,
+                initializer=self._parse_expr(initializer_ctx) if initializer_ctx is not None else None,
+                location=self._location(var_decl),
+            )
+
+        assign_stmt = self._call(ctx, "assignStmt")
+        if assign_stmt is not None:
+            return AstAssignStmt(
+                target=self._parse_lvalue(self._call(assign_stmt, "lvalue")),
+                value=self._parse_expr(self._call(assign_stmt, "expr")),
+                location=self._location(assign_stmt),
+            )
+
+        return_stmt = self._call(ctx, "returnStmt")
+        if return_stmt is not None:
+            return AstReturnStmt(
+                value=self._parse_expr(self._call(return_stmt, "expr")),
+                location=self._location(return_stmt),
+            )
+
+        return AstVarDeclStmt(name="", location=self._location(ctx))
+
+    def _parse_statements(self, ctx: Any) -> tuple[AstStatement, ...]:
         statements = self._call(ctx, "statement", []) or []
-        return tuple(statement.getText() for statement in statements)
+        return tuple(self._parse_statement(statement) for statement in statements)
 
     def visitProgram(self, ctx: Any):
         return self.visitChildren(ctx)
@@ -184,7 +361,7 @@ class AstBuilder(_AstBuilderMixin):
                 name=self._call(ctx, "ID").getText(),
                 return_type=self._call(ctx, "typeName").getText(),
                 params=tuple(params),
-                body=self._parse_statement_text(ctx),
+                body=self._parse_statements(ctx),
                 location=self._location(ctx),
             )
         )
@@ -195,7 +372,7 @@ class AstBuilder(_AstBuilderMixin):
             AstKernelDecl(
                 name=self._call(ctx, "ID").getText(),
                 params=self._parse_params(self._call(ctx, "paramList")),
-                body=self._parse_statement_text(ctx),
+                body=self._parse_statements(ctx),
                 location=self._location(ctx),
             )
         )
@@ -206,7 +383,7 @@ class AstBuilder(_AstBuilderMixin):
             AstKernelDecl(
                 name=self._call(ctx, "ID").getText(),
                 params=self._parse_params(self._call(ctx, "paramList")),
-                body=self._parse_statement_text(ctx),
+                body=self._parse_statements(ctx),
                 location=self._location(ctx),
             )
         )
@@ -259,7 +436,7 @@ class AstBuilder(_AstBuilderMixin):
             AstUniformDecl(
                 name=self._call(ctx, "ID").getText(),
                 declared_type=self._call(ctx, "typeName").getText(),
-                initializer=expr_ctx.getText() if expr_ctx else None,
+                initializer=self._parse_expr(expr_ctx) if expr_ctx else None,
                 location=self._location(ctx),
             )
         )
@@ -306,7 +483,7 @@ class AstBuilder(_AstBuilderMixin):
 def build_program_ast(parse_tree: Any, visitor_cls: type) -> AstProgram:
     """Build a typed AST using the parser's generated visitor base class."""
 
-    class _AstBuilderVisitor(visitor_cls, AstBuilder):
+    class _AstBuilderVisitor(AstBuilder, visitor_cls):
         def __init__(self):
             AstBuilder.__init__(self)
 
@@ -316,6 +493,35 @@ def build_program_ast(parse_tree: Any, visitor_cls: type) -> AstProgram:
 
 
 def ast_to_entities(program: AstProgram) -> dict[str, Any]:
+    def _expr_to_text(expr: AstExpr) -> str:
+        if isinstance(expr, AstIntExpr):
+            return str(expr.value)
+        if isinstance(expr, AstFloatExpr):
+            return str(expr.value)
+        if isinstance(expr, AstBoolExpr):
+            return "true" if expr.value else "false"
+        if isinstance(expr, AstLValueExpr):
+            return ".".join(expr.lvalue.parts)
+        if isinstance(expr, AstUnaryExpr):
+            return f"{expr.operator}{_expr_to_text(expr.operand)}"
+        if isinstance(expr, AstBinaryExpr):
+            return f"({_expr_to_text(expr.left)} {expr.operator} {_expr_to_text(expr.right)})"
+        if isinstance(expr, AstCallExpr):
+            return f"{expr.name}({', '.join(_expr_to_text(arg) for arg in expr.args)})"
+        return "0"
+
+    def _statement_to_text(statement: AstStatement) -> str:
+        if isinstance(statement, AstVarDeclStmt):
+            prefix = f"{statement.declared_type} " if statement.declared_type else ""
+            if statement.initializer is None:
+                return f"{prefix}{statement.name};"
+            return f"{prefix}{statement.name} = {_expr_to_text(statement.initializer)};"
+        if isinstance(statement, AstAssignStmt):
+            return f"{'.'.join(statement.target.parts)} = {_expr_to_text(statement.value)};"
+        if isinstance(statement, AstReturnStmt):
+            return f"return {_expr_to_text(statement.value)};"
+        return ";"
+
     streams = []
     accumulators = []
     uniforms = []
@@ -334,7 +540,7 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
             {
                 "name": uniform.name,
                 "type": uniform.declared_type,
-                "initializer": uniform.initializer,
+                "initializer": _expr_to_text(uniform.initializer) if uniform.initializer is not None else None,
             }
             for uniform in pipeline.uniforms
         )
@@ -380,7 +586,7 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                     {"modifier": param.modifier, "type": param.declared_type, "name": param.name}
                     for param in shader.params
                 ],
-                "body": list(shader.body),
+                "body": [_statement_to_text(statement) for statement in shader.body],
             }
             for shader in program.shaders
         ],
@@ -391,7 +597,7 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                     {"modifier": param.modifier, "type": param.declared_type, "name": param.name}
                     for param in flt.params
                 ],
-                "body": list(flt.body),
+                "body": [_statement_to_text(statement) for statement in flt.body],
             }
             for flt in program.filters
         ],
@@ -403,7 +609,7 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                     {"type": param.declared_type, "name": param.name}
                     for param in pure.params
                 ],
-                "body": list(pure.body),
+                "body": [_statement_to_text(statement) for statement in pure.body],
             }
             for pure in program.pure_functions
         ],

--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -1,12 +1,51 @@
 from __future__ import annotations
 
-import re
-from dataclasses import dataclass
 from typing import Any
+
+import functools
 
 from llvmlite import ir
 
-from .ast import AstProgram, ast_to_entities
+from .ast import (
+    AstAssignStmt,
+    AstBinaryExpr,
+    AstBoolExpr,
+    AstCallExpr,
+    AstFloatExpr,
+    AstIntExpr,
+    AstKernelDecl,
+    AstLValueExpr,
+    AstProgram,
+    AstPureDecl,
+    AstReturnStmt,
+    AstStatement,
+    AstUnaryExpr,
+    AstVarDeclStmt,
+    ast_to_entities,
+)
+
+
+@functools.lru_cache(maxsize=256)
+def _parse_statement_text(statement: str) -> AstStatement | None:
+    statement = statement.strip()
+    if not statement:
+        return None
+    if statement.startswith("return") and not statement.startswith("return "):
+        statement = f"return {statement[len("return") :]}"
+    from antlr4 import CommonTokenStream, InputStream
+    from generated.parser.LockstepLexer import LockstepLexer
+    from generated.parser.LockstepParser import LockstepParser
+    from generated.parser.LockstepVisitor import LockstepVisitor
+    from .ast import build_program_ast
+
+    source = f"pure float __tmp() {{ {statement} }}"
+    parser = LockstepParser(CommonTokenStream(LockstepLexer(InputStream(source))))
+    tree = parser.program()
+    program = build_program_ast(tree, LockstepVisitor)
+    if not program.pure_functions:
+        return None
+    body = program.pure_functions[0].body
+    return body[0] if body else None
 
 
 _PRIMITIVE_TYPE_MAP: dict[str, ir.Type] = {
@@ -20,107 +59,6 @@ _PRIMITIVE_TYPE_MAP: dict[str, ir.Type] = {
 
 def _sanitize_symbol(name: str) -> str:
     return "".join(ch if (ch.isalnum() or ch == "_") else "_" for ch in name)
-
-
-def _tokenize_expr(expr: str) -> list[str]:
-    token_pattern = r"\s*(==|!=|<=|>=|&&|\|\||[()+\-*/%,<>!]|[A-Za-z_][A-Za-z0-9_\.]*|\d+\.\d+|\d+|true|false)"
-    return [token for token in re.findall(token_pattern, expr) if token.strip()]
-
-
-@dataclass
-class _ExprParser:
-    tokens: list[str]
-    index: int = 0
-
-    def _peek(self) -> str | None:
-        return self.tokens[self.index] if self.index < len(self.tokens) else None
-
-    def _take(self, token: str | None = None) -> str:
-        current = self._peek()
-        if current is None:
-            raise ValueError("unexpected end of expression")
-        if token is not None and current != token:
-            raise ValueError(f"expected '{token}' but got '{current}'")
-        self.index += 1
-        return current
-
-    def parse(self):
-        return self._parse_or()
-
-    def _parse_or(self):
-        node = self._parse_and()
-        while self._peek() == "||":
-            op = self._take()
-            node = ("bin", op, node, self._parse_and())
-        return node
-
-    def _parse_and(self):
-        node = self._parse_equality()
-        while self._peek() == "&&":
-            op = self._take()
-            node = ("bin", op, node, self._parse_equality())
-        return node
-
-    def _parse_equality(self):
-        node = self._parse_rel()
-        while self._peek() in {"==", "!="}:
-            op = self._take()
-            node = ("bin", op, node, self._parse_rel())
-        return node
-
-    def _parse_rel(self):
-        node = self._parse_add()
-        while self._peek() in {"<", "<=", ">", ">="}:
-            op = self._take()
-            node = ("bin", op, node, self._parse_add())
-        return node
-
-    def _parse_add(self):
-        node = self._parse_mul()
-        while self._peek() in {"+", "-"}:
-            op = self._take()
-            node = ("bin", op, node, self._parse_mul())
-        return node
-
-    def _parse_mul(self):
-        node = self._parse_unary()
-        while self._peek() in {"*", "/", "%"}:
-            op = self._take()
-            node = ("bin", op, node, self._parse_unary())
-        return node
-
-    def _parse_unary(self):
-        if self._peek() in {"-", "!"}:
-            op = self._take()
-            return ("un", op, self._parse_unary())
-        return self._parse_primary()
-
-    def _parse_primary(self):
-        token = self._peek()
-        if token == "(":
-            self._take("(")
-            node = self._parse_or()
-            self._take(")")
-            return node
-        token = self._take()
-        if re.match(r"\d+\.\d+", token):
-            return ("float", float(token))
-        if re.match(r"\d+", token):
-            return ("int", int(token))
-        if token in {"true", "false"}:
-            return ("bool", token == "true")
-        if self._peek() == "(":
-            self._take("(")
-            args = []
-            if self._peek() != ")":
-                while True:
-                    args.append(self._parse_or())
-                    if self._peek() != ",":
-                        break
-                    self._take(",")
-            self._take(")")
-            return ("call", token, args)
-        return ("var", token)
 
 
 class _FunctionLowerer:
@@ -236,8 +174,8 @@ class _FunctionLowerer:
             return self.builder.icmp_signed(rel_map[op], lhs, rhs)
         raise TypeError(f"operator '{op}' requires comparable operands, got {lhs.type}")
 
-    def _load_var(self, name: str) -> ir.Value:
-        parts = name.split(".")
+    def _load_var(self, name_or_parts: str | tuple[str, ...]) -> ir.Value:
+        parts = name_or_parts.split(".") if isinstance(name_or_parts, str) else list(name_or_parts)
         base_key = _sanitize_symbol(parts[0])
         if base_key in self.locals:
             base_value = self.builder.load(self.locals[base_key], name=f"{base_key}_val")
@@ -246,28 +184,25 @@ class _FunctionLowerer:
             return self._extract_field_path(base_value, parts[1:])
         return ir.Constant(ir.FloatType(), 0.0)
 
-    def _parse_expr(self, expr: str):
-        parser = _ExprParser(_tokenize_expr(expr))
-        return parser.parse()
-
-    def _lower_expr(self, node):
-        kind = node[0]
-        if kind == "float":
-            return ir.Constant(ir.FloatType(), node[1])
-        if kind == "int":
-            return ir.Constant(ir.IntType(32), node[1])
-        if kind == "bool":
-            return ir.Constant(ir.IntType(1), int(node[1]))
-        if kind == "var":
-            return self._load_var(node[1])
-        if kind == "un":
-            op, operand = node[1], self._lower_expr(node[2])
+    def _lower_expr(self, expr):
+        if isinstance(expr, str):
+            raise TypeError("string expressions are not supported in typed lowering")
+        if isinstance(expr, AstFloatExpr):
+            return ir.Constant(ir.FloatType(), expr.value)
+        if isinstance(expr, AstIntExpr):
+            return ir.Constant(ir.IntType(32), expr.value)
+        if isinstance(expr, AstBoolExpr):
+            return ir.Constant(ir.IntType(1), int(expr.value))
+        if isinstance(expr, AstLValueExpr):
+            return self._load_var(expr.lvalue.parts)
+        if isinstance(expr, AstUnaryExpr):
+            op, operand = expr.operator, self._lower_expr(expr.operand)
             if op == "-":
                 return self._emit_numeric_unary_minus(operand)
             return self.builder.not_(operand)
-        if kind == "call":
-            name = node[1]
-            args = [self._lower_expr(arg) for arg in node[2]]
+        if isinstance(expr, AstCallExpr):
+            name = expr.name
+            args = [self._lower_expr(arg) for arg in expr.args]
             if name == "mix" and len(args) == 3:
                 if not all(isinstance(arg.type, ir.FloatType) for arg in args):
                     raise TypeError("mix expects float arguments")
@@ -287,7 +222,9 @@ class _FunctionLowerer:
                 return self.builder.call(callee, coerced, name=f"call_{name}")
             return ir.Constant(ir.FloatType(), 0.0)
 
-        op, lhs, rhs = node[1], self._lower_expr(node[2]), self._lower_expr(node[3])
+        if not isinstance(expr, AstBinaryExpr):
+            return ir.Constant(ir.FloatType(), 0.0)
+        op, lhs, rhs = expr.operator, self._lower_expr(expr.left), self._lower_expr(expr.right)
         if op in {"+", "-", "*", "/", "%"}:
             return self._emit_numeric_binary(op, lhs, rhs)
         if op in {"<", "<=", ">", ">=", "==", "!="}:
@@ -298,26 +235,24 @@ class _FunctionLowerer:
             return self.builder.or_(lhs, rhs)
         return ir.Constant(ir.FloatType(), 0.0)
 
-    def _lower_statement(self, statement: str, return_type: ir.Type):
-        statement = statement.strip()
-        if statement.startswith("return"):
-            expr = statement[len("return") :].strip().rstrip(";")
-            value = self._lower_expr(self._parse_expr(expr))
+    def _lower_statement(self, statement: AstStatement | str, return_type: ir.Type):
+        if isinstance(statement, str):
+            parsed_statement = _parse_statement_text(statement)
+            if parsed_statement is None:
+                return
+            statement = parsed_statement
+        if isinstance(statement, AstReturnStmt):
+            value = self._lower_expr(statement.value)
             if isinstance(return_type, ir.VoidType):
                 self.builder.ret_void()
             else:
                 self.builder.ret(self._coerce_value_to_type(value, return_type))
             return
 
-        if "=" in statement:
-            lhs, rhs = statement.rstrip(";").split("=", 1)
-            lhs = lhs.strip()
-            rhs = rhs.strip()
-            lhs_parts = lhs.split()
-            name = lhs_parts[-1]
-            base_name, *field_path = name.split(".")
+        if isinstance(statement, AstAssignStmt):
+            base_name, *field_path = statement.target.parts
             key = _sanitize_symbol(base_name)
-            value = self._lower_expr(self._parse_expr(rhs))
+            value = self._lower_expr(statement.value)
             if key not in self.locals:
                 slot = self.builder.alloca(value.type, name=key)
                 self.locals[key] = slot
@@ -331,18 +266,25 @@ class _FunctionLowerer:
             self.builder.store(updated, self.locals[key])
             return
 
-        if statement.endswith(";"):
-            maybe_decl = statement[:-1].split()
-            if maybe_decl:
-                declared_type = maybe_decl[0] if len(maybe_decl) > 1 else "float"
-                key = _sanitize_symbol(maybe_decl[-1].replace(".", "_"))
-                if key not in self.locals:
-                    llvm_type = self._llvm_type(declared_type, self.known_structs)
-                    slot = self.builder.alloca(llvm_type, name=key)
-                    self.locals[key] = slot
-                    self.builder.store(ir.Constant(llvm_type, None), slot)
+        if isinstance(statement, AstVarDeclStmt):
+            key = _sanitize_symbol(statement.name.replace(".", "_"))
+            initializer = self._lower_expr(statement.initializer) if statement.initializer is not None else None
+            if key not in self.locals:
+                if statement.declared_type is not None:
+                    llvm_type = self._llvm_type(statement.declared_type, self.known_structs)
+                elif initializer is not None:
+                    llvm_type = initializer.type
+                else:
+                    llvm_type = ir.FloatType()
+                slot = self.builder.alloca(llvm_type, name=key)
+                self.locals[key] = slot
+            if initializer is None:
+                self.builder.store(ir.Constant(self.locals[key].type.pointee, None), self.locals[key])
+            else:
+                coerced = self._coerce_value_to_type(initializer, self.locals[key].type.pointee)
+                self.builder.store(coerced, self.locals[key])
 
-    def lower_function(self, fn: ir.Function, statements: list[str], return_type: ir.Type):
+    def lower_function(self, fn: ir.Function, statements: list[AstStatement | str], return_type: ir.Type):
         block = fn.append_basic_block("entry")
         self.builder = ir.IRBuilder(block)
         self.locals = {}
@@ -365,16 +307,16 @@ class _FunctionLowerer:
                 self.builder.ret(ir.Constant(return_type, None))
 
 
-def _normalize_codegen_input(program_or_entities: AstProgram | dict[str, Any]) -> dict[str, Any]:
+def _normalize_codegen_input(program_or_entities: AstProgram | dict[str, Any]) -> tuple[AstProgram | None, dict[str, Any]]:
     if isinstance(program_or_entities, AstProgram):
-        return ast_to_entities(program_or_entities)
-    return program_or_entities
+        return program_or_entities, ast_to_entities(program_or_entities)
+    return None, program_or_entities
 
 
 def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
     """Generate LLVM IR using llvmlite lowering for pure/kernels."""
 
-    entities = _normalize_codegen_input(program_or_entities)
+    typed_program, entities = _normalize_codegen_input(program_or_entities)
 
     structs = entities.get("structs", [])
     shaders = entities.get("shaders", [])
@@ -457,17 +399,28 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
 
     lowerer.function_map = function_map
 
+    typed_pure_by_name: dict[str, AstPureDecl] = {}
+    typed_shaders_by_name: dict[str, AstKernelDecl] = {}
+    typed_filters_by_name: dict[str, AstKernelDecl] = {}
+    if typed_program is not None:
+        typed_pure_by_name = {decl.name: decl for decl in typed_program.pure_functions}
+        typed_shaders_by_name = {decl.name: decl for decl in typed_program.shaders}
+        typed_filters_by_name = {decl.name: decl for decl in typed_program.filters}
+
     for pure in pure_functions:
         fn = function_map[f"pure_{_sanitize_symbol(pure['name'])}"]
-        lowerer.lower_function(fn, pure.get("body", []), fn.function_type.return_type)
+        typed_decl = typed_pure_by_name.get(pure["name"])
+        lowerer.lower_function(fn, list(typed_decl.body) if typed_decl else pure.get("body", []), fn.function_type.return_type)
 
     for shader in shaders:
         fn = function_map[f"shader_{_sanitize_symbol(shader['name'])}"]
-        lowerer.lower_function(fn, shader.get("body", []), ir.VoidType())
+        typed_decl = typed_shaders_by_name.get(shader["name"])
+        lowerer.lower_function(fn, list(typed_decl.body) if typed_decl else shader.get("body", []), ir.VoidType())
 
     for flt in filters:
         fn = function_map[f"filter_{_sanitize_symbol(flt['name'])}"]
-        lowerer.lower_function(fn, flt.get("body", []), ir.VoidType())
+        typed_decl = typed_filters_by_name.get(flt["name"])
+        lowerer.lower_function(fn, list(typed_decl.body) if typed_decl else flt.get("body", []), ir.VoidType())
 
     stream_globals: dict[str, ir.GlobalVariable] = {}
     stream_capacities: dict[str, int] = {}


### PR DESCRIPTION
### Motivation
- The previous pipeline discarded ANTLR expression parse trees and re-parsed function bodies with a regex tokenizer and a custom `_ExprParser`, which duplicated parsing logic and lost precise source locations for expressions and statements.
- This made semantic diagnostics fragile and prevented the code generator from leveraging the parser's accurate precedence and location data.
- The change aims to preserve the full ANTLR expression/statement structure in the typed AST and use that in lowering to remove the brittle regex parser path.

### Description
- Add a strongly-typed expression and statement model to `ast.py` (`AstExpr`, `AstStatement`, `AstBinaryExpr`, `AstCallExpr`, `AstVarDeclStmt`, `AstAssignStmt`, `AstReturnStmt`, etc.) and change `AstPureDecl`, `AstKernelDecl`, and `AstUniformDecl` to store typed nodes instead of raw strings.
- Update `AstBuilder` to walk ANTLR expression/statement contexts and produce these typed dataclasses (including source `AstLocation`) and fix the `build_program_ast` MRO so the custom builder is actually used.
- Update `ast_to_entities` to serialize typed expressions/statements back to text for backwards compatibility with the entity/dict code paths.
- Rework `codegen.py` to lower typed AST nodes directly (remove the regex `_tokenize_expr` + `_ExprParser` path), add a cached `_parse_statement_text` fallback which uses ANTLR to parse legacy string statements on-demand, and make `emit_llvm_ir` prefer typed `AstProgram` bodies when available.

### Testing
- Ran targeted pytest invocations: `python -m pytest -q -o addopts='' tests/test_compiler_api.py` and `python -m pytest -q -o addopts='' tests/test_expr_precedence.py tests/test_simulator.py tests/test_cli_format.py`, and all tests in those suites passed.
- Ran narrower tests during development such as `tests/test_compiler_api.py::test_emit_llvm_ir_keeps_integer_arithmetic_in_integer_domain` and `tests/test_compiler_api.py::test_emit_llvm_ir_generates_expected_declarations`, which succeeded after fixes to the parsing fallback.
- Verified bytecode compilation with `python -m compileall lockstep_compiler` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a756f67a38832885497f57c6dedc8d)