### PR TITLE
Preserve parsed statement/expr AST shape through codegen

### DIFF
--- a/lockstep_compiler/ast.py
+++ b/lockstep_compiler/ast.py
@@ -11,6 +11,60 @@ class AstLocation:
 
 
 @dataclass(frozen=True)
+class AstExprLiteral:
+    kind: str
+    value: str
+
+
+@dataclass(frozen=True)
+class AstExprVar:
+    path: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AstExprUnary:
+    op: str
+    operand: "AstExpr"
+
+
+@dataclass(frozen=True)
+class AstExprBinary:
+    op: str
+    left: "AstExpr"
+    right: "AstExpr"
+
+
+@dataclass(frozen=True)
+class AstExprCall:
+    name: str
+    args: tuple["AstExpr", ...]
+
+
+AstExpr = AstExprLiteral | AstExprVar | AstExprUnary | AstExprBinary | AstExprCall
+
+
+@dataclass(frozen=True)
+class AstVarDeclStmt:
+    declared_type: str | None
+    name: str
+    initializer: AstExpr | None
+
+
+@dataclass(frozen=True)
+class AstAssignStmt:
+    target: tuple[str, ...]
+    value: AstExpr
+
+
+@dataclass(frozen=True)
+class AstReturnStmt:
+    value: AstExpr
+
+
+AstStatement = AstVarDeclStmt | AstAssignStmt | AstReturnStmt
+
+
+@dataclass(frozen=True)
 class AstKernelParam:
     modifier: str
     declared_type: str
@@ -35,7 +89,7 @@ class AstPureDecl:
     name: str
     return_type: str
     params: tuple[AstKernelParam, ...] = ()
-    body: tuple[str, ...] = ()
+    body: tuple[AstStatement, ...] = ()
     location: AstLocation = AstLocation()
 
 
@@ -43,7 +97,7 @@ class AstPureDecl:
 class AstKernelDecl:
     name: str
     params: tuple[AstKernelParam, ...] = ()
-    body: tuple[str, ...] = ()
+    body: tuple[AstStatement, ...] = ()
     location: AstLocation = AstLocation()
 
 
@@ -155,9 +209,96 @@ class AstBuilder(_AstBuilderMixin):
             params.append(AstKernelParam(modifier=modifier, declared_type=declared_type, name=name))
         return tuple(params)
 
-    def _parse_statement_text(self, ctx: Any) -> tuple[str, ...]:
+    def _parse_lvalue(self, lvalue_ctx: Any) -> tuple[str, ...]:
+        return tuple(token.getText() for token in self._call(lvalue_ctx, "ID", []) or [])
+
+    def _parse_left_associative(self, ctx: Any, sub_expr_getter: str):
+        parts = self._call(ctx, sub_expr_getter, []) or []
+        if not parts:
+            raise ValueError("malformed expression tree")
+        node = self._parse_expr(parts[0])
+        for index, part in enumerate(parts[1:], start=1):
+            op = ctx.getChild(index * 2 - 1).getText()
+            node = AstExprBinary(op=op, left=node, right=self._parse_expr(part))
+        return node
+
+    def _parse_expr(self, expr_ctx: Any):
+        class_name = expr_ctx.__class__.__name__
+
+        if class_name == "ExprContext":
+            return self._parse_expr(self._call(expr_ctx, "logicalExpr"))
+        if class_name == "LogicalExprContext":
+            return self._parse_expr(self._call(expr_ctx, "logicalOrExpr"))
+        if class_name == "LogicalOrExprContext":
+            return self._parse_left_associative(expr_ctx, "logicalAndExpr")
+        if class_name == "LogicalAndExprContext":
+            return self._parse_left_associative(expr_ctx, "equalityExpr")
+        if class_name == "EqualityExprContext":
+            return self._parse_left_associative(expr_ctx, "relExpr")
+        if class_name == "RelExprContext":
+            return self._parse_left_associative(expr_ctx, "addExpr")
+        if class_name == "AddExprContext":
+            return self._parse_left_associative(expr_ctx, "mulExpr")
+        if class_name == "MulExprContext":
+            return self._parse_left_associative(expr_ctx, "unaryExpr")
+        if class_name == "UnaryExprContext":
+            nested = self._call(expr_ctx, "unaryExpr")
+            if nested is not None:
+                return AstExprUnary(op=expr_ctx.getChild(0).getText(), operand=self._parse_expr(nested))
+            return self._parse_expr(self._call(expr_ctx, "primaryExpr"))
+        if class_name == "PrimaryExprContext":
+            inner = self._call(expr_ctx, "expr")
+            if inner is not None:
+                return self._parse_expr(inner)
+            expr_list = self._call(expr_ctx, "exprList")
+            id_token = self._call(expr_ctx, "ID")
+            if id_token is not None and expr_ctx.getChildCount() >= 3 and expr_ctx.getChild(1).getText() == "(":
+                args = ()
+                if expr_list is not None:
+                    args = tuple(self._parse_expr(child) for child in self._call(expr_list, "expr", []) or [])
+                return AstExprCall(name=id_token.getText(), args=args)
+            lvalue = self._call(expr_ctx, "lvalue")
+            if lvalue is not None:
+                return AstExprVar(path=self._parse_lvalue(lvalue))
+            if self._call(expr_ctx, "INT") is not None:
+                return AstExprLiteral(kind="int", value=self._call(expr_ctx, "INT").getText())
+            if self._call(expr_ctx, "FLOAT") is not None:
+                return AstExprLiteral(kind="float", value=self._call(expr_ctx, "FLOAT").getText())
+            if self._call(expr_ctx, "BOOL") is not None:
+                return AstExprLiteral(kind="bool", value=self._call(expr_ctx, "BOOL").getText())
+        raise ValueError(f"unsupported expression node: {class_name}")
+
+    def _parse_statement_text(self, ctx: Any) -> tuple[AstStatement, ...]:
         statements = self._call(ctx, "statement", []) or []
-        return tuple(statement.getText() for statement in statements)
+        parsed: list[AstStatement] = []
+        for statement in statements:
+            var_decl = self._call(statement, "varDecl")
+            if var_decl is not None:
+                declared_type = self._call(var_decl, "typeName")
+                initializer_ctx = self._call(var_decl, "expr")
+                parsed.append(
+                    AstVarDeclStmt(
+                        declared_type=declared_type.getText() if declared_type else None,
+                        name=self._call(var_decl, "ID").getText(),
+                        initializer=self._parse_expr(initializer_ctx) if initializer_ctx else None,
+                    )
+                )
+                continue
+
+            assign_stmt = self._call(statement, "assignStmt")
+            if assign_stmt is not None:
+                parsed.append(
+                    AstAssignStmt(
+                        target=self._parse_lvalue(self._call(assign_stmt, "lvalue")),
+                        value=self._parse_expr(self._call(assign_stmt, "expr")),
+                    )
+                )
+                continue
+
+            return_stmt = self._call(statement, "returnStmt")
+            if return_stmt is not None:
+                parsed.append(AstReturnStmt(value=self._parse_expr(self._call(return_stmt, "expr"))))
+        return tuple(parsed)
 
     def visitProgram(self, ctx: Any):
         return self.visitChildren(ctx)
@@ -306,7 +447,7 @@ class AstBuilder(_AstBuilderMixin):
 def build_program_ast(parse_tree: Any, visitor_cls: type) -> AstProgram:
     """Build a typed AST using the parser's generated visitor base class."""
 
-    class _AstBuilderVisitor(visitor_cls, AstBuilder):
+    class _AstBuilderVisitor(AstBuilder, visitor_cls):
         def __init__(self):
             AstBuilder.__init__(self)
 
@@ -316,6 +457,27 @@ def build_program_ast(parse_tree: Any, visitor_cls: type) -> AstProgram:
 
 
 def ast_to_entities(program: AstProgram) -> dict[str, Any]:
+    def _expr_to_text(expr: AstExpr) -> str:
+        if isinstance(expr, AstExprLiteral):
+            return expr.value
+        if isinstance(expr, AstExprVar):
+            return ".".join(expr.path)
+        if isinstance(expr, AstExprUnary):
+            return f"{expr.op}{_expr_to_text(expr.operand)}"
+        if isinstance(expr, AstExprBinary):
+            return f"({_expr_to_text(expr.left)} {expr.op} {_expr_to_text(expr.right)})"
+        return f"{expr.name}({', '.join(_expr_to_text(arg) for arg in expr.args)})"
+
+    def _statement_to_text(statement: AstStatement) -> str:
+        if isinstance(statement, AstVarDeclStmt):
+            prefix = f"{statement.declared_type} " if statement.declared_type else ""
+            if statement.initializer is None:
+                return f"{prefix}{statement.name};"
+            return f"{prefix}{statement.name} = {_expr_to_text(statement.initializer)};"
+        if isinstance(statement, AstAssignStmt):
+            return f"{'.'.join(statement.target)} = {_expr_to_text(statement.value)};"
+        return f"return {_expr_to_text(statement.value)};"
+
     streams = []
     accumulators = []
     uniforms = []
@@ -380,7 +542,8 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                     {"modifier": param.modifier, "type": param.declared_type, "name": param.name}
                     for param in shader.params
                 ],
-                "body": list(shader.body),
+                "body": [_statement_to_text(statement) for statement in shader.body],
+                "body_ast": list(shader.body),
             }
             for shader in program.shaders
         ],
@@ -391,7 +554,8 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                     {"modifier": param.modifier, "type": param.declared_type, "name": param.name}
                     for param in flt.params
                 ],
-                "body": list(flt.body),
+                "body": [_statement_to_text(statement) for statement in flt.body],
+                "body_ast": list(flt.body),
             }
             for flt in program.filters
         ],
@@ -403,7 +567,8 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                     {"type": param.declared_type, "name": param.name}
                     for param in pure.params
                 ],
-                "body": list(pure.body),
+                "body": [_statement_to_text(statement) for statement in pure.body],
+                "body_ast": list(pure.body),
             }
             for pure in program.pure_functions
         ],

--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -6,7 +6,19 @@ from typing import Any
 
 from llvmlite import ir
 
-from .ast import AstProgram, ast_to_entities
+from .ast import (
+    AstAssignStmt,
+    AstExprBinary,
+    AstExprCall,
+    AstExprLiteral,
+    AstExprUnary,
+    AstExprVar,
+    AstProgram,
+    AstReturnStmt,
+    AstStatement,
+    AstVarDeclStmt,
+    ast_to_entities,
+)
 
 
 _PRIMITIVE_TYPE_MAP: dict[str, ir.Type] = {
@@ -250,7 +262,54 @@ class _FunctionLowerer:
         parser = _ExprParser(_tokenize_expr(expr))
         return parser.parse()
 
+    def _lower_call(self, name: str, args: list[ir.Value]) -> ir.Value:
+        if name == "mix" and len(args) == 3:
+            if not all(isinstance(arg.type, ir.FloatType) for arg in args):
+                return ir.Constant(ir.FloatType(), 0.0)
+            a, b, t = args
+            one_minus_t = self.builder.fsub(ir.Constant(ir.FloatType(), 1.0), t, name="mix_one_minus_t")
+            return self.builder.fadd(self.builder.fmul(a, one_minus_t), self.builder.fmul(b, t), name="mix")
+        if name == "step" and len(args) == 2:
+            if not all(isinstance(arg.type, ir.FloatType) for arg in args):
+                return ir.Constant(ir.FloatType(), 0.0)
+            edge = args[0]
+            x_val = args[1]
+            cmp_result = self.builder.fcmp_ordered(">=", x_val, edge, name="step_cmp")
+            return self.builder.uitofp(cmp_result, ir.FloatType(), name="step")
+        callee = self.function_map.get(f"pure_{_sanitize_symbol(name)}")
+        if callee is not None:
+            coerced = [self._coerce_value_to_type(arg, param.type) for arg, param in zip(args, callee.args)]
+            return self.builder.call(callee, coerced, name=f"call_{name}")
+        return ir.Constant(ir.FloatType(), 0.0)
+
     def _lower_expr(self, node):
+        if isinstance(node, AstExprLiteral):
+            if node.kind == "float":
+                return ir.Constant(ir.FloatType(), float(node.value))
+            if node.kind == "int":
+                return ir.Constant(ir.IntType(32), int(node.value))
+            return ir.Constant(ir.IntType(1), int(node.value == "true"))
+        if isinstance(node, AstExprVar):
+            return self._load_var(".".join(node.path))
+        if isinstance(node, AstExprUnary):
+            operand = self._lower_expr(node.operand)
+            if node.op == "-":
+                return self._emit_numeric_unary_minus(operand)
+            return self.builder.not_(operand)
+        if isinstance(node, AstExprCall):
+            return self._lower_call(node.name, [self._lower_expr(arg) for arg in node.args])
+        if isinstance(node, AstExprBinary):
+            op, lhs, rhs = node.op, self._lower_expr(node.left), self._lower_expr(node.right)
+            if op in {"+", "-", "*", "/", "%"}:
+                return self._emit_numeric_binary(op, lhs, rhs)
+            if op in {"<", "<=", ">", ">=", "==", "!="}:
+                return self._emit_relational_compare(op, lhs, rhs)
+            if op == "&&":
+                return self.builder.and_(lhs, rhs)
+            if op == "||":
+                return self.builder.or_(lhs, rhs)
+            return ir.Constant(ir.FloatType(), 0.0)
+
         kind = node[0]
         if kind == "float":
             return ir.Constant(ir.FloatType(), node[1])
@@ -266,26 +325,7 @@ class _FunctionLowerer:
                 return self._emit_numeric_unary_minus(operand)
             return self.builder.not_(operand)
         if kind == "call":
-            name = node[1]
-            args = [self._lower_expr(arg) for arg in node[2]]
-            if name == "mix" and len(args) == 3:
-                if not all(isinstance(arg.type, ir.FloatType) for arg in args):
-                    return ir.Constant(ir.FloatType(), 0.0)
-                a, b, t = args
-                one_minus_t = self.builder.fsub(ir.Constant(ir.FloatType(), 1.0), t, name="mix_one_minus_t")
-                return self.builder.fadd(self.builder.fmul(a, one_minus_t), self.builder.fmul(b, t), name="mix")
-            if name == "step" and len(args) == 2:
-                if not all(isinstance(arg.type, ir.FloatType) for arg in args):
-                    return ir.Constant(ir.FloatType(), 0.0)
-                edge = args[0]
-                x_val = args[1]
-                cmp_result = self.builder.fcmp_ordered(">=", x_val, edge, name="step_cmp")
-                return self.builder.uitofp(cmp_result, ir.FloatType(), name="step")
-            callee = self.function_map.get(f"pure_{_sanitize_symbol(name)}")
-            if callee is not None:
-                coerced = [self._coerce_value_to_type(arg, param.type) for arg, param in zip(args, callee.args)]
-                return self.builder.call(callee, coerced, name=f"call_{name}")
-            return ir.Constant(ir.FloatType(), 0.0)
+            return self._lower_call(node[1], [self._lower_expr(arg) for arg in node[2]])
 
         op, lhs, rhs = node[1], self._lower_expr(node[2]), self._lower_expr(node[3])
         if op in {"+", "-", "*", "/", "%"}:
@@ -298,7 +338,48 @@ class _FunctionLowerer:
             return self.builder.or_(lhs, rhs)
         return ir.Constant(ir.FloatType(), 0.0)
 
-    def _lower_statement(self, statement: str, return_type: ir.Type):
+    def _lower_assignment(self, target_name: str, value: ir.Value):
+        base_name, *field_path = target_name.split(".")
+        key = _sanitize_symbol(base_name)
+        if key not in self.locals:
+            slot = self.builder.alloca(value.type, name=key)
+            self.locals[key] = slot
+        if not field_path:
+            slot_type = self.locals[key].type.pointee
+            self.builder.store(self._coerce_value_to_type(value, slot_type), self.locals[key])
+            return
+
+        current = self.builder.load(self.locals[key], name=f"{key}_val")
+        updated = self._insert_field_path(current, field_path, value)
+        self.builder.store(updated, self.locals[key])
+
+    def _lower_statement(self, statement: str | AstStatement, return_type: ir.Type):
+        if isinstance(statement, AstReturnStmt):
+            value = self._lower_expr(statement.value)
+            if isinstance(return_type, ir.VoidType):
+                self.builder.ret_void()
+            else:
+                self.builder.ret(self._coerce_value_to_type(value, return_type))
+            return
+
+        if isinstance(statement, AstAssignStmt):
+            self._lower_assignment(".".join(statement.target), self._lower_expr(statement.value))
+            return
+
+        if isinstance(statement, AstVarDeclStmt):
+            key = _sanitize_symbol(statement.name)
+            declared_type = statement.declared_type or "float"
+            llvm_type = self._llvm_type(declared_type, self.known_structs)
+            if key not in self.locals:
+                slot = self.builder.alloca(llvm_type, name=key)
+                self.locals[key] = slot
+                self.builder.store(ir.Constant(llvm_type, None), slot)
+            if statement.initializer is not None:
+                value = self._lower_expr(statement.initializer)
+                slot_type = self.locals[key].type.pointee
+                self.builder.store(self._coerce_value_to_type(value, slot_type), self.locals[key])
+            return
+
         statement = statement.strip()
         if statement.startswith("return"):
             expr = statement[len("return") :].strip().rstrip(";")
@@ -315,20 +396,7 @@ class _FunctionLowerer:
             rhs = rhs.strip()
             lhs_parts = lhs.split()
             name = lhs_parts[-1]
-            base_name, *field_path = name.split(".")
-            key = _sanitize_symbol(base_name)
-            value = self._lower_expr(self._parse_expr(rhs))
-            if key not in self.locals:
-                slot = self.builder.alloca(value.type, name=key)
-                self.locals[key] = slot
-            if not field_path:
-                slot_type = self.locals[key].type.pointee
-                self.builder.store(self._coerce_value_to_type(value, slot_type), self.locals[key])
-                return
-
-            current = self.builder.load(self.locals[key], name=f"{key}_val")
-            updated = self._insert_field_path(current, field_path, value)
-            self.builder.store(updated, self.locals[key])
+            self._lower_assignment(name, self._lower_expr(self._parse_expr(rhs)))
             return
 
         if statement.endswith(";"):
@@ -342,7 +410,7 @@ class _FunctionLowerer:
                     self.locals[key] = slot
                     self.builder.store(ir.Constant(llvm_type, None), slot)
 
-    def lower_function(self, fn: ir.Function, statements: list[str], return_type: ir.Type):
+    def lower_function(self, fn: ir.Function, statements: list[str | AstStatement], return_type: ir.Type):
         block = fn.append_basic_block("entry")
         self.builder = ir.IRBuilder(block)
         self.locals = {}
@@ -459,15 +527,15 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
 
     for pure in pure_functions:
         fn = function_map[f"pure_{_sanitize_symbol(pure['name'])}"]
-        lowerer.lower_function(fn, pure.get("body", []), fn.function_type.return_type)
+        lowerer.lower_function(fn, pure.get("body_ast", pure.get("body", [])), fn.function_type.return_type)
 
     for shader in shaders:
         fn = function_map[f"shader_{_sanitize_symbol(shader['name'])}"]
-        lowerer.lower_function(fn, shader.get("body", []), ir.VoidType())
+        lowerer.lower_function(fn, shader.get("body_ast", shader.get("body", [])), ir.VoidType())
 
     for flt in filters:
         fn = function_map[f"filter_{_sanitize_symbol(flt['name'])}"]
-        lowerer.lower_function(fn, flt.get("body", []), ir.VoidType())
+        lowerer.lower_function(fn, flt.get("body_ast", flt.get("body", [])), ir.VoidType())
 
     arena_fields: list[tuple[str, str, ir.Type]] = []
     stream_slots: dict[str, int] = {}

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -353,3 +353,26 @@ def test_emit_llvm_ir_does_not_raise_on_mixed_int_float_expression():
     )
 
     assert 'define float @"pure_bad_mix"()' in llvm_ir
+
+
+def test_compile_lockstep_builds_structured_statement_ast():
+    from lockstep_compiler.ast import AstExprBinary, AstExprVar, AstReturnStmt
+
+    result = compiler_module.compile_lockstep(
+        """
+        pure float f(float x, float y) {
+            return x + y * x;
+        }
+        pipeline Main {
+            bind { }
+        }
+        """,
+        verbose=False,
+    )
+
+    body = result.ast.pure_functions[0].body
+    assert isinstance(body[0], AstReturnStmt)
+    assert isinstance(body[0].value, AstExprBinary)
+    assert body[0].value.op == "+"
+    assert isinstance(body[0].value.left, AstExprVar)
+    assert isinstance(body[0].value.right, AstExprBinary)


### PR DESCRIPTION
### Motivation
- The parser visitor was flattening statement/expressions to strings (`statement.getText()`) which forced the backend to re-parse text with a regex-based expression parser, creating a dangerous dual-source-of-truth between ANTLR trees and the regex parser. 
- The goal is to preserve the ANTLR parse structure in the AST so lowering can consume a single, authoritative tree and avoid fragile re-tokenization.

### Description
- Introduced structured expression and statement node types (`AstExpr*`, `AstVarDeclStmt`, `AstAssignStmt`, `AstReturnStmt`) and changed `AstPureDecl`/`AstKernelDecl` bodies to `tuple[AstStatement, ...]` so the AST preserves parse structure (`lockstep_compiler/ast.py`).
- Implemented expression/statement construction in `AstBuilder` by walking ANTLR contexts (lvalues, calls, literals, unary/binary precedence chains) and replaced the previous `statement.getText()` flattening with typed nodes; also fixed visitor MRO so `AstBuilder` overrides are effective (`build_program_ast` order change).
- Kept backward compatibility in `ast_to_entities` by exporting both textual `body` (generated from structured nodes) and the new `body_ast` so existing consumers still receive strings while the lowerer can use the structured AST.
- Updated lowering in `codegen.py` to lower directly from structured AST (`body_ast`) with new helpers (`_lower_call`, `_lower_assignment`, structured `_lower_expr`/`_lower_statement`) and retained the legacy regex parsing only as a fallback for dict-based inputs.
- Added a compiler API test `test_compile_lockstep_builds_structured_statement_ast` validating that `compile_lockstep` produces structured statement/expression nodes for pure function bodies (`tests/test_compiler_api.py`).

### Testing
- Ran the targeted test suite with coverage flags disabled using `pytest -q -o addopts='' tests/test_compiler_api.py tests/test_expr_precedence.py tests/test_optimizer.py` and all tests passed with `16 passed, 6 skipped`.
- Also exercised the compiler API and ad-hoc checks to verify `AstProgram` contains `pure_functions` with structured `AstReturnStmt` and nested `AstExprBinary` nodes, and confirmed LLVM emission still succeeds for existing integration cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7595e29c08328b687e8ab55b10191)