### PR TITLE
Validate simulator input JSON shape and surface CLI errors

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -197,6 +197,9 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
         except json.JSONDecodeError as err:
             print(f"Unable to parse simulation input JSON: {err}", file=stderr)
             return 1
+        except ValueError as err:
+            print(f"Invalid simulation input: {err}", file=stderr)
+            return 1
 
         entities = getattr(result, "entities", result)
         simulation = simulate_pipeline_entities(

--- a/lockstep_compiler/simulator.py
+++ b/lockstep_compiler/simulator.py
@@ -159,4 +159,21 @@ def simulate_pipeline_source(source_code: str, *, stream_inputs=None, accumulato
 
 def parse_simulation_inputs(raw: str) -> tuple[dict[str, list[Any]], dict[str, list[Any]]]:
     payload = json.loads(raw) if raw.strip() else {}
-    return payload.get("streams", {}), payload.get("accumulators", {})
+
+    if not isinstance(payload, dict):
+        raise ValueError("Invalid simulation input at '<root>': expected an object.")
+
+    def _validate_input_map(field: str) -> dict[str, list[Any]]:
+        value = payload.get(field, {})
+        if not isinstance(value, dict):
+            raise ValueError(f"Invalid simulation input at '{field}': expected an object map.")
+        for name, rows in value.items():
+            if not isinstance(rows, list):
+                raise ValueError(
+                    f"Invalid simulation input at '{field}.{name}': expected a list of values."
+                )
+        return value
+
+    streams = _validate_input_map("streams")
+    accumulators = _validate_input_map("accumulators")
+    return streams, accumulators

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -8,7 +8,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from lockstep_compiler.cli import run_cli
-from lockstep_compiler.simulator import simulate_pipeline_entities
+from lockstep_compiler.simulator import parse_simulation_inputs, simulate_pipeline_entities
 
 
 def test_simulate_pipeline_entities_tracks_route_cardinality_and_fold():
@@ -151,3 +151,59 @@ def test_simulate_pipeline_entities_saturates_stream_writes_at_capacity():
         {"_source": 1, "_kernel": "Project"},
         {"_source": 4, "_kernel": "Project"},
     ]
+
+
+
+def test_parse_simulation_inputs_rejects_non_object_root():
+    try:
+        parse_simulation_inputs('[1, 2, 3]')
+    except ValueError as err:
+        assert "<root>" in str(err)
+    else:
+        raise AssertionError("Expected ValueError for non-object root")
+
+
+def test_parse_simulation_inputs_rejects_invalid_field_types():
+    try:
+        parse_simulation_inputs('{"streams": [], "accumulators": {}}')
+    except ValueError as err:
+        assert "streams" in str(err)
+    else:
+        raise AssertionError("Expected ValueError for non-object streams field")
+
+
+def test_parse_simulation_inputs_rejects_non_list_values():
+    try:
+        parse_simulation_inputs('{"streams": {"s": 42}, "accumulators": {}}')
+    except ValueError as err:
+        assert "streams.s" in str(err)
+    else:
+        raise AssertionError("Expected ValueError for non-list stream value")
+
+
+def test_run_cli_simulate_reports_invalid_simulation_shape(tmp_path):
+    input_file = tmp_path / "sim-input.json"
+    input_file.write_text('{"streams": {"s": 1}}', encoding="utf-8")
+
+    def fake_compiler(_source):
+        return {
+            "streams": [{"name": "s", "type": "int", "capacity": "4"}],
+            "accumulators": [],
+            "uniforms": [],
+            "shaders": [],
+            "filters": [],
+            "bind_routes": [],
+        }
+
+    stderr = io.StringIO()
+    exit_code = run_cli(
+        ["--simulate", "--simulate-input", str(input_file)],
+        stdin=io.StringIO("pipeline P { }"),
+        stdout=io.StringIO(),
+        stderr=stderr,
+        compiler=fake_compiler,
+    )
+
+    assert exit_code == 1
+    assert "Invalid simulation input:" in stderr.getvalue()
+    assert "streams.s" in stderr.getvalue()


### PR DESCRIPTION
### Motivation
- Provide early, clear validation for `--simulate` input JSON to avoid internal errors and make user mistakes actionable.
- Ensure the simulator receives the expected shapes (`streams`/`accumulators` maps of lists) so downstream simulation logic can assume correct types.

### Description
- Add strict shape validation in `parse_simulation_inputs` to ensure the JSON root is an object, `streams` and `accumulators` (when present) are object maps, and each map value is a list, raising `ValueError` with field-level context like `'<root>'`, `streams`, or `streams.<name>` on errors.
- Update the CLI `--simulate` flow in `run_cli` to catch `ValueError` from `parse_simulation_inputs` and print a user-facing message `Invalid simulation input: ...` instead of surfacing a generic internal error.
- Add unit tests in `tests/test_simulator.py` covering malformed payloads (non-object root, wrong `streams` field type, non-list map values) and a CLI test that asserts the validation message is reported for invalid simulation input.

### Testing
- Ran `pytest -q -o addopts='' tests/test_simulator.py tests/test_cli_libraries.py` and all tests passed (`10 passed`).
- An initial `pytest` invocation failed in this environment due to injected coverage options from `pyproject.toml`, but tests were re-run with `-o addopts=''` to disable those options and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98e5956e0832883d9b6d95cfab06b)