### PR TITLE
Handle LSP compile errors when diagnostics are absent

### DIFF
--- a/lockstep_compiler/lsp.py
+++ b/lockstep_compiler/lsp.py
@@ -33,32 +33,25 @@ _MEMBER_ACCESS_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_
 def compile_for_lsp(source: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Compile source and return entities + diagnostics in dictionary form."""
 
+    def _diagnostics_to_dicts(diagnostics: list[Any]) -> list[dict[str, Any]]:
+        return [
+            {
+                "severity": diagnostic.severity,
+                "code": diagnostic.code,
+                "message": diagnostic.message,
+                "line": diagnostic.line,
+                "column": diagnostic.column,
+                "hint": diagnostic.hint,
+            }
+            for diagnostic in diagnostics
+        ]
+
     try:
         result = compile_lockstep(source, verbose=False)
-        diagnostics = [
-            {
-                "severity": diagnostic.severity,
-                "code": diagnostic.code,
-                "message": diagnostic.message,
-                "line": diagnostic.line,
-                "column": diagnostic.column,
-                "hint": diagnostic.hint,
-            }
-            for diagnostic in result.diagnostics
-        ]
+        diagnostics = _diagnostics_to_dicts(result.diagnostics)
         return result.entities, diagnostics
     except LockstepCompileError as error:
-        diagnostics = [
-            {
-                "severity": diagnostic.severity,
-                "code": diagnostic.code,
-                "message": diagnostic.message,
-                "line": diagnostic.line,
-                "column": diagnostic.column,
-                "hint": diagnostic.hint,
-            }
-            for diagnostic in error.diagnostics
-        ]
+        diagnostics = _diagnostics_to_dicts(error.diagnostics or error.errors)
         return {}, diagnostics
 
 

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -1,8 +1,11 @@
 from lockstep_compiler.lsp import (
     build_struct_member_index,
+    compile_for_lsp,
     find_member_definition,
     provide_bind_completion_items,
 )
+from lockstep_compiler.errors import LockstepCompileError
+from lockstep_compiler.models import LockstepDiagnostic
 
 
 SOURCE = """
@@ -46,3 +49,76 @@ def test_provide_bind_completion_items_includes_routes_and_kernels():
 
     assert "dst=Integrate(src,dst,0.1);" in items
     assert "Integrate(...)" in items
+
+
+def test_compile_for_lsp_falls_back_to_errors_when_diagnostics_missing(monkeypatch):
+    parse_errors = [
+        LockstepDiagnostic(
+            severity="error",
+            code="LCK001",
+            message="missing ';'",
+            line=2,
+            column=7,
+            hint="Terminate the statement with a semicolon.",
+        )
+    ]
+
+    def _raise_compile_error(*_args, **_kwargs):
+        raise LockstepCompileError(parse_errors, diagnostics=[])
+
+    monkeypatch.setattr("lockstep_compiler.lsp.compile_lockstep", _raise_compile_error)
+
+    entities, diagnostics = compile_for_lsp("shader Broken(")
+
+    assert entities == {}
+    assert diagnostics == [
+        {
+            "severity": "error",
+            "code": "LCK001",
+            "message": "missing ';'",
+            "line": 2,
+            "column": 7,
+            "hint": "Terminate the statement with a semicolon.",
+        }
+    ]
+
+
+def test_compile_for_lsp_prefers_diagnostics_over_errors(monkeypatch):
+    parse_errors = [
+        LockstepDiagnostic(
+            severity="error",
+            code="LCK001",
+            message="parser message",
+            line=2,
+            column=7,
+            hint="parse hint",
+        )
+    ]
+    semantic_diagnostics = [
+        LockstepDiagnostic(
+            severity="error",
+            code="LCK210",
+            message="semantic message",
+            line=4,
+            column=3,
+            hint="semantic hint",
+        )
+    ]
+
+    def _raise_compile_error(*_args, **_kwargs):
+        raise LockstepCompileError(parse_errors, diagnostics=semantic_diagnostics)
+
+    monkeypatch.setattr("lockstep_compiler.lsp.compile_lockstep", _raise_compile_error)
+
+    _, diagnostics = compile_for_lsp("shader Broken(")
+
+    assert diagnostics == [
+        {
+            "severity": "error",
+            "code": "LCK210",
+            "message": "semantic message",
+            "line": 4,
+            "column": 3,
+            "hint": "semantic hint",
+        }
+    ]


### PR DESCRIPTION
### Motivation
- Ensure LSP diagnostics are always published even when `LockstepCompileError.diagnostics` is empty by falling back to the original `errors` collection and preserving the existing diagnostic dictionary shape (`severity`, `code`, `message`, `line`, `column`, `hint`).

### Description
- Add a shared serializer `_diagnostics_to_dicts` in `lockstep_compiler/lsp.py` to convert diagnostics into the expected dictionary format. 
- When catching `LockstepCompileError`, use `error.diagnostics or error.errors` so `errors` are used as a fallback if `diagnostics` is empty. 
- Add tests in `tests/test_lsp.py` that simulate a `LockstepCompileError` with only `errors` populated and verify diagnostics are returned, and another test that verifies `error.diagnostics` are preferred when present. 
- Keep existing behavior unchanged when `error.diagnostics` is provided.

### Testing
- Ran `PYTHONPATH=. pytest -q -o addopts='' tests/test_lsp.py` and all tests passed (`5 passed`).
- An initial `pytest -q tests/test_lsp.py` run failed in this environment due to repository `addopts` including coverage flags/plugins that are not available, so the adjusted `PYTHONPATH` invocation above was used successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98e5991908328b43271c1ba0bac5c)