### PR TITLE
Scope-aware LSP variable type inference and member resolution

### DIFF
--- a/lockstep_compiler/lsp.py
+++ b/lockstep_compiler/lsp.py
@@ -28,6 +28,39 @@ _PURE_DEF_RE = re.compile(
 )
 _BIND_BLOCK_RE = re.compile(r"\bbind\s*\{(?P<body>[\s\S]*?)\}", re.MULTILINE)
 _MEMBER_ACCESS_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)")
+_BLOCK_HEADER_RE = re.compile(r"\b(struct|shader|filter|pure|pipeline)\s+([A-Za-z_][A-Za-z0-9_]*)")
+_LOCAL_DECL_RE = re.compile(
+    r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:=|;)"
+)
+_PIPELINE_DECL_RE = re.compile(
+    r"^\s*(stream\s*<\s*([A-Za-z_][A-Za-z0-9_]*)[^>]*>|accum|uniform)\s+([A-Za-z_][A-Za-z0-9_]*)\b"
+)
+
+_EXCLUDED_DECL_TYPES = {
+    "return",
+    "if",
+    "for",
+    "while",
+    "bind",
+    "stream",
+    "uniform",
+    "accum",
+    "struct",
+    "shader",
+    "filter",
+    "pipeline",
+    "pure",
+}
+
+
+@dataclass(frozen=True)
+class _VariableSymbol:
+    name: str
+    declared_type: str
+    line: int
+    scope_start: int
+    scope_end: int
+    scope_depth: int
 
 
 def compile_for_lsp(source: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
@@ -95,17 +128,168 @@ def build_struct_member_index(source: str) -> dict[str, dict[str, MemberDefiniti
     return index
 
 
-def infer_variable_types(source: str) -> dict[str, str]:
-    """Best-effort type inference for names declared as `<Type> <name>`."""
+def _collect_symbols(source: str, entities: dict[str, Any] | None) -> list[_VariableSymbol]:
+    lines = source.splitlines()
+    symbols: list[_VariableSymbol] = []
+    scope_stack: list[dict[str, Any]] = []
+    pending_block: dict[str, Any] | None = None
+
+    shader_param_map: dict[str, list[dict[str, Any]]] = {}
+    filter_param_map: dict[str, list[dict[str, Any]]] = {}
+    pure_param_map: dict[str, list[dict[str, Any]]] = {}
+    if entities:
+        shader_param_map = {
+            shader.get("name", ""): shader.get("params", [])
+            for shader in entities.get("shaders", [])
+            if isinstance(shader, dict)
+        }
+        filter_param_map = {
+            flt.get("name", ""): flt.get("params", [])
+            for flt in entities.get("filters", [])
+            if isinstance(flt, dict)
+        }
+        pure_param_map = {
+            pure.get("name", ""): pure.get("params", [])
+            for pure in entities.get("pure_functions", [])
+            if isinstance(pure, dict)
+        }
+
+    for line_no, line in enumerate(lines):
+        header = _BLOCK_HEADER_RE.search(line)
+        if header:
+            kind, scope_name = header.groups()
+            if "{" in line:
+                pending_block = {"kind": kind, "name": scope_name, "line": line_no}
+                if kind in {"shader", "filter", "pure"}:
+                    if kind == "shader":
+                        params = shader_param_map.get(scope_name)
+                    elif kind == "filter":
+                        params = filter_param_map.get(scope_name)
+                    else:
+                        params = pure_param_map.get(scope_name)
+                    if params:
+                        for param in params:
+                            declared_type = param.get("type")
+                            param_name = param.get("name")
+                            if declared_type and param_name:
+                                symbols.append(
+                                    _VariableSymbol(
+                                        name=param_name,
+                                        declared_type=declared_type,
+                                        line=line_no,
+                                        scope_start=line_no,
+                                        scope_end=10**9,
+                                        scope_depth=len(scope_stack) + 1,
+                                    )
+                                )
+
+        open_count = line.count("{")
+        close_count = line.count("}")
+        for _ in range(open_count):
+            if pending_block:
+                scope_stack.append({**pending_block, "depth": len(scope_stack) + 1})
+                pending_block = None
+            else:
+                scope_stack.append({"kind": "block", "name": "", "line": line_no, "depth": len(scope_stack) + 1})
+
+        active_scope = scope_stack[-1] if scope_stack else None
+        inside_struct = any(scope.get("kind") == "struct" for scope in scope_stack)
+
+        if active_scope and active_scope.get("kind") in {"shader", "filter", "pure"} and not inside_struct:
+            local_match = _LOCAL_DECL_RE.match(line)
+            if local_match:
+                declared_type, name = local_match.groups()
+                if declared_type not in _EXCLUDED_DECL_TYPES:
+                    symbols.append(
+                        _VariableSymbol(
+                            name=name,
+                            declared_type=declared_type,
+                            line=line_no,
+                            scope_start=active_scope["line"],
+                            scope_end=10**9,
+                            scope_depth=int(active_scope.get("depth", 0)),
+                        )
+                    )
+
+        if active_scope and active_scope.get("kind") == "pipeline" and not inside_struct:
+            pipeline_match = _PIPELINE_DECL_RE.match(line)
+            if pipeline_match:
+                kind_text, stream_type, name = pipeline_match.groups()
+                declared_type = stream_type if stream_type else kind_text
+                if declared_type not in _EXCLUDED_DECL_TYPES:
+                    symbols.append(
+                        _VariableSymbol(
+                            name=name,
+                            declared_type=declared_type,
+                            line=line_no,
+                            scope_start=active_scope["line"],
+                            scope_end=10**9,
+                            scope_depth=int(active_scope.get("depth", 0)),
+                        )
+                    )
+
+        for _ in range(close_count):
+            if scope_stack:
+                closed_scope = scope_stack.pop()
+                scope_start = int(closed_scope.get("line", line_no))
+                scope_depth = int(closed_scope.get("depth", 0))
+                for idx, symbol in enumerate(symbols):
+                    if (
+                        symbol.scope_start == scope_start
+                        and symbol.scope_depth == scope_depth
+                        and symbol.scope_end == 10**9
+                    ):
+                        symbols[idx] = _VariableSymbol(
+                            name=symbol.name,
+                            declared_type=symbol.declared_type,
+                            line=symbol.line,
+                            scope_start=symbol.scope_start,
+                            scope_end=line_no,
+                            scope_depth=symbol.scope_depth,
+                        )
+
+    return symbols
+
+
+def infer_variable_types(
+    source: str,
+    current_line: int,
+    entities: dict[str, Any] | None = None,
+) -> dict[str, str]:
+    """Infer in-scope variable types for a source position."""
+
+    if entities:
+        inferred: dict[str, tuple[str, int, int]] = {}
+        for symbol in _collect_symbols(source, entities):
+            if symbol.line > current_line or not (symbol.scope_start <= current_line <= symbol.scope_end):
+                continue
+            previous = inferred.get(symbol.name)
+            rank = (symbol.scope_depth, symbol.line)
+            if previous is None or rank >= (previous[1], previous[2]):
+                inferred[symbol.name] = (symbol.declared_type, symbol.scope_depth, symbol.line)
+        return {name: value[0] for name, value in inferred.items()}
 
     inferred: dict[str, str] = {}
-    for declared_type, name in _PARAM_RE.findall(source):
-        inferred.setdefault(name, declared_type)
+    for idx, line in enumerate(source.splitlines()):
+        if idx > current_line:
+            break
+        local_match = _LOCAL_DECL_RE.match(line)
+        if local_match:
+            declared_type, name = local_match.groups()
+            if declared_type not in _EXCLUDED_DECL_TYPES:
+                inferred[name] = declared_type
 
-    for declared_type, name in _TYPED_NAME_RE.findall(source):
-        if declared_type in {"return", "if", "for", "while", "bind", "stream", "uniform"}:
-            continue
-        inferred.setdefault(name, declared_type)
+        param_match = _PARAM_RE.findall(line)
+        for declared_type, name in param_match:
+            if declared_type not in _EXCLUDED_DECL_TYPES:
+                inferred[name] = declared_type
+
+        pipeline_match = _PIPELINE_DECL_RE.match(line)
+        if pipeline_match:
+            kind_text, stream_type, name = pipeline_match.groups()
+            declared_type = stream_type if stream_type else kind_text
+            if declared_type not in _EXCLUDED_DECL_TYPES:
+                inferred[name] = declared_type
     return inferred
 
 
@@ -126,7 +310,8 @@ def find_member_definition(
         if not (start <= column <= end):
             continue
         variable_name, field_name = match.groups()
-        variable_types = infer_variable_types(source)
+        entities, _ = compile_for_lsp(source)
+        variable_types = infer_variable_types(source, line, entities if entities else None)
         struct_name = variable_types.get(variable_name)
         if not struct_name:
             return None

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -46,3 +46,54 @@ def test_provide_bind_completion_items_includes_routes_and_kernels():
 
     assert "dst=Integrate(src,dst,0.1);" in items
     assert "Integrate(...)" in items
+
+
+SHADOWED_SOURCE = """
+struct Vec3 { float x; float y; float z; };
+struct Vec2 { float x; float y; };
+
+shader Shadow(in Vec3 value) {
+    Vec2 value = Vec2(0.0, 0.0);
+    value.x = 1.0;
+}
+"""
+
+
+def test_find_member_definition_prefers_nearest_shadowed_variable_scope():
+    target_line = 6
+    target_column = 8
+
+    definition = find_member_definition(SHADOWED_SOURCE, target_line, target_column)
+
+    assert definition is not None
+    assert definition.struct_name == "Vec2"
+    assert definition.field_name == "x"
+
+
+DUPLICATE_SCOPE_SOURCE = """
+struct InType { float x; };
+struct StreamType { float x; };
+
+shader Sample(in InType src) {
+    src.x = 1.0;
+}
+
+pipeline P {
+    stream<StreamType, 32> src;
+
+    bind {
+        src = Sample(src);
+    }
+}
+"""
+
+
+def test_find_member_definition_resolves_duplicate_identifiers_by_scope():
+    shader_line = 5
+    shader_column = 8
+
+    shader_definition = find_member_definition(DUPLICATE_SCOPE_SOURCE, shader_line, shader_column)
+
+    assert shader_definition is not None
+    assert shader_definition.struct_name == "InType"
+    assert shader_definition.field_name == "x"


### PR DESCRIPTION
### Motivation
- Replace fragile global regex-only name/type inference with AST/entity-driven symbol extraction so member resolution is accurate in the presence of shadowing and duplicate identifiers.
- Track declaration scope (shader/filter/pure/pipeline) and prefer the nearest in-scope variable at the query line to avoid resolving to out-of-scope declarations.
- Exclude struct field declarations, language keywords, and other non-variable constructs from variable inference to reduce false matches.
- Preserve a conservative regex fallback when compile entities are not available.

### Description
- Added `_VariableSymbol` dataclass and `_collect_symbols` to walk source lines, track scope stack, and extract symbols from compile `entities` (shader/filter/pure params and local/pipeline declarations) using `_BLOCK_HEADER_RE`, `_LOCAL_DECL_RE`, and `_PIPELINE_DECL_RE`.
- Reworked `infer_variable_types` to accept a `current_line` and optional `entities` and to choose the nearest in-scope symbol by `scope_depth` and declaration line when entities are present, otherwise use a conservative line-bounded regex fallback.
- Updated `find_member_definition` to call `compile_for_lsp` and pass the resulting `entities` and the current line to `infer_variable_types` before resolving `foo.bar` against the struct index.
- Added tests in `tests/test_lsp.py` covering shadowed names and duplicate identifiers across shader/pipeline scopes and kept existing member-resolution and completion tests.

### Testing
- Running `pytest -q tests/test_lsp.py` initially failed due to repository `addopts` including unavailable coverage args in the environment.
- Running `PYTHONPATH=. pytest -q tests/test_lsp.py -o addopts=''` executed the updated test file and reported `5 passed`, confirming the new scope-aware inference and member-resolution tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98e5cca1483288c429a5be9bec7ef)