### PR TITLE
Improve LSP completion: cursor-aware bind snippets, ranked/deduped candidates, richer metadata

### DIFF
--- a/lockstep_compiler/lsp.py
+++ b/lockstep_compiler/lsp.py
@@ -30,6 +30,48 @@ _BIND_BLOCK_RE = re.compile(r"\bbind\s*\{(?P<body>[\s\S]*?)\}", re.MULTILINE)
 _MEMBER_ACCESS_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)")
 
 
+def _is_inside_bind_block(source: str, line: int, column: int) -> bool:
+    """Return whether the given cursor position is inside any `bind { ... }` body."""
+
+    if line < 0 or column < 0:
+        return False
+
+    lines = source.splitlines(keepends=True)
+    if line >= len(lines):
+        return False
+
+    offset = sum(len(existing) for existing in lines[:line]) + min(column, len(lines[line]))
+
+    for match in re.finditer(r"\bbind\s*\{", source):
+        block_start = match.end()
+        depth = 1
+        index = block_start
+        while index < len(source) and depth > 0:
+            token = source[index]
+            if token == "{":
+                depth += 1
+            elif token == "}":
+                depth -= 1
+            index += 1
+
+        if depth != 0:
+            continue
+
+        block_end = index - 1
+        if block_start <= offset <= block_end:
+            return True
+
+    return False
+
+
+def _normalize_completion_name(entry: Any) -> str | None:
+    if isinstance(entry, dict):
+        return entry.get("name")
+    if isinstance(entry, str):
+        return entry
+    return str(entry) if entry else None
+
+
 def compile_for_lsp(source: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Compile source and return entities + diagnostics in dictionary form."""
 
@@ -135,11 +177,23 @@ def find_member_definition(
     return None
 
 
-def provide_bind_completion_items(source: str) -> list[str]:
-    """Return completion labels for bind routes and callable kernels."""
+def provide_bind_completion_items(
+    source: str,
+    *,
+    line: int | None = None,
+    column: int | None = None,
+) -> list[dict[str, Any]]:
+    """Return ranked completion entries for bind routes and callable symbols."""
 
     entities, _ = compile_for_lsp(source)
-    items: list[str] = []
+    completion_entries: list[dict[str, Any]] = []
+    seen_labels: set[str] = set()
+
+    inside_bind = (
+        line is not None
+        and column is not None
+        and _is_inside_bind_block(source, line=line, column=column)
+    )
 
     bind_routes = entities.get("bind_routes", [])
     if not bind_routes:
@@ -150,33 +204,75 @@ def provide_bind_completion_items(source: str) -> list[str]:
                 if normalized:
                     bind_routes.append(f"{normalized};")
 
-    for route in bind_routes:
-        if route not in items:
-            items.append(route)
+    if inside_bind:
+        for route in bind_routes:
+            if route in seen_labels:
+                continue
+            completion_entries.append(
+                {
+                    "label": route,
+                    "detail": "Bind route template",
+                    "sort_text": f"1-{route}",
+                    "kind": "snippet",
+                }
+            )
+            seen_labels.add(route)
 
     shaders = entities.get("shaders", [])
+    filters = entities.get("filters", [])
     if not shaders:
         shaders = [{"name": name} for name in _SHADER_DEF_RE.findall(source)]
+    if not filters:
+        filters = []
 
-    for shader in shaders:
-        shader_name = shader.get("name") if isinstance(shader, dict) else str(shader)
-        if shader_name and shader_name not in items:
-            items.append(f"{shader_name}(...)")
+    shader_filter_names = sorted(
+        {
+            f"{name}(...)"
+            for name in [
+                _normalize_completion_name(entry)
+                for entry in [*shaders, *filters]
+            ]
+            if name
+        }
+    )
+    for callable_name in shader_filter_names:
+        if callable_name in seen_labels:
+            continue
+        completion_entries.append(
+            {
+                "label": callable_name,
+                "detail": "Shader/filter callable",
+                "sort_text": f"2-{callable_name}",
+                "kind": "function",
+            }
+        )
+        seen_labels.add(callable_name)
 
     pure_functions = entities.get("pure_functions", [])
     if not pure_functions:
         pure_functions = [{"name": name} for name in _PURE_DEF_RE.findall(source)]
 
-    for pure_function in pure_functions:
-        function_name = (
-            pure_function.get("name")
-            if isinstance(pure_function, dict)
-            else str(pure_function)
+    pure_function_names = sorted(
+        {
+            f"{name}(...)"
+            for name in [_normalize_completion_name(entry) for entry in pure_functions]
+            if name
+        }
+    )
+    for function_name in pure_function_names:
+        if function_name in seen_labels:
+            continue
+        completion_entries.append(
+            {
+                "label": function_name,
+                "detail": "Pure function callable",
+                "sort_text": f"3-{function_name}",
+                "kind": "function",
+            }
         )
-        if function_name and function_name not in items:
-            items.append(f"{function_name}(...)")
+        seen_labels.add(function_name)
 
-    return items
+    return completion_entries
 
 
 def run_lsp_server() -> int:
@@ -220,10 +316,26 @@ def run_lsp_server() -> int:
     @server.feature(types.TEXT_DOCUMENT_COMPLETION)
     def completion(params: types.CompletionParams):
         document = server.workspace.get_text_document(params.text_document.uri)
-        labels = provide_bind_completion_items(document.source)
+        entries = provide_bind_completion_items(
+            document.source,
+            line=params.position.line,
+            column=params.position.character,
+        )
         return types.CompletionList(
             is_incomplete=False,
-            items=[types.CompletionItem(label=label, kind=types.CompletionItemKind.Function) for label in labels],
+            items=[
+                types.CompletionItem(
+                    label=entry["label"],
+                    detail=entry["detail"],
+                    sort_text=entry["sort_text"],
+                    kind=(
+                        types.CompletionItemKind.Snippet
+                        if entry["kind"] == "snippet"
+                        else types.CompletionItemKind.Function
+                    ),
+                )
+                for entry in entries
+            ],
         )
 
     @server.feature(types.TEXT_DOCUMENT_DEFINITION)

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -42,7 +42,41 @@ def test_find_member_definition_resolves_struct_field():
 
 
 def test_provide_bind_completion_items_includes_routes_and_kernels():
-    items = provide_bind_completion_items(SOURCE)
+    items = provide_bind_completion_items(SOURCE, line=12, column=8)
+    labels = [item["label"] for item in items]
 
-    assert "dst=Integrate(src,dst,0.1);" in items
-    assert "Integrate(...)" in items
+    assert labels[0] == "dst=Integrate(src,dst,0.1);"
+    assert "Integrate(...)" in labels
+    assert items[0]["detail"] == "Bind route template"
+
+
+def test_provide_bind_completion_items_omits_bind_routes_outside_bind_block():
+    items = provide_bind_completion_items(SOURCE, line=4, column=8)
+    labels = [item["label"] for item in items]
+
+    assert "dst=Integrate(src,dst,0.1);" not in labels
+    assert labels == ["Integrate(...)"]
+
+
+def test_provide_bind_completion_items_deduplicates_and_ranks_categories():
+    source = """
+shader mix(in float value, out float out_value) { }
+pure float mix(float a, float b) { return a; }
+
+pipeline P {
+    bind {
+        out = mix(in_stream, out_stream);
+    }
+}
+"""
+
+    items = provide_bind_completion_items(source, line=6, column=10)
+
+    assert [item["label"] for item in items] == [
+        "out=mix(in_stream,out_stream);",
+        "mix(...)",
+    ]
+    assert [item["detail"] for item in items] == [
+        "Bind route template",
+        "Shader/filter callable",
+    ]


### PR DESCRIPTION
### Motivation
- Provide accurate completion results by only offering bind-route templates when the cursor is inside a `bind { ... }` block.
- Make completions easier to scan by separating categories (bind routes, shaders/filters, pure functions) and applying a deterministic ranking and deduplication.
- Surface richer metadata so clients can distinguish snippet-like route templates from callable symbols and permit better sorting in editors.

### Description
- Add `_is_inside_bind_block` to determine whether a cursor position is inside a `bind` block and `_normalize_completion_name` to unify name extraction.
- Refactor `provide_bind_completion_items` to accept `line`/`column`, return structured entries (`label`, `detail`, `sort_text`, `kind`), produce category-ordered results (1: bind route snippets, 2: shaders/filters, 3: pure functions) and deduplicate labels across categories.
- Update `run_lsp_server` completion handler to pass `CompletionParams.position` into `provide_bind_completion_items` and map structured entries into `CompletionItem`s with `detail`, `sort_text`, and appropriate `kind` mapping (snippet vs function).
- Extend tests in `tests/test_lsp.py` to cover inside-vs-outside-bind behavior, label deduplication, and category ordering expectations.

### Testing
- Ran the updated LSP unit tests with `PYTHONPATH=. pytest -q tests/test_lsp.py` after installing the missing `pytest-cov` plugin, and the test suite for `tests/test_lsp.py` completed successfully.
- The test run produced expected assertions for inside-bind suggestions, omission of bind routes outside bind blocks, and deduped/ranked completion ordering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98e5d75088328b5e1bfdd1b261f1f)