### PR TITLE
Add C header generation pass for arena layout

### DIFF
--- a/lockstep_compiler/__init__.py
+++ b/lockstep_compiler/__init__.py
@@ -1,3 +1,4 @@
+from .c_header import emit_c_header
 from .cli import build_arg_parser, run_cli
 from .compiler import compile_lockstep, load_default_parser_classes, validate_semantics
 from .errors import LockstepCompileError, ParseErrorCollector
@@ -12,6 +13,7 @@ __all__ = [
     "LockstepDiagnostic",
     "ParseErrorCollector",
     "build_arg_parser",
+    "emit_c_header",
     "build_debug_visitor",
     "build_semantic_validator",
     "compile_lockstep",

--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .ast import AstProgram, ast_to_entities
+
+_PRIMITIVE_C_TYPE = {
+    "bool": "uint8_t",
+    "int": "int32_t",
+    "uint": "uint32_t",
+    "float": "float",
+    "double": "double",
+}
+
+_PRIMITIVE_SIZE = {
+    "bool": 1,
+    "int": 4,
+    "uint": 4,
+    "float": 4,
+    "double": 8,
+}
+
+
+def _sanitize_symbol(name: str) -> str:
+    return "".join(ch if (ch.isalnum() or ch == "_") else "_" for ch in name)
+
+
+def _normalize_structs(structs: list[Any]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for struct_decl in structs:
+        if isinstance(struct_decl, str):
+            normalized.append({"name": struct_decl, "fields": []})
+        elif isinstance(struct_decl, dict) and struct_decl.get("name"):
+            fields = struct_decl.get("fields") if isinstance(struct_decl.get("fields"), list) else []
+            normalized.append({"name": struct_decl["name"], "fields": fields})
+    return normalized
+
+
+def _field_size(type_name: str, struct_sizes: dict[str, int]) -> int:
+    if type_name in _PRIMITIVE_SIZE:
+        return _PRIMITIVE_SIZE[type_name]
+    if type_name in struct_sizes:
+        return struct_sizes[type_name]
+    return 8
+
+
+def _resolve_struct_layouts(normalized_structs: list[dict[str, Any]]) -> tuple[dict[str, int], set[str]]:
+    struct_sizes: dict[str, int] = {}
+    unresolved = {struct["name"] for struct in normalized_structs}
+    struct_map = {struct["name"]: struct for struct in normalized_structs}
+    opaque_structs: set[str] = set()
+
+    while unresolved:
+        progress = False
+        for struct_name in list(unresolved):
+            fields = struct_map[struct_name].get("fields", [])
+            can_resolve = True
+            size = 0
+            for field in fields:
+                field_type_name = field.get("type", "float")
+                if field_type_name in unresolved:
+                    can_resolve = False
+                    break
+                size += _field_size(field_type_name, struct_sizes)
+            if not can_resolve:
+                continue
+            struct_sizes[struct_name] = size
+            unresolved.remove(struct_name)
+            progress = True
+
+        if not progress:
+            for struct_name in unresolved:
+                struct_sizes[struct_name] = 1
+                opaque_structs.add(struct_name)
+            break
+
+    return struct_sizes, opaque_structs
+
+
+def _c_type(type_name: str, known_structs: set[str]) -> str:
+    if type_name in _PRIMITIVE_C_TYPE:
+        return _PRIMITIVE_C_TYPE[type_name]
+    if type_name in known_structs:
+        return f"struct Lockstep_{_sanitize_symbol(type_name)}"
+    return "void*"
+
+
+def emit_c_header(program_or_entities: AstProgram | dict[str, Any], guard: str = "LOCKSTEP_GENERATED_H") -> str:
+    entities = ast_to_entities(program_or_entities) if isinstance(program_or_entities, AstProgram) else program_or_entities
+
+    normalized_structs = _normalize_structs(entities.get("structs", []))
+    known_structs = {struct["name"] for struct in normalized_structs}
+    struct_sizes, opaque_structs = _resolve_struct_layouts(normalized_structs)
+
+    arena_fields: list[tuple[str, str, str]] = []
+    for stream in entities.get("streams", []):
+        arena_fields.append(("stream", stream["name"], stream["type"]))
+    for accumulator in entities.get("accumulators", []):
+        arena_fields.append(("accum", accumulator["name"], accumulator["type"]))
+    for uniform in entities.get("uniforms", []):
+        arena_fields.append(("uniform", uniform["name"], uniform["type"]))
+
+    offsets: list[tuple[str, str, int]] = []
+    cursor = 0
+    for kind, name, type_name in arena_fields:
+        offsets.append((kind, name, cursor))
+        cursor += _field_size(type_name, struct_sizes)
+
+    lines = [
+        f"#ifndef {guard}",
+        f"#define {guard}",
+        "",
+        "#include <stdint.h>",
+        "#include <stddef.h>",
+        "",
+        "#if defined(_MSC_VER)",
+        "#define LOCKSTEP_PACKED_STRUCT(definition) __pragma(pack(push, 1)) definition __pragma(pack(pop))",
+        "#else",
+        "#define LOCKSTEP_PACKED_STRUCT(definition) definition __attribute__((packed))",
+        "#endif",
+        "",
+    ]
+
+    for struct_decl in normalized_structs:
+        struct_name = struct_decl["name"]
+        c_struct_name = f"Lockstep_{_sanitize_symbol(struct_name)}"
+        if struct_name in opaque_structs:
+            lines.append(
+                f"LOCKSTEP_PACKED_STRUCT(struct {c_struct_name} {{ uint8_t _opaque; }});"
+            )
+            lines.append("")
+            continue
+
+        lines.append(f"LOCKSTEP_PACKED_STRUCT(struct {c_struct_name} {{")
+        for field in struct_decl.get("fields", []):
+            field_type = _c_type(field.get("type", "float"), known_structs)
+            field_name = _sanitize_symbol(field.get("name", "field"))
+            lines.append(f"    {field_type} {field_name};")
+        lines.append("});")
+        lines.append("")
+
+    lines.append("LOCKSTEP_PACKED_STRUCT(struct Lockstep_Arena {")
+    for kind, name, type_name in arena_fields:
+        c_type_name = _c_type(type_name, known_structs)
+        lines.append(f"    {c_type_name} {kind}_{_sanitize_symbol(name)};")
+    lines.append("});")
+    lines.append("")
+
+    lines.append(f"#define LOCKSTEP_ARENA_BYTES {cursor}")
+    for kind, name, offset in offsets:
+        macro_suffix = f"{kind}_{_sanitize_symbol(name)}".upper()
+        lines.append(f"#define LOCKSTEP_OFFSET_{macro_suffix} {offset}")
+    lines.append("")
+
+    lines.extend(
+        [
+            "#ifdef __cplusplus",
+            'extern "C" {',
+            "#endif",
+            "",
+            "void Lockstep_Tick(struct Lockstep_Arena* arena);",
+            "",
+            "#ifdef __cplusplus",
+            "}",
+            "#endif",
+            "",
+            "#endif",
+            "",
+        ]
+    )
+
+    return "\n".join(lines)

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -4,6 +4,7 @@ from typing import Any
 from antlr4 import CommonTokenStream, InputStream
 
 from .ast import ast_to_entities, build_program_ast
+from .c_header import emit_c_header
 from .codegen import emit_llvm_ir
 from .errors import LockstepCompileError, ParseErrorCollector
 from .models import LockstepCompileResult, normalize_diagnostics
@@ -112,6 +113,7 @@ def _compile_lockstep_with_dependencies(
         entities=entities,
         ast=typed_ast,
         llvm_ir=emit_llvm_ir(typed_ast or entities),
+        c_header=emit_c_header(typed_ast or entities),
         diagnostics=all_diagnostics,
     )
 

--- a/lockstep_compiler/models.py
+++ b/lockstep_compiler/models.py
@@ -18,6 +18,7 @@ class LockstepCompileResult:
     entities: dict[str, Any]
     ast: Any | None = None
     llvm_ir: str = ""
+    c_header: str = ""
     diagnostics: list[LockstepDiagnostic] = field(default_factory=list)
 
 

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -8,6 +8,7 @@ if str(REPO_ROOT) not in sys.path:
 
 import lockstep_compiler
 import lockstep_compiler.compiler as compiler_module
+from lockstep_compiler.c_header import emit_c_header
 from lockstep_compiler.codegen import emit_llvm_ir
 import pytest
 
@@ -386,3 +387,94 @@ def test_ast_dataclasses_normalize_declared_types_to_ast_type():
     assert isinstance(param.declared_type, AstType)
     assert param.declared_type.name == "float"
     assert param.declared_type.kind == "primitive"
+
+
+def test_emit_c_header_generates_structs_offsets_and_tick_signature():
+    header = emit_c_header(
+        {
+            "structs": [
+                {
+                    "name": "Vec3",
+                    "fields": [
+                        {"type": "float", "name": "x"},
+                        {"type": "float", "name": "y"},
+                        {"type": "float", "name": "z"},
+                    ],
+                }
+            ],
+            "streams": [{"name": "raw_positions", "type": "Vec3"}],
+            "accumulators": [{"name": "energy", "type": "float"}],
+            "uniforms": [{"name": "dt", "type": "float"}],
+        }
+    )
+
+    assert "#ifndef LOCKSTEP_GENERATED_H" in header
+    assert "struct Lockstep_Vec3" in header
+    assert "struct Lockstep_Arena" in header
+    assert "#define LOCKSTEP_ARENA_BYTES 20" in header
+    assert "#define LOCKSTEP_OFFSET_STREAM_RAW_POSITIONS 0" in header
+    assert "#define LOCKSTEP_OFFSET_ACCUM_ENERGY 12" in header
+    assert "#define LOCKSTEP_OFFSET_UNIFORM_DT 16" in header
+    assert "void Lockstep_Tick(struct Lockstep_Arena* arena);" in header
+
+
+def test_compile_result_includes_c_header(monkeypatch):
+    class StubLexer:
+        def __init__(self, input_stream):
+            self.input_stream = input_stream
+
+        def removeErrorListeners(self):
+            pass
+
+        def addErrorListener(self, listener):
+            pass
+
+    class StubParser:
+        def __init__(self, stream):
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            return "TREE"
+
+    class StubVisitor:
+        pass
+
+    class StubDebugVisitor:
+        def __init__(self, verbose=True):
+            self.verbose = verbose
+            self.structs = []
+            self.shaders = []
+            self.filters = []
+            self.pure_functions = []
+            self.streams = [{"name": "s", "type": "float"}]
+            self.accumulators = []
+            self.uniforms = []
+            self.bind_routes = []
+            self.bind_routes_ir = []
+            self.diagnostics = []
+
+        def visit(self, tree):
+            return None
+
+    monkeypatch.setattr(
+        compiler_module,
+        "_load_default_parser_classes",
+        lambda: (StubLexer, StubParser, StubVisitor),
+    )
+
+    result = lockstep_compiler.compile_lockstep(
+        "pipeline P { }",
+        verbose=False,
+        semantic_validator=lambda _tree: [],
+        token_stream_cls=lambda lexer: object(),
+        debug_visitor_cls=StubDebugVisitor,
+    )
+
+    assert "#define LOCKSTEP_ARENA_BYTES 4" in result.c_header
+    assert "void Lockstep_Tick(struct Lockstep_Arena* arena);" in result.c_header


### PR DESCRIPTION
### Motivation
- Generate a C-compatible packed header that describes the arena memory layout used by the LLVM backend so hosts can allocate/prime memory and call `Lockstep_Tick`. 
- Compute stable byte offsets for streams/accumulators/uniforms and provide struct definitions matching the compiler's packed layout.

### Description
- Added `lockstep_compiler/c_header.py` implementing `emit_c_header(...)` which normalizes frontend struct declarations, resolves packed struct sizes (with an opaque fallback for unresolved cycles), computes arena field offsets, and emits a guarded C header with packed `struct` declarations, `LOCKSTEP_ARENA_BYTES`, per-field `LOCKSTEP_OFFSET_*` macros, and the `Lockstep_Tick(struct Lockstep_Arena* arena)` signature.
- Wired the compiler pipeline to call `emit_c_header(...)` and store the result in the compile result via a new `c_header` field on `LockstepCompileResult` (updated `lockstep_compiler/models.py` and `lockstep_compiler/compiler.py`).
- Exported `emit_c_header` from package top-level API by updating `lockstep_compiler/__init__.py`.
- Added tests in `tests/test_compiler_api.py` validating header contents (guards, struct declarations, offsets, arena bytes, and tick signature) and that `compile_lockstep(...)` includes `c_header` in the result.

### Testing
- Fixed and ran the compiler API tests with `pytest -q -o addopts='' tests/test_compiler_api.py`, which completed successfully with `15 passed`.
- Running `pytest -q tests/test_compiler_api.py` without the `-o addopts=''` override fails in this environment due to repository `addopts` including coverage flags/plugins that are unavailable, so the override was used to validate the new behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98ed625848328aede070407123641)