### PR TITLE
Implement stateful BindMemory support in generated LLVM IR

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -619,11 +619,29 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
         }
     )
 
-    tick = ir.Function(module, ir.FunctionType(ir.VoidType(), [arena_type.as_pointer()]), name="Lockstep_Tick")
-    arena_ptr = tick.args[0]
-    arena_ptr.name = "arena"
+    arena_ptr_type = arena_type.as_pointer()
+    arena_binding = ir.GlobalVariable(module, arena_ptr_type, name="lockstep_bound_arena")
+    arena_binding.linkage = "internal"
+    arena_binding.initializer = ir.Constant(arena_ptr_type, None)
+
+    bind_memory = ir.Function(module, ir.FunctionType(ir.VoidType(), [ir.IntType(8).as_pointer()]), name="Lockstep_BindMemory")
+    bind_arg = bind_memory.args[0]
+    bind_arg.name = "ptr"
+    bind_entry = bind_memory.append_basic_block("entry")
+    bind_builder = ir.IRBuilder(bind_entry)
+    typed_arena = bind_builder.bitcast(bind_arg, arena_ptr_type, name="arena")
+    bind_builder.store(typed_arena, arena_binding)
+    bind_builder.ret_void()
+
+    tick = ir.Function(module, ir.FunctionType(ir.VoidType(), []), name="Lockstep_Tick")
     tick_entry = tick.append_basic_block("entry")
     tick_builder = ir.IRBuilder(tick_entry)
+    arena_ptr = tick_builder.load(arena_binding, name="arena")
+    arena_is_null = tick_builder.icmp_unsigned("==", arena_ptr, ir.Constant(arena_ptr_type, None), name="arena_is_null")
+    tick_exit = tick.append_basic_block("exit")
+    tick_active = tick.append_basic_block("active")
+    tick_builder.cbranch(arena_is_null, tick_exit, tick_active)
+    tick_builder.position_at_end(tick_active)
 
     def _zero_value(llvm_type: ir.Type) -> ir.Value:
         if isinstance(llvm_type, ir.VoidType):
@@ -714,6 +732,8 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
             escaped = str(route).replace("\\", "\\\\").replace('"', '\\"')
             asm = ir.InlineAsm(asm_ty, f"; bind: {escaped}", "", side_effect=True)
             tick_builder.call(asm, [])
+    tick_builder.branch(tick_exit)
+    tick_builder.position_at_end(tick_exit)
     tick_builder.ret_void()
 
     return str(module)

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -88,7 +88,8 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
     assert result.entities["fused_bind_groups"] == []
 
     assert result.llvm_ir.startswith('; ModuleID = "lockstep"\n')
-    assert 'define void @"Lockstep_Tick"(<{}>* %"arena")' in result.llvm_ir
+    assert 'define void @"Lockstep_BindMemory"(i8* %"ptr")' in result.llvm_ir
+    assert 'define void @"Lockstep_Tick"()' in result.llvm_ir
 
 
 def test_emit_llvm_ir_generates_expected_declarations():
@@ -118,7 +119,8 @@ def test_emit_llvm_ir_generates_expected_declarations():
     assert "define float @\"pure_mix\"()" in llvm_ir
     assert "define void @\"shader_ApplyGravity\"()" in llvm_ir
     assert "define void @\"filter_Cull\"()" in llvm_ir
-    assert 'define void @"Lockstep_Tick"(<{%"struct.Vec3", float, float}>* %"arena")' in llvm_ir
+    assert 'define void @"Lockstep_BindMemory"(i8* %"ptr")' in llvm_ir
+    assert 'define void @"Lockstep_Tick"()' in llvm_ir
     assert '; bind: out = ApplyGravity(inp, out, energy, dt);' in llvm_ir
     assert "fmul float" in llvm_ir
     assert "uitofp i1" in llvm_ir


### PR DESCRIPTION
### Motivation
- Decouple host-provided arena binding from the `Lockstep_Tick` entrypoint so the host can `Bind` memory once and call `Tick` without passing the arena pointer each time.
- Match the documented host integration pattern (host calls `Lockstep_BindMemory(ptr)` then `Lockstep_Tick()`), and make the generated IR hold the bound arena in module state.

### Description
- Add an internal global `lockstep_bound_arena` and produce a generated `Lockstep_BindMemory(i8* ptr)` function that bitcasts and stores the host pointer into that global.
- Change `Lockstep_Tick` generation to a zero-argument function that loads the arena pointer from the global instead of taking an arena parameter.
- Add a null-bind guard in `Lockstep_Tick` that exits early when no arena has been bound while preserving the existing bind-route lowering and kernel loop lowering logic.
- Update tests to assert the new IR exports (`Lockstep_BindMemory` and zero-arg `Lockstep_Tick`).

### Testing
- Running `pytest -q tests/test_compiler_api.py` initially failed due to repository `addopts` coverage flags not available in the environment, which is an unrelated test runner config issue.
- Re-running with adjusted options using `pytest -q -o addopts='' tests/test_compiler_api.py` succeeded with all tests passing (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98ee6b36c832888ce3a3f71c4feeb)