### PR TITLE
Adjust Lockstep_Tick ABI to accept noalias stream/accumulator pointers

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -606,8 +606,6 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
         uniform_slots[uniform["name"]] = len(arena_fields)
         arena_fields.append(("uniform", uniform["name"], lowerer._llvm_type(uniform["type"], known_structs)))
 
-    arena_type = ir.LiteralStructType([field_type for _, _, field_type in arena_fields], packed=True)
-
     kernel_signatures = {
         shader["name"]: {"kind": "shader", "params": shader.get("params", [])}
         for shader in shaders
@@ -619,9 +617,23 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
         }
     )
 
-    tick = ir.Function(module, ir.FunctionType(ir.VoidType(), [arena_type.as_pointer()]), name="Lockstep_Tick")
-    arena_ptr = tick.args[0]
-    arena_ptr.name = "arena"
+    tick_arg_specs: list[tuple[str, str, ir.Type, bool]] = []
+    for stream in streams:
+        tick_arg_specs.append(("stream", stream["name"], lowerer._llvm_type(stream["type"], known_structs), True))
+    for accum in accumulators:
+        tick_arg_specs.append(("accum", accum["name"], lowerer._llvm_type(accum["type"], known_structs), True))
+    for uniform in uniforms:
+        tick_arg_specs.append(("uniform", uniform["name"], lowerer._llvm_type(uniform["type"], known_structs), False))
+
+    tick_param_types = [field_type.as_pointer() for _, _, field_type, _ in tick_arg_specs]
+    tick = ir.Function(module, ir.FunctionType(ir.VoidType(), tick_param_types), name="Lockstep_Tick")
+    tick_param_ptrs: dict[tuple[str, str], ir.Argument] = {}
+    for arg, (kind, name, _, apply_noalias) in zip(tick.args, tick_arg_specs):
+        arg.name = f"{kind}_{_sanitize_symbol(name)}"
+        if apply_noalias:
+            arg.add_attribute("noalias")
+        tick_param_ptrs[(kind, name)] = arg
+
     tick_entry = tick.append_basic_block("entry")
     tick_builder = ir.IRBuilder(tick_entry)
 
@@ -630,13 +642,11 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
             return ir.Constant(ir.IntType(32), 0)
         return ir.Constant(llvm_type, None)
 
-    def _load_arena_slot(field_index: int, field_type: ir.Type) -> ir.Value:
-        slot_ptr = tick_builder.gep(
-            arena_ptr,
-            [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), field_index)],
-            name=f"arena_slot_{field_index}",
-        )
-        return tick_builder.load(slot_ptr, name=f"arena_val_{field_index}")
+    def _load_tick_param(kind: str, name: str, field_type: ir.Type) -> ir.Value:
+        ptr = tick_param_ptrs.get((kind, name))
+        if ptr is None:
+            return _zero_value(field_type)
+        return tick_builder.load(ptr, name=f"{kind}_{_sanitize_symbol(name)}_val")
 
     def _lower_kernel_route(route: dict[str, Any]):
         kernel_name = str(route.get("kernel", ""))
@@ -683,11 +693,11 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
             modifier = params[index].get("modifier") if index < len(params) else None
             value = None
             if modifier in {"in", "out"} and arg_name in stream_slots:
-                value = _load_arena_slot(stream_slots[arg_name], param.type)
+                value = _load_tick_param("stream", arg_name, param.type)
             elif modifier == "accum" and arg_name in accum_slots:
-                value = _load_arena_slot(accum_slots[arg_name], param.type)
+                value = _load_tick_param("accum", arg_name, param.type)
             elif modifier == "uniform" and arg_name in uniform_slots:
-                value = _load_arena_slot(uniform_slots[arg_name], param.type)
+                value = _load_tick_param("uniform", arg_name, param.type)
             if value is None:
                 value = _zero_value(param.type)
             call_args.append(value)

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -88,7 +88,7 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
     assert result.entities["fused_bind_groups"] == []
 
     assert result.llvm_ir.startswith('; ModuleID = "lockstep"\n')
-    assert 'define void @"Lockstep_Tick"(<{}>* %"arena")' in result.llvm_ir
+    assert 'define void @"Lockstep_Tick"()' in result.llvm_ir
 
 
 def test_emit_llvm_ir_generates_expected_declarations():
@@ -118,7 +118,7 @@ def test_emit_llvm_ir_generates_expected_declarations():
     assert "define float @\"pure_mix\"()" in llvm_ir
     assert "define void @\"shader_ApplyGravity\"()" in llvm_ir
     assert "define void @\"filter_Cull\"()" in llvm_ir
-    assert 'define void @"Lockstep_Tick"(<{%"struct.Vec3", float, float}>* %"arena")' in llvm_ir
+    assert 'define void @"Lockstep_Tick"(%"struct.Vec3"* noalias %"stream_raw_positions", float* noalias %"accum_energy", float* %"uniform_dt")' in llvm_ir
     assert '; bind: out = ApplyGravity(inp, out, energy, dt);' in llvm_ir
     assert "fmul float" in llvm_ir
     assert "uitofp i1" in llvm_ir


### PR DESCRIPTION
### Motivation
- The codegen needs to expose explicit aliasing information so streams (and accumulators) can be treated as non-aliasing by downstream LLVM optimizations, instead of hiding all fields inside a packed arena pointer.
- Changing the `Lockstep_Tick` ABI to accept separate pointers makes it possible to mark stream/accum pointers with `noalias` from `llvmlite`.

### Description
- Replaced the single packed `arena` parameter with per-resource pointer parameters by building `tick_arg_specs` for `stream`, `accum`, and `uniform` and creating `Lockstep_Tick` with those pointer argument types.
- Added `noalias` attributes to stream and accumulator pointer arguments via `arg.add_attribute("noalias")` when appropriate.
- Removed arena GEP/load logic and added helper `_load_tick_param(kind, name, type)` to load values from the named function parameters `stream_*`, `accum_*`, and `uniform_*`.
- Updated kernel-route lowering to call `_load_tick_param` instead of loading from the old arena slots, and adjusted tests to assert the new `Lockstep_Tick` signature.

### Testing
- Ran `pytest -q -o addopts='' tests/test_compiler_api.py`, which succeeded with `13 passed`.
- Running `pytest -q tests/test_compiler_api.py` without overriding project `addopts` failed due to environment-specific coverage CLI flags, so the explicit `-o addopts=''` invocation was used to run the suite successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98ef1bd948328a33145e53d7ed2fe)