### PR TITLE
Lower prelude intrinsics in codegen and add max builtin support

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -175,13 +175,59 @@ class _FunctionLowerer:
         function_map: dict[str, ir.Function],
         known_structs: dict[str, ir.IdentifiedStructType] | None = None,
         struct_fields: dict[str, list[dict[str, str]]] | None = None,
+        intrinsic_names: set[str] | None = None,
     ):
         self.module = module
         self.function_map = function_map
         self.known_structs = known_structs or {}
         self.struct_fields = struct_fields or {}
+        self.intrinsic_names = intrinsic_names or set()
         self.builder: ir.IRBuilder | None = None
         self.locals: dict[str, ir.AllocaInstr] = {}
+
+    def _declare_llvm_intrinsic(self, intrinsic_name: str, arg_type: ir.Type) -> ir.Function:
+        llvm_name = f"llvm.{intrinsic_name}.f32"
+        intrinsic = self.module.globals.get(llvm_name)
+        if intrinsic is not None:
+            return intrinsic
+        fn_type = ir.FunctionType(arg_type, [arg_type, arg_type])
+        return ir.Function(self.module, fn_type, name=llvm_name)
+
+    def _lower_intrinsic_call(self, name: str, args: list[ir.Value]) -> ir.Value | None:
+        if name == "step" and len(args) == 2:
+            if not all(isinstance(arg.type, ir.FloatType) for arg in args):
+                return ir.Constant(ir.FloatType(), 0.0)
+            edge, x_val = args
+            cmp_result = self.builder.fcmp_ordered(">=", x_val, edge, name="step_cmp")
+            return self.builder.uitofp(cmp_result, ir.FloatType(), name="step")
+
+        if name == "mix" and len(args) == 3:
+            if not all(isinstance(arg.type, ir.FloatType) for arg in args):
+                return ir.Constant(ir.FloatType(), 0.0)
+            a, b, t = args
+            one_minus_t = self.builder.fsub(ir.Constant(ir.FloatType(), 1.0), t, name="mix_one_minus_t")
+            return self.builder.fadd(
+                self.builder.fmul(a, one_minus_t),
+                self.builder.fmul(b, t),
+                name="mix",
+            )
+
+        if name == "max" and len(args) == 2:
+            if not all(isinstance(arg.type, ir.FloatType) for arg in args):
+                return ir.Constant(ir.FloatType(), 0.0)
+            maxnum = self._declare_llvm_intrinsic("maxnum", ir.FloatType())
+            return self.builder.call(maxnum, args, name="max")
+
+        if name == "clamp" and len(args) == 3:
+            if not all(isinstance(arg.type, ir.FloatType) for arg in args):
+                return ir.Constant(ir.FloatType(), 0.0)
+            x_val, min_value, max_value = args
+            maxnum = self._declare_llvm_intrinsic("maxnum", ir.FloatType())
+            minnum = self._declare_llvm_intrinsic("minnum", ir.FloatType())
+            clamped_min = self.builder.call(maxnum, [x_val, min_value], name="clamp_min")
+            return self.builder.call(minnum, [clamped_min, max_value], name="clamp")
+
+        return None
 
     def _struct_name_for_type(self, llvm_type: ir.Type) -> str | None:
         for name, known_ty in self.known_structs.items():
@@ -296,19 +342,10 @@ class _FunctionLowerer:
         return parser.parse()
 
     def _lower_call(self, name: str, args: list[ir.Value]) -> ir.Value:
-        if name == "mix" and len(args) == 3:
-            if not all(isinstance(arg.type, ir.FloatType) for arg in args):
-                return ir.Constant(ir.FloatType(), 0.0)
-            a, b, t = args
-            one_minus_t = self.builder.fsub(ir.Constant(ir.FloatType(), 1.0), t, name="mix_one_minus_t")
-            return self.builder.fadd(self.builder.fmul(a, one_minus_t), self.builder.fmul(b, t), name="mix")
-        if name == "step" and len(args) == 2:
-            if not all(isinstance(arg.type, ir.FloatType) for arg in args):
-                return ir.Constant(ir.FloatType(), 0.0)
-            edge = args[0]
-            x_val = args[1]
-            cmp_result = self.builder.fcmp_ordered(">=", x_val, edge, name="step_cmp")
-            return self.builder.uitofp(cmp_result, ir.FloatType(), name="step")
+        if name in self.intrinsic_names:
+            lowered_intrinsic = self._lower_intrinsic_call(name, args)
+            if lowered_intrinsic is not None:
+                return lowered_intrinsic
         callee = self.function_map.get(f"pure_{_sanitize_symbol(name)}")
         if callee is not None:
             coerced = [self._coerce_value_to_type(arg, param.type) for arg, param in zip(args, callee.args)]
@@ -527,7 +564,13 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
         known_structs[struct_name] = struct_ty
         struct_fields[struct_name] = struct_decl["fields"]
 
-    lowerer = _FunctionLowerer(module, {}, known_structs, struct_fields)
+    intrinsic_names = {
+        pure.get("name")
+        for pure in pure_functions
+        if isinstance(pure, dict) and pure.get("intrinsic") and pure.get("name")
+    }
+
+    lowerer = _FunctionLowerer(module, {}, known_structs, struct_fields, intrinsic_names)
 
     unresolved = set(known_structs.keys())
     while unresolved:
@@ -580,6 +623,8 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
 
     for pure in pure_functions:
         fn = function_map[f"pure_{_sanitize_symbol(pure['name'])}"]
+        if pure.get("intrinsic"):
+            continue
         lowerer.lower_function(fn, pure.get("body_ast", pure.get("body", [])), fn.function_type.return_type)
 
     for shader in shaders:

--- a/lockstep_compiler/prelude.lock
+++ b/lockstep_compiler/prelude.lock
@@ -4,3 +4,4 @@
 intrinsic float step(float edge, float x);
 intrinsic float mix(float a, float b, float t);
 intrinsic float clamp(float x, float min_value, float max_value);
+intrinsic float max(float x, float y);

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -78,7 +78,7 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
     assert result.entities["structs"] == []
     assert result.entities["shaders"] == []
     assert result.entities["filters"] == []
-    assert {fn["name"] for fn in result.entities["pure_functions"]} == {"step", "mix", "clamp"}
+    assert {fn["name"] for fn in result.entities["pure_functions"]} == {"step", "mix", "clamp", "max"}
     assert result.entities["streams"] == []
     assert result.entities["accumulators"] == []
     assert result.entities["uniforms"] == []
@@ -106,7 +106,13 @@ def test_emit_llvm_ir_generates_expected_declarations():
             ],
             "shaders": [{"name": "ApplyGravity"}],
             "filters": [{"name": "Cull"}],
-            "pure_functions": [{"name": "mix", "return_type": "float", "params": [], "body": ["returnmix(0.0,1.0,step(0.5,1.0));"]}],
+            "pure_functions": [
+                {"name": "step", "return_type": "float", "params": [{"name": "edge", "type": "float"}, {"name": "x", "type": "float"}], "intrinsic": True},
+                {"name": "mix", "return_type": "float", "params": [{"name": "a", "type": "float"}, {"name": "b", "type": "float"}, {"name": "t", "type": "float"}], "intrinsic": True},
+                {"name": "clamp", "return_type": "float", "params": [{"name": "x", "type": "float"}, {"name": "min_value", "type": "float"}, {"name": "max_value", "type": "float"}], "intrinsic": True},
+                {"name": "max", "return_type": "float", "params": [{"name": "x", "type": "float"}, {"name": "y", "type": "float"}], "intrinsic": True},
+                {"name": "demo", "return_type": "float", "params": [], "body": ["return clamp(max(mix(0.0, 1.0, step(0.5, 1.0)), 0.25), 0.0, 1.0);"]},
+            ],
             "streams": [{"name": "raw_positions", "type": "Vec3"}],
             "accumulators": [{"name": "energy", "type": "float"}],
             "uniforms": [{"name": "dt", "type": "float", "initializer": "0.016"}],
@@ -115,12 +121,15 @@ def test_emit_llvm_ir_generates_expected_declarations():
     )
 
     assert "%\"struct.Vec3\" = type {float, float, float}" in llvm_ir
-    assert "define float @\"pure_mix\"()" in llvm_ir
+    assert "define float @\"pure_demo\"()" in llvm_ir
     assert "define void @\"shader_ApplyGravity\"()" in llvm_ir
     assert "define void @\"filter_Cull\"()" in llvm_ir
     assert 'define void @"Lockstep_Tick"(<{%"struct.Vec3", float, float}>* %"arena")' in llvm_ir
     assert '; bind: out = ApplyGravity(inp, out, energy, dt);' in llvm_ir
-    assert "fmul float" in llvm_ir
+    assert 'declare float @"llvm.maxnum.f32"(float %".1", float %".2")' in llvm_ir
+    assert 'declare float @"llvm.minnum.f32"(float %".1", float %".2")' in llvm_ir
+    assert 'call float @"llvm.maxnum.f32"' in llvm_ir
+    assert 'call float @"llvm.minnum.f32"' in llvm_ir
     assert "uitofp i1" in llvm_ir
 
 

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1154,6 +1154,7 @@ def test_semantic_validator_records_pure_signature_from_declaration(debug_compil
         "step",
         "mix",
         "clamp",
+        "max",
     }
 
 


### PR DESCRIPTION
### Motivation
- Move intrinsic semantics out of ad-hoc hardcoded lowering in the Python codegen and make `mix`, `step`, `clamp`, and `max` proper prelude intrinsics so they are handled consistently by the compiler pipeline.
- Expose `max` as a standard prelude intrinsic so the semantic layer and codegen can treat it like the other branchless helpers referenced in the README.

### Description
- Added `max` to `lockstep_compiler/prelude.lock` so it is available from `load_intrinsics()` as a builtin (`intrinsic float max(float x, float y);`).
- Introduced intrinsic dispatch in `lockstep_compiler/codegen.py` by adding `intrinsic_names` to `_FunctionLowerer` and a centralized `_lower_intrinsic_call` implementation to lower intrinsics instead of hardcoding them in `_lower_call`.
- Implemented lowering for `step` and `mix` (existing semantics) and for `max` via `llvm.maxnum.f32` and `clamp` as a composition of `llvm.maxnum.f32` and `llvm.minnum.f32` using a `_declare_llvm_intrinsic` helper.
- Prevented intrinsic declarations from being emitted as normal function bodies by skipping body lowering for `pure_functions` marked with `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98efde05083288473a868f2ce422a)