### PR TITLE
Refactor: Extract sanitize_symbol to utils module and simplify codegen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 generated/parser/*.interp
 generated/parser/*.tokens
-__pycache__/*
+__pycache__/
+*.pyc
 .coverage
 coverage.xml
-tests/__pycache__/*
 tools/*.jar
 build/
 *.egg-info/

--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from .ast import AstProgram, ast_to_entities
+from .utils import sanitize_symbol as _sanitize_symbol
 
 _PRIMITIVE_C_TYPE = {
     "bool": "uint8_t",
@@ -19,10 +20,6 @@ _PRIMITIVE_SIZE = {
     "float": 4,
     "double": 8,
 }
-
-
-def _sanitize_symbol(name: str) -> str:
-    return "".join(ch if (ch.isalnum() or ch == "_") else "_" for ch in name)
 
 
 def _normalize_structs(structs: list[Any]) -> list[dict[str, Any]]:

--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -215,4 +215,4 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
 def main(argv=None):
     from .compiler import compile_lockstep
 
-    return run_cli(argv, compiler=compile_lockstep)
+    sys.exit(run_cli(argv, compiler=compile_lockstep))

--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -20,6 +20,7 @@ from .ast import (
     AstVarDeclStmt,
     ast_to_entities,
 )
+from .utils import sanitize_symbol as _sanitize_symbol
 
 
 _PRIMITIVE_TYPE_MAP: dict[str, ir.Type] = {
@@ -29,10 +30,6 @@ _PRIMITIVE_TYPE_MAP: dict[str, ir.Type] = {
     "float": ir.FloatType(),
     "double": ir.DoubleType(),
 }
-
-
-def _sanitize_symbol(name: str) -> str:
-    return "".join(ch if (ch.isalnum() or ch == "_") else "_" for ch in name)
 
 
 def _type_name(value: AstType | str) -> str:
@@ -352,62 +349,24 @@ class _FunctionLowerer:
             return self.builder.call(callee, coerced, name=f"call_{name}")
         return ir.Constant(ir.FloatType(), 0.0)
 
-    def _lower_expr(self, node):
-        if isinstance(node, AstExprLiteral):
-            if node.kind == "float":
-                return ir.Constant(ir.FloatType(), float(node.value))
-            if node.kind == "int":
-                return ir.Constant(ir.IntType(32), int(node.value))
-            return ir.Constant(ir.IntType(1), int(node.value == "true"))
-        if isinstance(node, AstExprVar):
-            return self._load_var(".".join(node.path))
-        if isinstance(node, AstExprUnary):
-            operand = self._lower_expr(node.operand)
-            if node.op == "-":
-                return self._emit_numeric_unary_minus(operand)
-            return self.builder.not_(operand)
-        if isinstance(node, AstExprCall):
-            return self._lower_call(node.name, [self._lower_expr(arg) for arg in node.args])
-        if isinstance(node, AstExprBinary):
-            op, lhs, rhs = node.op, self._lower_expr(node.left), self._lower_expr(node.right)
-            if op in {"+", "-", "*", "/", "%"}:
-                return self._emit_numeric_binary(op, lhs, rhs)
-            if op in {"&", "|", "^", "<<", ">>"} and isinstance(lhs.type, ir.IntType) and lhs.type == rhs.type:
-                if op == "&":
-                    return self.builder.and_(lhs, rhs)
-                if op == "|":
-                    return self.builder.or_(lhs, rhs)
-                if op == "^":
-                    return self.builder.xor(lhs, rhs)
-                if op == "<<":
-                    return self.builder.shl(lhs, rhs)
-                return self.builder.ashr(lhs, rhs)
-            if op in {"<", "<=", ">", ">=", "==", "!="}:
-                return self._emit_relational_compare(op, lhs, rhs)
-            if op == "&&":
-                return self.builder.and_(lhs, rhs)
-            if op == "||":
-                return self.builder.or_(lhs, rhs)
-            return ir.Constant(ir.FloatType(), 0.0)
-
+    @staticmethod
+    def _normalize_expr_node(node) -> "AstExprLiteral | AstExprVar | AstExprUnary | AstExprBinary | AstExprCall":
+        """Convert legacy tuple-based expression nodes to typed AST nodes."""
+        if isinstance(node, (AstExprLiteral, AstExprVar, AstExprUnary, AstExprBinary, AstExprCall)):
+            return node
         kind = node[0]
-        if kind == "float":
-            return ir.Constant(ir.FloatType(), node[1])
-        if kind == "int":
-            return ir.Constant(ir.IntType(32), node[1])
-        if kind == "bool":
-            return ir.Constant(ir.IntType(1), int(node[1]))
+        if kind in {"float", "int", "bool"}:
+            return AstExprLiteral(kind=kind, value=str(node[1]))
         if kind == "var":
-            return self._load_var(node[1])
+            return AstExprVar(path=tuple(node[1].split(".")))
         if kind == "un":
-            op, operand = node[1], self._lower_expr(node[2])
-            if op == "-":
-                return self._emit_numeric_unary_minus(operand)
-            return self.builder.not_(operand)
+            return AstExprUnary(op=node[1], operand=node[2])
         if kind == "call":
-            return self._lower_call(node[1], [self._lower_expr(arg) for arg in node[2]])
+            return AstExprCall(name=node[1], args=tuple(node[2]))
+        # "bin" — binary operation
+        return AstExprBinary(op=node[1], left=node[2], right=node[3])
 
-        op, lhs, rhs = node[1], self._lower_expr(node[2]), self._lower_expr(node[3])
+    def _lower_binary_op(self, op: str, lhs: ir.Value, rhs: ir.Value) -> ir.Value:
         if op in {"+", "-", "*", "/", "%"}:
             return self._emit_numeric_binary(op, lhs, rhs)
         if op in {"&", "|", "^", "<<", ">>"} and isinstance(lhs.type, ir.IntType) and lhs.type == rhs.type:
@@ -427,6 +386,28 @@ class _FunctionLowerer:
         if op == "||":
             return self.builder.or_(lhs, rhs)
         return ir.Constant(ir.FloatType(), 0.0)
+
+    def _lower_expr(self, node):
+        node = self._normalize_expr_node(node)
+
+        if isinstance(node, AstExprLiteral):
+            if node.kind == "float":
+                return ir.Constant(ir.FloatType(), float(node.value))
+            if node.kind == "int":
+                return ir.Constant(ir.IntType(32), int(node.value))
+            return ir.Constant(ir.IntType(1), int(node.value == "true"))
+        if isinstance(node, AstExprVar):
+            return self._load_var(".".join(node.path))
+        if isinstance(node, AstExprUnary):
+            operand = self._lower_expr(node.operand)
+            if node.op == "-":
+                return self._emit_numeric_unary_minus(operand)
+            return self.builder.not_(operand)
+        if isinstance(node, AstExprCall):
+            return self._lower_call(node.name, [self._lower_expr(arg) for arg in node.args])
+        # AstExprBinary
+        lhs, rhs = self._lower_expr(node.left), self._lower_expr(node.right)
+        return self._lower_binary_op(node.op, lhs, rhs)
 
     def _lower_assignment(self, target_name: str, value: ir.Value):
         base_name, *field_path = target_name.split(".")
@@ -726,48 +707,39 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
         vector_value = _build_vector_splat(accum_value, simd_width)
         vector_ty = vector_value.type
 
-        if isinstance(uniform_type, (ir.FloatType, ir.DoubleType)):
-            if operator in {"sum", "avg"}:
-                intrinsic_name = f"llvm.vector.reduce.fadd.v{simd_width}{uniform_type.intrinsic_name}"
-                intrinsic = _get_vector_reduce_intrinsic(intrinsic_name, uniform_type, [uniform_type, vector_ty])
-                reduced = tick_builder.call(intrinsic, [ir.Constant(uniform_type, 0.0), vector_value], name="fold_reduce")
-                reduced.fastmath.add("fast")
-                if operator == "avg":
-                    divisor = ir.Constant(uniform_type, float(simd_width))
-                    reduced = tick_builder.fdiv(reduced, divisor, name="fold_avg")
-                return reduced
-            if operator == "min":
-                intrinsic_name = f"llvm.vector.reduce.fmin.v{simd_width}{uniform_type.intrinsic_name}"
-                intrinsic = _get_vector_reduce_intrinsic(intrinsic_name, uniform_type, [vector_ty])
-                reduced = tick_builder.call(intrinsic, [vector_value], name="fold_reduce")
-                reduced.fastmath.add("fast")
-                return reduced
-            if operator == "max":
-                intrinsic_name = f"llvm.vector.reduce.fmax.v{simd_width}{uniform_type.intrinsic_name}"
-                intrinsic = _get_vector_reduce_intrinsic(intrinsic_name, uniform_type, [vector_ty])
-                reduced = tick_builder.call(intrinsic, [vector_value], name="fold_reduce")
-                reduced.fastmath.add("fast")
-                return reduced
+        # Map (is_float, operator) -> intrinsic suffix for reduction ops.
+        is_float = isinstance(uniform_type, (ir.FloatType, ir.DoubleType))
+        is_int = isinstance(uniform_type, ir.IntType)
+        _REDUCE_INTRINSIC = {
+            (True, "sum"): "fadd", (True, "avg"): "fadd",
+            (True, "min"): "fmin", (True, "max"): "fmax",
+            (False, "sum"): "add", (False, "avg"): "add",
+            (False, "min"): "smin", (False, "max"): "smax",
+        }
+        intrinsic_suffix = _REDUCE_INTRINSIC.get((is_float, operator)) if (is_float or is_int) else None
+        if intrinsic_suffix is None:
+            return _zero_value(uniform_type)
 
-        if isinstance(uniform_type, ir.IntType):
-            if operator in {"sum", "avg"}:
-                intrinsic_name = f"llvm.vector.reduce.add.v{simd_width}{uniform_type.intrinsic_name}"
-                intrinsic = _get_vector_reduce_intrinsic(intrinsic_name, uniform_type, [vector_ty])
-                reduced = tick_builder.call(intrinsic, [vector_value], name="fold_reduce")
-                if operator == "avg":
-                    divisor = ir.Constant(uniform_type, simd_width)
-                    reduced = tick_builder.sdiv(reduced, divisor, name="fold_avg")
-                return reduced
-            if operator == "min":
-                intrinsic_name = f"llvm.vector.reduce.smin.v{simd_width}{uniform_type.intrinsic_name}"
-                intrinsic = _get_vector_reduce_intrinsic(intrinsic_name, uniform_type, [vector_ty])
-                return tick_builder.call(intrinsic, [vector_value], name="fold_reduce")
-            if operator == "max":
-                intrinsic_name = f"llvm.vector.reduce.smax.v{simd_width}{uniform_type.intrinsic_name}"
-                intrinsic = _get_vector_reduce_intrinsic(intrinsic_name, uniform_type, [vector_ty])
-                return tick_builder.call(intrinsic, [vector_value], name="fold_reduce")
+        intrinsic_name = f"llvm.vector.reduce.{intrinsic_suffix}.v{simd_width}{uniform_type.intrinsic_name}"
+        # fadd requires a starting accumulator argument
+        needs_start_value = is_float and operator in {"sum", "avg"}
+        if needs_start_value:
+            intrinsic = _get_vector_reduce_intrinsic(intrinsic_name, uniform_type, [uniform_type, vector_ty])
+            reduced = tick_builder.call(intrinsic, [ir.Constant(uniform_type, 0.0), vector_value], name="fold_reduce")
+        else:
+            intrinsic = _get_vector_reduce_intrinsic(intrinsic_name, uniform_type, [vector_ty])
+            reduced = tick_builder.call(intrinsic, [vector_value], name="fold_reduce")
 
-        return _zero_value(uniform_type)
+        if is_float:
+            reduced.fastmath.add("fast")
+
+        if operator == "avg":
+            if is_float:
+                reduced = tick_builder.fdiv(reduced, ir.Constant(uniform_type, float(simd_width)), name="fold_avg")
+            else:
+                reduced = tick_builder.sdiv(reduced, ir.Constant(uniform_type, simd_width), name="fold_avg")
+
+        return reduced
 
     def _lower_kernel_route(route: dict[str, Any]):
         kernel_name = str(route.get("kernel", ""))

--- a/lockstep_compiler/errors.py
+++ b/lockstep_compiler/errors.py
@@ -24,18 +24,20 @@ class ParseErrorCollector(ErrorListener):
 
 
 class LockstepCompileError(Exception):
-    """Raised when the Lockstep source contains parse errors."""
+    """Raised when the Lockstep source contains parse or semantic errors."""
 
-    def __init__(self, errors, diagnostics=None, *, phase: str = "parse"):
+    def __init__(self, errors, diagnostics=None, *, phase: str = "parse", source_file: str | None = None):
         self.errors = errors
         self.diagnostics = diagnostics or []
         self.phase = phase
+        self.source_file = source_file
         super().__init__(self._format_message())
 
     def _format_message(self):
         count = len(self.errors)
         suffix = "" if count == 1 else "s"
-        summary = f"Compilation failed with {count} {self.phase} error{suffix}."
+        file_context = f" in '{self.source_file}'" if self.source_file else ""
+        summary = f"Compilation failed with {count} {self.phase} error{suffix}{file_context}."
         details = "\n".join(
             f"line {error.line}:{error.column} {error.message}" for error in self.errors
         )

--- a/lockstep_compiler/utils.py
+++ b/lockstep_compiler/utils.py
@@ -1,0 +1,3 @@
+def sanitize_symbol(name: str) -> str:
+    """Replace non-alphanumeric, non-underscore characters with underscores."""
+    return "".join(ch if (ch.isalnum() or ch == "_") else "_" for ch in name)

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -181,7 +181,11 @@ def test_cli_main_wires_default_compiler(monkeypatch):
     monkeypatch.setattr(cli_module, "run_cli", fake_run_cli)
     monkeypatch.setattr(compiler_module, "compile_lockstep", sentinel_compiler)
 
-    assert cli_module.main(["--dump"]) == 7
+    import pytest
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_module.main(["--dump"])
+    assert exc_info.value.code == 7
 
 
 def test_load_default_parser_classes_is_cached(monkeypatch):


### PR DESCRIPTION
## Summary
This PR refactors the codebase to improve code organization and maintainability by extracting the `sanitize_symbol` function into a shared utilities module and simplifying the expression lowering logic in the code generator.

## Key Changes

- **Extract `sanitize_symbol` to utils module**: Moved the `sanitize_symbol` function from `codegen.py` and `c_header.py` into a new `lockstep_compiler/utils.py` module to eliminate duplication and provide a single source of truth.

- **Refactor expression lowering in codegen**: 
  - Introduced `_normalize_expr_node()` static method to convert legacy tuple-based expression nodes to typed AST nodes, improving type safety and maintainability.
  - Extracted binary operation handling into a dedicated `_lower_binary_op()` method to reduce code duplication and improve readability.
  - Simplified `_lower_expr()` to use the new helper methods, making the logic clearer and easier to follow.

- **Simplify vector reduction fold logic**: Refactored `_reduce_fold()` to use a lookup table for intrinsic suffixes instead of deeply nested conditionals, reducing code duplication and improving maintainability.

- **Improve error reporting**: Updated `LockstepCompileError` to optionally include the source file name in error messages for better context.

- **Fix CLI exit handling**: Modified `main()` in `cli.py` to properly call `sys.exit()` with the return code from `run_cli()`.

- **Update test expectations**: Fixed test in `test_compiler_api.py` to properly handle `SystemExit` exception when testing CLI error handling.

- **Improve .gitignore**: Updated patterns to be more precise (`__pycache__/` instead of `__pycache__/*`) and added `*.pyc` for better coverage of Python cache files.

## Implementation Details

The refactoring maintains backward compatibility by supporting both legacy tuple-based expression nodes and new typed AST nodes through the `_normalize_expr_node()` method. This allows for a gradual migration path without breaking existing code.

The vector reduction refactoring uses a dictionary-based lookup to map (is_float, operator) tuples to intrinsic suffixes, significantly reducing the number of conditional branches and making the code more maintainable.

https://claude.ai/code/session_01HGsKaAZgAXACQcB4JZMcKS