### PR TITLE
Add optional saturated-write debug helpers to generated C header

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ lockstepc path/to/program.lock --simulate --simulate-input path/to/input.json
 
 Simulation output includes per-route `input_count`/`output_count`, updated stream snapshots, accumulator contents, and folded uniform values.
 
+Generated C headers include `Lockstep_SaturatedWriteIndex(...)` plus per-stream `LOCKSTEP_CAPACITY_STREAM_<NAME>` macros. Define `LOCKSTEP_DEBUG_SATURATED_WRITES` before including the header to log whenever a saturated write falls back to the final index. Override `LOCKSTEP_SATURATED_WRITE_LOG(...)` to integrate with custom telemetry.
+
 ### Diagnostic Shape
 
 Each diagnostic includes:

--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -109,6 +109,9 @@ def emit_c_header(program_or_entities: AstProgram | dict[str, Any], guard: str =
         "",
         "#include <stdint.h>",
         "#include <stddef.h>",
+        "#ifdef LOCKSTEP_DEBUG_SATURATED_WRITES",
+        "#include <stdio.h>",
+        "#endif",
         "",
         "#if defined(_MSC_VER)",
         "#define LOCKSTEP_PACKED_STRUCT(definition) __pragma(pack(push, 1)) definition __pragma(pack(pop))",
@@ -147,7 +150,36 @@ def emit_c_header(program_or_entities: AstProgram | dict[str, Any], guard: str =
     for kind, name, offset in offsets:
         macro_suffix = f"{kind}_{_sanitize_symbol(name)}".upper()
         lines.append(f"#define LOCKSTEP_OFFSET_{macro_suffix} {offset}")
+    for stream in entities.get("streams", []):
+        stream_name = _sanitize_symbol(stream["name"]).upper()
+        stream_capacity = int(stream.get("capacity", 0)) if stream.get("capacity") is not None else 0
+        lines.append(f"#define LOCKSTEP_CAPACITY_STREAM_{stream_name} {stream_capacity}")
     lines.append("")
+
+    lines.extend(
+        [
+            "#ifndef LOCKSTEP_SATURATED_WRITE_LOG",
+            "#define LOCKSTEP_SATURATED_WRITE_LOG(stream_name, index, capacity, saturated_index) \\",
+            "    fprintf(stderr, \"[lockstep] saturated write stream=%s index=%zu capacity=%zu -> %zu\\n\", \\",
+            "            (stream_name), (size_t)(index), (size_t)(capacity), (size_t)(saturated_index))",
+            "#endif",
+            "",
+            "static inline size_t Lockstep_SaturatedWriteIndex(size_t index, size_t capacity, const char* stream_name) {",
+            "    if (capacity == 0) {",
+            "        return 0;",
+            "    }",
+            "    if (index < capacity) {",
+            "        return index;",
+            "    }",
+            "    const size_t saturated_index = capacity - 1;",
+            "#ifdef LOCKSTEP_DEBUG_SATURATED_WRITES",
+            "    LOCKSTEP_SATURATED_WRITE_LOG(stream_name != NULL ? stream_name : \"<unnamed>\", index, capacity, saturated_index);",
+            "#endif",
+            "    return saturated_index;",
+            "}",
+            "",
+        ]
+    )
 
     lines.extend(
         [

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -459,6 +459,24 @@ def test_emit_c_header_generates_structs_offsets_and_tick_signature():
     assert "void Lockstep_Tick(struct Lockstep_Arena* arena);" in header
 
 
+
+
+def test_emit_c_header_includes_optional_saturated_write_debug_helpers():
+    header = emit_c_header(
+        {
+            "streams": [{"name": "output_stream", "type": "float", "capacity": "16"}],
+            "accumulators": [],
+            "uniforms": [],
+        }
+    )
+
+    assert "#ifdef LOCKSTEP_DEBUG_SATURATED_WRITES" in header
+    assert '#include <stdio.h>' in header
+    assert "#define LOCKSTEP_CAPACITY_STREAM_OUTPUT_STREAM 16" in header
+    assert "#ifndef LOCKSTEP_SATURATED_WRITE_LOG" in header
+    assert "static inline size_t Lockstep_SaturatedWriteIndex(size_t index, size_t capacity, const char* stream_name)" in header
+    assert "LOCKSTEP_SATURATED_WRITE_LOG(stream_name != NULL ? stream_name : \"<unnamed>\"" in header
+
 def test_compile_result_includes_c_header(monkeypatch):
     class StubLexer:
         def __init__(self, input_stream):


### PR DESCRIPTION
### Motivation

- Saturated "trash can" stream writes silently drop excess items which makes debugging difficult when a pipeline exceeds a stream capacity.  Adding an opt-in logging hook helps detect when saturation occurs.  
- Exposing per-stream capacity macros allows host code to introspect configured limits without parsing the header text.  

### Description

- Extended `lockstep_compiler/c_header.py` to emit conditional `#include <stdio.h>` when `LOCKSTEP_DEBUG_SATURATED_WRITES` is defined and to produce per-stream `#define LOCKSTEP_CAPACITY_STREAM_<NAME> <N>` macros.  
- Added a customizable logging macro `LOCKSTEP_SATURATED_WRITE_LOG(...)` and a small helper `static inline size_t Lockstep_SaturatedWriteIndex(size_t index, size_t capacity, const char* stream_name)` which returns the saturated index and logs when `LOCKSTEP_DEBUG_SATURATED_WRITES` is enabled.  
- Added `tests/test_compiler_api.py::test_emit_c_header_includes_optional_saturated_write_debug_helpers` to cover the new header surface and updated `README.md` to document the flag and hook.  

### Testing

- Ran `pytest -q tests/test_compiler_api.py -k "emit_c_header"` which initially failed in this environment due to project `pyproject.toml` injecting coverage options understood by CI but not by the local pytest invocation.  
- Re-ran the targeted tests with `pytest -q -o addopts='' tests/test_compiler_api.py -k "emit_c_header"` and the tests covering the emitted header passed.  
- Verified the CLI/header integration test with `pytest -q -o addopts='' tests/test_improvements.py -k "emit_header"` which also passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ada203f8d083289c67152df3930fd1)