### PR TITLE
Make CLI output flags mutually exclusive and add `--report` JSON mode

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -61,6 +61,16 @@ def build_arg_parser():
         action="store_true",
         help="Emit generated C host header to stdout.",
     )
+    mode_group.add_argument(
+        "--simulate",
+        action="store_true",
+        help="Simulate bind-route execution on small in-memory datasets.",
+    )
+    mode_group.add_argument(
+        "--report",
+        action="store_true",
+        help="Emit one JSON report containing both compiled entities and simulation output.",
+    )
     parser.add_argument(
         "--debug",
         action="store_true",
@@ -74,15 +84,28 @@ def build_arg_parser():
         help="Path to a Lockstep source library file containing shared structs/pure functions.",
     )
     parser.add_argument(
-        "--simulate",
-        action="store_true",
-        help="Simulate bind-route execution on small in-memory datasets.",
-    )
-    parser.add_argument(
         "--simulate-input",
         help="Path to a JSON file containing simulation inputs with `streams` and optional `accumulators` maps.",
     )
     return parser
+
+
+def _load_simulation_inputs(args, *, stderr):
+    input_payload = ""
+    if args.simulate_input:
+        input_path = Path(args.simulate_input)
+        try:
+            input_payload = input_path.read_text(encoding="utf-8")
+        except OSError as err:
+            print(f"Unable to read simulation input '{input_path}': {err}", file=stderr)
+            return None
+    try:
+        return parse_simulation_inputs(input_payload)
+    except json.JSONDecodeError as err:
+        print(f"Unable to parse simulation input JSON: {err}", file=stderr)
+    except ValueError as err:
+        print(f"Invalid simulation input: {err}", file=stderr)
+    return None
 
 
 def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
@@ -213,35 +236,37 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
         print(c_header, file=stdout)
         return 0
 
+    entities = getattr(result, "entities", result)
+
     if args.dump:
-        entities = getattr(result, "entities", result)
         print(json.dumps(entities, indent=2, sort_keys=True, default=str), file=stdout)
+        return 0
 
-    if args.simulate:
-        input_payload = ""
-        if args.simulate_input:
-            input_path = Path(args.simulate_input)
-            try:
-                input_payload = input_path.read_text(encoding="utf-8")
-            except OSError as err:
-                print(f"Unable to read simulation input '{input_path}': {err}", file=stderr)
-                return 1
-        try:
-            stream_inputs, accumulator_inputs = parse_simulation_inputs(input_payload)
-        except json.JSONDecodeError as err:
-            print(f"Unable to parse simulation input JSON: {err}", file=stderr)
+    if args.simulate or args.report:
+        simulation_inputs = _load_simulation_inputs(args, stderr=stderr)
+        if simulation_inputs is None:
             return 1
-        except ValueError as err:
-            print(f"Invalid simulation input: {err}", file=stderr)
-            return 1
+        stream_inputs, accumulator_inputs = simulation_inputs
 
-        entities = getattr(result, "entities", result)
         simulation = simulate_pipeline_entities(
             entities,
             stream_inputs=stream_inputs,
             accumulator_inputs=accumulator_inputs,
         )
-        print(json.dumps(simulation, indent=2, sort_keys=True, default=str), file=stdout)
+
+        if args.report:
+            print(
+                json.dumps(
+                    {"entities": entities, "simulation": simulation},
+                    indent=2,
+                    sort_keys=True,
+                    default=str,
+                ),
+                file=stdout,
+            )
+        else:
+            print(json.dumps(simulation, indent=2, sort_keys=True, default=str), file=stdout)
+        return 0
 
     return 0
 

--- a/tests/test_improvements.py
+++ b/tests/test_improvements.py
@@ -213,6 +213,22 @@ def test_arg_parser_has_version():
     assert args.version is True
 
 
+def test_arg_parser_rejects_multiple_output_modes():
+    parser = build_arg_parser()
+    try:
+        parser.parse_args(["--dump", "--simulate"])
+    except SystemExit as err:
+        assert err.code == 2
+    else:
+        raise AssertionError("Expected parser to reject multiple output-producing flags")
+
+
+def test_arg_parser_has_report():
+    parser = build_arg_parser()
+    args = parser.parse_args(["--report"])
+    assert args.report is True
+
+
 # ---------------------------------------------------------------------------
 # LSP hover
 # ---------------------------------------------------------------------------

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -115,6 +115,49 @@ def test_run_cli_simulate_reads_input_file(tmp_path):
     assert payload["streams"]["s"] == [1, 2, 3]
 
 
+
+def test_run_cli_report_prints_single_json_payload_with_entities_and_simulation():
+    def fake_compiler(_source):
+        return {
+            "streams": [{"name": "s", "type": "int", "capacity": "4"}],
+            "accumulators": [],
+            "uniforms": [],
+            "shaders": [],
+            "filters": [],
+            "bind_routes": [],
+        }
+
+    stdout = io.StringIO()
+    exit_code = run_cli(
+        ["--report"],
+        stdin=io.StringIO("pipeline P { }"),
+        stdout=stdout,
+        compiler=fake_compiler,
+    )
+
+    assert exit_code == 0
+    decoder = json.JSONDecoder()
+    payload_text = stdout.getvalue()
+    payload, index = decoder.raw_decode(payload_text)
+    assert payload["entities"]["streams"][0]["name"] == "s"
+    assert payload["simulation"]["streams"] == {"s": []}
+    assert payload_text[index:].strip() == ""
+
+
+def test_run_cli_rejects_combined_dump_and_simulate_modes():
+    try:
+        run_cli(
+            ["--dump", "--simulate"],
+            stdin=io.StringIO("pipeline P { }"),
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+            compiler=lambda source: source,
+        )
+    except SystemExit as err:
+        assert err.code == 2
+    else:
+        raise AssertionError("Expected parser to reject combined output-producing flags")
+
 def test_simulate_pipeline_entities_saturates_stream_writes_at_capacity():
     entities = {
         "streams": [


### PR DESCRIPTION
### Motivation
- Prevent the CLI from emitting multiple top-level JSON payloads in a single invocation by making output-producing flags mutually exclusive.
- Provide an explicit combined output mode that returns both compiled `entities` and `simulation` together in a single structured JSON object.

### Description
- Moved `--simulate` into the parser's mutually-exclusive group alongside `--dump`, `--format`, `--emit-ir`, and `--emit-header` in `lockstep_compiler/cli.py` so output-producing flags cannot be combined.
- Added a new `--report` flag that emits one JSON object containing both `entities` and `simulation` when requested.
- Introduced `_load_simulation_inputs()` to centralize reading and validating the `--simulate-input` file and to surface consistent error messages.
- Refactored `run_cli()` output flow to return immediately after producing a single output path (`dump`, `simulate`, or `report`) so each invocation emits at most one top-level payload.
- Added/updated tests in `tests/test_improvements.py` and `tests/test_simulator.py` to assert argument-parser mutual exclusivity and to verify `--report` emits a single JSON document containing both `entities` and `simulation`.

### Testing
- Ran `pytest -q -o addopts='' tests/test_improvements.py tests/test_simulator.py tests/test_cli_format.py tests/test_cli_libraries.py` to avoid repository `--cov` addopts interfering with the environment.
- All targeted tests passed: `35 passed` for the invoked test set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b33a7526bc832894cc08ca877d2b9e)