### PR TITLE
Validate --simulate-input usage in CLI

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -93,6 +93,13 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
     stdout = sys.stdout if stdout is None else stdout
     stderr = sys.stderr if stderr is None else stderr
 
+    if args.simulate_input and not args.simulate:
+        print(
+            "usage error: --simulate-input requires --simulate.",
+            file=stderr,
+        )
+        return 2
+
     if args.version:
         from importlib.metadata import version as _pkg_version, PackageNotFoundError
         try:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -115,6 +115,23 @@ def test_run_cli_simulate_reads_input_file(tmp_path):
     assert payload["streams"]["s"] == [1, 2, 3]
 
 
+def test_run_cli_rejects_simulate_input_without_simulate(tmp_path):
+    input_file = tmp_path / "sim-input.json"
+    input_file.write_text('{"streams": {"s": [1]}}', encoding="utf-8")
+
+    stderr = io.StringIO()
+    exit_code = run_cli(
+        ["--simulate-input", str(input_file)],
+        stdin=io.StringIO("pipeline P { }"),
+        stdout=io.StringIO(),
+        stderr=stderr,
+        compiler=lambda _source: {},
+    )
+
+    assert exit_code == 2
+    assert "--simulate-input requires --simulate" in stderr.getvalue()
+
+
 def test_simulate_pipeline_entities_saturates_stream_writes_at_capacity():
     entities = {
         "streams": [


### PR DESCRIPTION
### Motivation
- Prevent confusing/invalid CLI usage by ensuring `--simulate-input` is only accepted when `--simulate` is also provided.

### Description
- Add a post-parse check in `run_cli` to print a clear usage error to `stderr` and return exit code `2` when `args.simulate_input` is provided but `args.simulate` is not, and add `test_run_cli_rejects_simulate_input_without_simulate` to `tests/test_simulator.py` to exercise this behavior.

### Testing
- Ran targeted pytest invocations; an initial run failed due to repo `addopts`/coverage CLI args, then reran with `-o addopts=''` and the relevant tests passed (`3 passed` for the group and `1 passed` for the new test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b33a7908bc8328aca26c0a1ff31990)