### PR TITLE
Refactor LSP member analysis to reuse per-request context

### DIFF
--- a/lockstep_compiler/lsp.py
+++ b/lockstep_compiler/lsp.py
@@ -16,6 +16,13 @@ class MemberDefinition:
     column: int
 
 
+@dataclass(frozen=True)
+class AnalysisContext:
+    variable_types: dict[str, str]
+    struct_member_index: dict[str, dict[str, MemberDefinition]]
+    struct_field_types: dict[str, dict[str, str]]
+
+
 _STRUCT_RE = re.compile(r"\bstruct\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{", re.MULTILINE)
 _FIELD_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s*;")
 _TYPED_NAME_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)\b")
@@ -151,10 +158,40 @@ def infer_variable_types(source: str) -> dict[str, str]:
     return inferred
 
 
+def _build_struct_field_type_index(source: str) -> dict[str, dict[str, str]]:
+    """Index struct field type declarations for hover text generation."""
+
+    index: dict[str, dict[str, str]] = {}
+    for struct_match in _STRUCT_RE.finditer(source):
+        struct_name = struct_match.group(1)
+        body_start = struct_match.end()
+        body_end = source.find("}", body_start)
+        if body_end == -1:
+            continue
+
+        body = source[body_start:body_end]
+        index[struct_name] = {}
+        for field_match in _FIELD_RE.finditer(body):
+            index[struct_name][field_match.group(2)] = field_match.group(1)
+
+    return index
+
+
+def build_analysis_context(source: str) -> AnalysisContext:
+    """Build reusable per-request analysis context for member-based LSP features."""
+
+    return AnalysisContext(
+        variable_types=infer_variable_types(source),
+        struct_member_index=build_struct_member_index(source),
+        struct_field_types=_build_struct_field_type_index(source),
+    )
+
+
 def find_member_definition(
     source: str,
     line: int,
     column: int,
+    analysis_context: AnalysisContext | None = None,
 ) -> MemberDefinition | None:
     """Resolve `foo.bar` usages to `struct` field declaration locations."""
 
@@ -163,16 +200,18 @@ def find_member_definition(
         return None
 
     line_text = lines[line]
+    context = analysis_context or build_analysis_context(source)
+    variable_types = context.variable_types
+    struct_index = context.struct_member_index
+
     for match in _MEMBER_ACCESS_RE.finditer(line_text):
         start, end = match.span(0)
         if not (start <= column <= end):
             continue
         variable_name, field_name = match.groups()
-        variable_types = infer_variable_types(source)
         struct_name = variable_types.get(variable_name)
         if not struct_name:
             return None
-        struct_index = build_struct_member_index(source)
         return struct_index.get(struct_name, {}).get(field_name)
     return None
 
@@ -279,6 +318,7 @@ def provide_hover_info(
     source: str,
     line: int,
     column: int,
+    analysis_context: AnalysisContext | None = None,
 ) -> str | None:
     """Return hover text for the identifier at the given position."""
 
@@ -287,6 +327,10 @@ def provide_hover_info(
         return None
 
     line_text = lines[line]
+    context = analysis_context or build_analysis_context(source)
+    variable_types = context.variable_types
+    struct_index = context.struct_member_index
+    field_types = context.struct_field_types
 
     # Try member access first (foo.bar)
     for match in _MEMBER_ACCESS_RE.finditer(line_text):
@@ -294,24 +338,13 @@ def provide_hover_info(
         if not (start <= column <= end):
             continue
         variable_name, field_name = match.groups()
-        variable_types = infer_variable_types(source)
         struct_name = variable_types.get(variable_name)
         if struct_name:
-            struct_index = build_struct_member_index(source)
             field_def = struct_index.get(struct_name, {}).get(field_name)
             if field_def:
-                # Find the field type from struct declarations
-                for struct_match in _STRUCT_RE.finditer(source):
-                    if struct_match.group(1) != struct_name:
-                        continue
-                    body_start = struct_match.end()
-                    body_end = source.find("}", body_start)
-                    if body_end == -1:
-                        continue
-                    body = source[body_start:body_end]
-                    for fm in _FIELD_RE.finditer(body):
-                        if fm.group(2) == field_name:
-                            return f"(field) `{struct_name}.{field_name}: {fm.group(1)}`"
+                field_type = field_types.get(struct_name, {}).get(field_name)
+                if field_type:
+                    return f"(field) `{struct_name}.{field_name}: {field_type}`"
             return f"(field) `{struct_name}.{field_name}`"
         return None
 
@@ -322,7 +355,6 @@ def provide_hover_info(
         if not (start <= column < end):
             continue
         name = match.group(1)
-        variable_types = infer_variable_types(source)
         if name in variable_types:
             return f"(variable) `{name}: {variable_types[name]}`"
 
@@ -409,10 +441,12 @@ def run_lsp_server() -> int:
     @server.feature(types.TEXT_DOCUMENT_HOVER)
     def hover(params: types.HoverParams):
         document = server.workspace.get_text_document(params.text_document.uri)
+        analysis_context = build_analysis_context(document.source)
         info = provide_hover_info(
             document.source,
             params.position.line,
             params.position.character,
+            analysis_context=analysis_context,
         )
         if info is None:
             return None
@@ -426,10 +460,12 @@ def run_lsp_server() -> int:
     @server.feature(types.TEXT_DOCUMENT_DEFINITION)
     def definition(params: types.DefinitionParams):
         document = server.workspace.get_text_document(params.text_document.uri)
+        analysis_context = build_analysis_context(document.source)
         member = find_member_definition(
             document.source,
             params.position.line,
             params.position.character,
+            analysis_context=analysis_context,
         )
         if member is None:
             return None

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -1,7 +1,9 @@
 from lockstep_compiler.lsp import (
+    build_analysis_context,
     build_struct_member_index,
     find_member_definition,
     provide_bind_completion_items,
+    provide_hover_info,
 )
 
 
@@ -80,3 +82,60 @@ pipeline P {
         "Bind route template",
         "Shader/filter callable",
     ]
+
+
+def test_large_source_member_definition_matches_default_and_context_path():
+    struct_count = 50
+    shader_count = 60
+    struct_defs = [
+        f"struct Vec{i} {{ float x; float y; float z; }};" for i in range(struct_count)
+    ]
+    shader_defs = [
+        f"shader S{i}(in Vec{i % struct_count} pos, out Vec{i % struct_count} out_pos) {{ out_pos.y = pos.y; }}"
+        for i in range(shader_count)
+    ]
+    source = "\n".join([*struct_defs, *shader_defs])
+
+    target_line = struct_count + shader_count - 1
+    target_column = shader_defs[-1].index("pos.y") + 1
+
+    expected = find_member_definition(source, target_line, target_column)
+
+    context = build_analysis_context(source)
+    actual = find_member_definition(
+        source,
+        target_line,
+        target_column,
+        analysis_context=context,
+    )
+
+    assert expected is not None
+    assert actual == expected
+
+
+def test_large_source_hover_matches_default_and_context_path():
+    source = "\n".join(
+        [
+            "struct Payload { float value; int id; };",
+            *[
+                f"shader Step{i}(in Payload p, out Payload out_p) {{ out_p.value = p.value; }}"
+                for i in range(120)
+            ],
+        ]
+    )
+
+    target_line = 120
+    target_column = source.splitlines()[target_line].index("p.value") + 2
+
+    expected = provide_hover_info(source, target_line, target_column)
+
+    context = build_analysis_context(source)
+    actual = provide_hover_info(
+        source,
+        target_line,
+        target_column,
+        analysis_context=context,
+    )
+
+    assert expected == "(field) `Payload.value: float`"
+    assert actual == expected


### PR DESCRIPTION
### Motivation
- Avoid repeated regex and index recomputation when resolving member accesses and hover info to improve LSP performance.
- Preserve rich hover text including field types without rescanning struct bodies for every match.
- Ensure behavior remains unchanged under larger sources by adding tests that exercise a heavier synthetic workload.

### Description
- Introduced an `AnalysisContext` dataclass and `build_analysis_context(source)` to precompute `variable_types`, `struct_member_index`, and `struct_field_types` once per request.
- Added `_build_struct_field_type_index(source)` to capture field types for hover text generation and used it in the analysis context.
- Updated `find_member_definition(...)` and `provide_hover_info(...)` to accept an optional `analysis_context` and to reuse precomputed indexes instead of recomputing during match iteration.
- Wired LSP server handlers in `run_lsp_server()` to build a single `AnalysisContext` per request and pass it to hover/definition resolution.
- Added larger behavioral tests in `tests/test_lsp.py` to compare default and context-driven code paths for definition and hover resolution on synthetic large sources.

### Testing
- `pytest -q tests/test_lsp.py` initially failed in this environment due to repository `addopts` coverage arguments that are not available here.
- `PYTHONPATH=. pytest -q tests/test_lsp.py -o addopts=''` was run and all tests in that file passed successfully (7 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b33a8267b88328b56a9d0a7f4e9147)