### PR TITLE
Use compiler entities to drive LSP symbol tables

### DIFF
--- a/lockstep_compiler/lsp.py
+++ b/lockstep_compiler/lsp.py
@@ -26,6 +26,7 @@ _SHADER_DEF_RE = re.compile(r"\bshader\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
 _PURE_DEF_RE = re.compile(
     r"\bpure\s+[A-Za-z_][A-Za-z0-9_]*\s+([A-Za-z_][A-Za-z0-9_]*)\s*\("
 )
+_FILTER_DEF_RE = re.compile(r"\bfilter\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
 _BIND_BLOCK_RE = re.compile(r"\bbind\s*\{(?P<body>[\s\S]*?)\}", re.MULTILINE)
 _MEMBER_ACCESS_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)")
 
@@ -107,6 +108,113 @@ def compile_for_lsp(source: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
 def build_struct_member_index(source: str) -> dict[str, dict[str, MemberDefinition]]:
     """Index struct field declarations with source locations (0-based)."""
 
+    entities, _ = compile_for_lsp(source)
+    if entities.get("structs"):
+        return _build_struct_member_index_from_entities(source, entities)
+
+    return _build_struct_member_index_from_regex(source)
+
+
+def _mask_comments(source: str) -> str:
+    """Replace comment contents with spaces while preserving offsets."""
+
+    chars = list(source)
+    index = 0
+    while index < len(chars):
+        if chars[index] == "/" and index + 1 < len(chars):
+            if chars[index + 1] == "/":
+                chars[index] = " "
+                chars[index + 1] = " "
+                index += 2
+                while index < len(chars) and chars[index] != "\n":
+                    chars[index] = " "
+                    index += 1
+                continue
+            if chars[index + 1] == "*":
+                chars[index] = " "
+                chars[index + 1] = " "
+                index += 2
+                while index + 1 < len(chars):
+                    if chars[index] == "*" and chars[index + 1] == "/":
+                        chars[index] = " "
+                        chars[index + 1] = " "
+                        index += 2
+                        break
+                    if chars[index] != "\n":
+                        chars[index] = " "
+                    index += 1
+                continue
+        index += 1
+    return "".join(chars)
+
+
+def _offset_to_line_column(source: str, offset: int) -> tuple[int, int]:
+    line = source.count("\n", 0, offset)
+    line_start = source.rfind("\n", 0, offset)
+    if line_start == -1:
+        return line, offset
+    return line, offset - line_start - 1
+
+
+def _find_matching_brace(source: str, brace_index: int) -> int:
+    depth = 0
+    for idx in range(brace_index, len(source)):
+        token = source[idx]
+        if token == "{":
+            depth += 1
+        elif token == "}":
+            depth -= 1
+            if depth == 0:
+                return idx
+    return -1
+
+
+def _build_struct_member_index_from_entities(
+    source: str,
+    entities: dict[str, Any],
+) -> dict[str, dict[str, MemberDefinition]]:
+    masked = _mask_comments(source)
+    index: dict[str, dict[str, MemberDefinition]] = {}
+
+    for struct in entities.get("structs", []):
+        struct_name = struct.get("name")
+        if not struct_name:
+            continue
+        field_names = [field.get("name") for field in struct.get("fields", []) if field.get("name")]
+        struct_match = re.search(rf"\bstruct\s+{re.escape(struct_name)}\b", masked)
+        if not struct_match:
+            continue
+
+        open_brace = masked.find("{", struct_match.end())
+        if open_brace == -1:
+            continue
+        close_brace = _find_matching_brace(masked, open_brace)
+        if close_brace == -1:
+            continue
+
+        struct_fields: dict[str, MemberDefinition] = {}
+        body = masked[open_brace + 1 : close_brace]
+        body_start = open_brace + 1
+        for field_name in field_names:
+            field_match = re.search(rf"\b{re.escape(field_name)}\b\s*;", body)
+            if not field_match:
+                continue
+            field_offset = body_start + field_match.start()
+            line, column = _offset_to_line_column(source, field_offset)
+            struct_fields[field_name] = MemberDefinition(
+                struct_name=struct_name,
+                field_name=field_name,
+                line=line,
+                column=column,
+            )
+        index[struct_name] = struct_fields
+
+    return index
+
+
+def _build_struct_member_index_from_regex(source: str) -> dict[str, dict[str, MemberDefinition]]:
+    """Fallback indexer used when compilation cannot provide entities."""
+
     index: dict[str, dict[str, MemberDefinition]] = {}
 
     for struct_match in _STRUCT_RE.finditer(source):
@@ -121,12 +229,7 @@ def build_struct_member_index(source: str) -> dict[str, dict[str, MemberDefiniti
         for field_match in _FIELD_RE.finditer(body):
             field_name = field_match.group(2)
             absolute_offset = body_start + field_match.start(2)
-            line = source.count("\n", 0, absolute_offset)
-            line_start = source.rfind("\n", 0, absolute_offset)
-            if line_start == -1:
-                column = absolute_offset
-            else:
-                column = absolute_offset - line_start - 1
+            line, column = _offset_to_line_column(source, absolute_offset)
             index[struct_name][field_name] = MemberDefinition(
                 struct_name=struct_name,
                 field_name=field_name,
@@ -140,12 +243,70 @@ def build_struct_member_index(source: str) -> dict[str, dict[str, MemberDefiniti
 def infer_variable_types(source: str) -> dict[str, str]:
     """Best-effort type inference for names declared as `<Type> <name>`."""
 
+    entities, _ = compile_for_lsp(source)
+    if entities:
+        return _infer_variable_types_from_entities(entities)
+
+    return _infer_variable_types_from_regex(source)
+
+
+def _expr_inferred_type(expr: Any, known_types: dict[str, str]) -> str | None:
+    path = getattr(expr, "path", None)
+    if path:
+        return known_types.get(path[0])
+
+    literal_kind = getattr(expr, "kind", None)
+    if literal_kind == "number":
+        value = getattr(expr, "value", "")
+        return "float" if "." in value else "int"
+    if literal_kind == "boolean":
+        return "bool"
+
+    return None
+
+
+def _infer_variable_types_from_entities(entities: dict[str, Any]) -> dict[str, str]:
+    inferred: dict[str, str] = {}
+
+    for kernel in [*entities.get("shaders", []), *entities.get("filters", [])]:
+        for param in kernel.get("params", []):
+            name = param.get("name")
+            declared_type = param.get("type")
+            if name and declared_type:
+                inferred.setdefault(name, declared_type)
+
+        for stmt in kernel.get("body_ast", []):
+            name = getattr(stmt, "name", None)
+            if not name:
+                continue
+            declared_type = getattr(stmt, "declared_type", None)
+            if declared_type is not None:
+                inferred.setdefault(name, str(declared_type))
+                continue
+            initializer = getattr(stmt, "initializer", None)
+            initializer_type = _expr_inferred_type(initializer, inferred) if initializer else None
+            if initializer_type:
+                inferred.setdefault(name, initializer_type)
+
+    for pure in entities.get("pure_functions", []):
+        for param in pure.get("params", []):
+            name = param.get("name")
+            declared_type = param.get("type")
+            if name and declared_type:
+                inferred.setdefault(name, declared_type)
+
+    return inferred
+
+
+def _infer_variable_types_from_regex(source: str) -> dict[str, str]:
+    """Fallback inference used when compilation cannot provide entities."""
+
     inferred: dict[str, str] = {}
     for declared_type, name in _PARAM_RE.findall(source):
         inferred.setdefault(name, declared_type)
 
     for declared_type, name in _TYPED_NAME_RE.findall(source):
-        if declared_type in {"return", "if", "for", "while", "bind", "stream", "uniform"}:
+        if declared_type in {"return", "if", "for", "while", "bind", "stream", "uniform", "shader", "filter", "pure", "struct", "pipeline"}:
             continue
         inferred.setdefault(name, declared_type)
     return inferred
@@ -326,18 +487,34 @@ def provide_hover_info(
         if name in variable_types:
             return f"(variable) `{name}: {variable_types[name]}`"
 
-        # Check if it's a struct name
-        for struct_match in _STRUCT_RE.finditer(source):
-            if struct_match.group(1) == name:
+        entities, _ = compile_for_lsp(source)
+        if entities:
+            if any(struct.get("name") == name for struct in entities.get("structs", [])):
                 return f"(struct) `struct {name}`"
-
-        # Check shaders/filters/pure functions
-        for shader_match in _SHADER_DEF_RE.finditer(source):
-            if shader_match.group(1) == name:
+            if any(shader.get("name") == name for shader in entities.get("shaders", [])):
                 return f"(shader) `shader {name}(...)`"
-        for pure_match in _PURE_DEF_RE.finditer(source):
-            if pure_match.group(1) == name:
+            if any(filter_decl.get("name") == name for filter_decl in entities.get("filters", [])):
+                return f"(filter) `filter {name}(...)`"
+            if any(
+                pure.get("name") == name and not pure.get("intrinsic")
+                for pure in entities.get("pure_functions", [])
+            ):
                 return f"(pure) `pure {name}(...)`"
+        else:
+            # Regex fallback only when compile failed hard.
+            for struct_match in _STRUCT_RE.finditer(source):
+                if struct_match.group(1) == name:
+                    return f"(struct) `struct {name}`"
+
+            for shader_match in _SHADER_DEF_RE.finditer(source):
+                if shader_match.group(1) == name:
+                    return f"(shader) `shader {name}(...)`"
+            for filter_match in _FILTER_DEF_RE.finditer(source):
+                if filter_match.group(1) == name:
+                    return f"(filter) `filter {name}(...)`"
+            for pure_match in _PURE_DEF_RE.finditer(source):
+                if pure_match.group(1) == name:
+                    return f"(pure) `pure {name}(...)`"
         return None
 
     return None

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -2,6 +2,7 @@ from lockstep_compiler.lsp import (
     build_struct_member_index,
     find_member_definition,
     provide_bind_completion_items,
+    provide_hover_info,
 )
 
 
@@ -80,3 +81,69 @@ pipeline P {
         "Bind route template",
         "Shader/filter callable",
     ]
+
+
+TRICKY_FORMAT_SOURCE = """
+struct Particle {
+    float mass; // mass comment
+    /* block comment before velocity */
+    Vec3 velocity;
+};
+
+shader
+Apply(
+    in Particle src,
+    out Particle dst,
+    uniform float dt
+) {
+    Particle local = src;
+    dst.velocity = local.velocity;
+    float speed = dt;
+}
+
+// comment before filter
+filter
+Post(
+    in Particle src,
+    out Particle dst
+) {
+    dst = src;
+}
+
+pure float
+blend(float a, float b)
+{
+    return a;
+}
+"""
+
+
+def test_build_struct_member_index_ignores_comments_and_tracks_locations():
+    index = build_struct_member_index(TRICKY_FORMAT_SOURCE)
+
+    assert index["Particle"]["mass"].line == 2
+    assert index["Particle"]["velocity"].line == 4
+
+
+def test_infer_and_definition_resolve_member_declared_from_body_ast():
+    line = 14
+    column = 8  # dst.velocity
+
+    definition = find_member_definition(TRICKY_FORMAT_SOURCE, line, column)
+
+    assert definition is not None
+    assert definition.struct_name == "Particle"
+    assert definition.field_name == "velocity"
+    assert definition.line == 4
+
+
+def test_hover_resolves_variable_and_callable_symbols_with_tricky_formatting():
+    variable_hover = provide_hover_info(TRICKY_FORMAT_SOURCE, 14, 20)  # local.velocity
+    shader_hover = provide_hover_info(TRICKY_FORMAT_SOURCE, 8, 0)  # Apply
+    filter_hover = provide_hover_info(TRICKY_FORMAT_SOURCE, 20, 0)  # Post
+    pure_hover = provide_hover_info(TRICKY_FORMAT_SOURCE, 28, 0)  # blend
+
+    assert variable_hover == "(field) `Particle.velocity: Vec3`"
+    assert shader_hover == "(shader) `shader Apply(...)`"
+    assert filter_hover == "(filter) `filter Post(...)`"
+    assert pure_hover == "(pure) `pure blend(...)`"


### PR DESCRIPTION
### Motivation
- Reduce brittle regex-only heuristics by using the compiler `compile_for_lsp()` output to build accurate symbol tables for the LSP. 
- Ensure hover/definition resolution remains correct under tricky formatting and comments by deriving symbol/field locations from semantic entities when available. 

### Description
- Use `compile_for_lsp()` entities first to construct struct member indices and variable type inference via new helpers `
_build_struct_member_index_from_entities` and `
_infer_variable_types_from_entities`, with regex-based code paths retained only as a fallback when compilation fails. 
- Add comment-masking (`_mask_comments`), brace-matching (`_find_matching_brace`) and offset mapping (`_offset_to_line_column`) helpers to preserve source offsets and compute field `line`/`column` positions robustly. 
- Extend hover lookup to prefer entity-driven checks for `struct`, `shader`, `filter`, and `pure` symbols and add `_FILTER_DEF_RE` for regex fallback detection. 
- Add tests to `tests/test_lsp.py` covering comment-heavy and multiline declarations to verify struct field indexing, member-definition resolution, and hover resolution for variables and callable symbols under tricky formatting. 

### Testing
- Ran the focused test suite with `PYTHONPATH=. pytest -q -o addopts='' tests/test_lsp.py` and all tests passed (`8 passed`). 
- New/updated tests live in `tests/test_lsp.py` and exercise: comment masking for struct fields, entity-driven variable type inference, member-definition resolution and hover output for shader/filter/pure symbols.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b33a84950883288e4df87b86c27243)