### PR TITLE
Track diagnostics back to original library and primary source files

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -111,11 +111,13 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
         source = stdin.read()
 
     library_sources = []
+    library_source_files = []
     for library_path in args.lib:
         library_source = _read_source_file(Path(library_path), stderr=stderr)
         if library_source is None:
             return 1
         library_sources.append(library_source)
+        library_source_files.append(str(Path(library_path)))
 
     if args.format:
         print(format_lockstep_source(source), end="", file=stdout)
@@ -135,6 +137,8 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
 
     supports_verbose = False
     supports_library_sources = False
+    supports_source_file = False
+    supports_library_source_files = False
     try:
         signature = inspect.signature(compiler)
     except (TypeError, ValueError):
@@ -151,12 +155,26 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
             or parameter.name == "library_sources"
             for parameter in signature.parameters.values()
         )
+        supports_source_file = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            or parameter.name == "source_file"
+            for parameter in signature.parameters.values()
+        )
+        supports_library_source_files = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            or parameter.name == "library_source_files"
+            for parameter in signature.parameters.values()
+        )
 
     compile_kwargs = {}
     if supports_verbose:
         compile_kwargs["verbose"] = False
     if supports_library_sources:
         compile_kwargs["library_sources"] = library_sources
+    if supports_source_file:
+        compile_kwargs["source_file"] = str(source_path) if args.path else "<stdin>"
+    if supports_library_source_files:
+        compile_kwargs["library_source_files"] = library_source_files
 
     try:
         if compile_kwargs:
@@ -171,7 +189,10 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
             file=stderr,
         )
         for error in err.errors:
-            print(f"line {error.line}:{error.column} {error.message}", file=stderr)
+            if error.source_file:
+                print(f"{error.source_file}:{error.line}:{error.column} {error.message}", file=stderr)
+            else:
+                print(f"line {error.line}:{error.column} {error.message}", file=stderr)
         if args.debug:
             if err.diagnostics:
                 print("diagnostics:", file=stderr)
@@ -185,6 +206,7 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
                                 "line": diagnostic.line,
                                 "column": diagnostic.column,
                                 "hint": diagnostic.hint,
+                                "source_file": diagnostic.source_file,
                             }
                             for diagnostic in err.diagnostics
                         ],

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -1,4 +1,5 @@
 import functools
+from dataclasses import replace
 from typing import Any
 
 from antlr4 import CommonTokenStream, InputStream
@@ -7,10 +8,13 @@ from .ast import ast_to_entities, build_program_ast
 from .c_header import emit_c_header
 from .codegen import emit_llvm_ir
 from .errors import LockstepCompileError, ParseErrorCollector
-from .models import LockstepCompileResult, normalize_diagnostics
+from .models import LockstepCompileResult, LockstepDiagnostic, normalize_diagnostics
 from .optimizer import optimize_bind_routes
 from .prelude import load_intrinsics
 from .visitors import build_debug_visitor, validate_semantics as _validate_semantics
+
+
+DEFAULT_SOURCE_FILE = "<stdin>"
 
 
 def _merge_intrinsic_pure_functions(pure_functions: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -21,10 +25,76 @@ def _merge_intrinsic_pure_functions(pure_functions: list[dict[str, Any]]) -> lis
     return list(merged.values())
 
 
+def _line_count(source: str) -> int:
+    return source.count("\n") + 1
+
+
+def _build_combined_source(
+    source_code: str,
+    *,
+    source_file: str,
+    library_sources: list[str] | None,
+    library_source_files: list[str] | None,
+) -> tuple[str, list[tuple[int, int, str]]]:
+    libraries = library_sources or []
+    all_sources = [*libraries, source_code]
+    resolved_library_files = library_source_files or [
+        f"<library:{idx + 1}>" for idx in range(len(libraries))
+    ]
+    if len(resolved_library_files) < len(libraries):
+        resolved_library_files = [
+            *resolved_library_files,
+            *[
+                f"<library:{idx + 1}>"
+                for idx in range(len(resolved_library_files), len(libraries))
+            ],
+        ]
+    all_source_files = [*resolved_library_files[: len(libraries)], source_file]
+    mapping: list[tuple[int, int, str]] = []
+    current_line = 1
+    for index, part in enumerate(all_sources):
+        part_line_count = _line_count(part)
+        start_line = current_line
+        end_line = start_line + part_line_count - 1
+        mapping.append((start_line, end_line, all_source_files[index]))
+        current_line = end_line + 1
+        if index < len(all_sources) - 1:
+            current_line += 1
+    return "\n\n".join(all_sources), mapping
+
+
+def _remap_diagnostic(
+    diagnostic: LockstepDiagnostic,
+    source_map: list[tuple[int, int, str]],
+    default_source_file: str,
+) -> LockstepDiagnostic:
+    if diagnostic.source_file:
+        return diagnostic
+    for start_line, end_line, mapped_source in source_map:
+        if start_line <= diagnostic.line <= end_line:
+            return replace(
+                diagnostic,
+                source_file=mapped_source,
+                line=(diagnostic.line - start_line) + 1,
+            )
+    return replace(diagnostic, source_file=default_source_file)
+
+
+def _remap_diagnostics(
+    diagnostics: list[LockstepDiagnostic],
+    *,
+    source_map: list[tuple[int, int, str]],
+    default_source_file: str,
+) -> list[LockstepDiagnostic]:
+    return [_remap_diagnostic(diagnostic, source_map, default_source_file) for diagnostic in diagnostics]
+
+
 def _compile_lockstep_with_dependencies(
     source_code: str,
     *,
     verbose: bool = True,
+    source_file: str = DEFAULT_SOURCE_FILE,
+    source_map: list[tuple[int, int, str]] | None = None,
     lexer_cls,
     parser_cls,
     visitor_cls,
@@ -32,9 +102,11 @@ def _compile_lockstep_with_dependencies(
     token_stream_cls=CommonTokenStream,
     debug_visitor_cls=None,
 ) -> LockstepCompileResult:
+    source_map = source_map or [(1, _line_count(source_code), source_file)]
+
     input_stream = InputStream(source_code)
     lexer = lexer_cls(input_stream)
-    error_listener = ParseErrorCollector()
+    error_listener = ParseErrorCollector(source_file=None)
     lexer.removeErrorListeners()
     lexer.addErrorListener(error_listener)
     stream = token_stream_cls(lexer)
@@ -45,7 +117,16 @@ def _compile_lockstep_with_dependencies(
     tree = parser.program()
 
     if error_listener.errors:
-        raise LockstepCompileError(error_listener.errors, diagnostics=error_listener.errors)
+        parse_errors = _remap_diagnostics(
+            error_listener.errors,
+            source_map=source_map,
+            default_source_file=source_file,
+        )
+        raise LockstepCompileError(
+            parse_errors,
+            diagnostics=parse_errors,
+            source_file=parse_errors[0].source_file if parse_errors else source_file,
+        )
 
     typed_ast = None
     if debug_visitor_cls is None:
@@ -64,12 +145,18 @@ def _compile_lockstep_with_dependencies(
         )
     except TypeError:
         semantic_diagnostics = normalize_diagnostics(semantic_validator(tree))
+    semantic_diagnostics = _remap_diagnostics(
+        semantic_diagnostics,
+        source_map=source_map,
+        default_source_file=source_file,
+    )
     semantic_errors = [d for d in semantic_diagnostics if d.severity == "error"]
     if semantic_errors:
         raise LockstepCompileError(
             semantic_errors,
             diagnostics=semantic_diagnostics,
             phase="semantic",
+            source_file=semantic_errors[0].source_file,
         )
 
     debug_diagnostics = []
@@ -80,7 +167,11 @@ def _compile_lockstep_with_dependencies(
         debug_visitor_cls = debug_visitor_cls or build_debug_visitor(visitor_cls)
         visitor = debug_visitor_cls(verbose=verbose)
         visitor.visit(tree)
-        debug_diagnostics = visitor.diagnostics
+        debug_diagnostics = _remap_diagnostics(
+            visitor.diagnostics,
+            source_map=source_map,
+            default_source_file=source_file,
+        )
         entities = {
             "structs": visitor.structs,
             "shaders": visitor.shaders,
@@ -142,7 +233,9 @@ def compile_lockstep(
     source_code: str,
     *,
     verbose: bool = True,
+    source_file: str = DEFAULT_SOURCE_FILE,
     library_sources: list[str] | None = None,
+    library_source_files: list[str] | None = None,
     lexer_cls=None,
     parser_cls=None,
     visitor_cls=None,
@@ -150,8 +243,12 @@ def compile_lockstep(
     token_stream_cls=CommonTokenStream,
     debug_visitor_cls=None,
 ) -> LockstepCompileResult:
-    if library_sources:
-        source_code = "\n\n".join([*library_sources, source_code])
+    source_code, source_map = _build_combined_source(
+        source_code,
+        source_file=source_file,
+        library_sources=library_sources,
+        library_source_files=library_source_files,
+    )
 
     if lexer_cls is None or parser_cls is None or visitor_cls is None:
         default_lexer_cls, default_parser_cls, default_visitor_cls = (
@@ -164,6 +261,8 @@ def compile_lockstep(
     return _compile_lockstep_with_dependencies(
         source_code,
         verbose=verbose,
+        source_file=source_file,
+        source_map=source_map,
         lexer_cls=lexer_cls,
         parser_cls=parser_cls,
         visitor_cls=visitor_cls,

--- a/lockstep_compiler/errors.py
+++ b/lockstep_compiler/errors.py
@@ -6,8 +6,9 @@ from .models import LockstepDiagnostic
 class ParseErrorCollector(ErrorListener):
     """Collects syntax errors emitted by ANTLR during lex/parse."""
 
-    def __init__(self):
+    def __init__(self, source_file: str | None = None):
         super().__init__()
+        self.source_file = source_file
         self.errors: list[LockstepDiagnostic] = []
 
     def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e):
@@ -18,6 +19,7 @@ class ParseErrorCollector(ErrorListener):
                 message=msg,
                 line=line,
                 column=column,
+                source_file=self.source_file,
                 hint="Fix syntax errors before semantic analysis can continue.",
             )
         )
@@ -36,9 +38,15 @@ class LockstepCompileError(Exception):
     def _format_message(self):
         count = len(self.errors)
         suffix = "" if count == 1 else "s"
-        file_context = f" in '{self.source_file}'" if self.source_file else ""
+        inferred_source_file = self.source_file or (self.errors[0].source_file if self.errors else None)
+        file_context = f" in '{inferred_source_file}'" if inferred_source_file else ""
         summary = f"Compilation failed with {count} {self.phase} error{suffix}{file_context}."
-        details = "\n".join(
-            f"line {error.line}:{error.column} {error.message}" for error in self.errors
-        )
-        return summary if not details else f"{summary}\n{details}"
+
+        details = []
+        for error in self.errors:
+            if error.source_file:
+                details.append(f"{error.source_file}:{error.line}:{error.column} {error.message}")
+            else:
+                details.append(f"line {error.line}:{error.column} {error.message}")
+        detail_text = "\n".join(details)
+        return summary if not detail_text else f"{summary}\n{detail_text}"

--- a/lockstep_compiler/lsp.py
+++ b/lockstep_compiler/lsp.py
@@ -85,6 +85,7 @@ def compile_for_lsp(source: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
                 "line": diagnostic.line,
                 "column": diagnostic.column,
                 "hint": diagnostic.hint,
+                "source_file": diagnostic.source_file,
             }
             for diagnostic in result.diagnostics
         ]
@@ -98,6 +99,7 @@ def compile_for_lsp(source: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
                 "line": diagnostic.line,
                 "column": diagnostic.column,
                 "hint": diagnostic.hint,
+                "source_file": diagnostic.source_file,
             }
             for diagnostic in error.diagnostics
         ]

--- a/lockstep_compiler/models.py
+++ b/lockstep_compiler/models.py
@@ -10,6 +10,7 @@ class LockstepDiagnostic:
     line: int
     column: int
     hint: str | None = None
+    source_file: str | None = None
 
 
 @dataclass
@@ -70,11 +71,12 @@ def normalize_diagnostics(
 ) -> list[LockstepDiagnostic]:
     """Deduplicate and deterministically sort diagnostics."""
 
-    deduped: dict[tuple[str, str, int, int], LockstepDiagnostic] = {}
+    deduped: dict[tuple[str, str, str | None, int, int], LockstepDiagnostic] = {}
     for diagnostic in diagnostics:
         key = (
             diagnostic.code,
             diagnostic.message,
+            diagnostic.source_file,
             diagnostic.line,
             diagnostic.column,
         )
@@ -84,6 +86,7 @@ def normalize_diagnostics(
     return sorted(
         deduped.values(),
         key=lambda diagnostic: (
+            diagnostic.source_file or "",
             diagnostic.line,
             diagnostic.column,
             _SEVERITY_PRIORITY.get(diagnostic.severity, 99),

--- a/tests/test_cli_libraries.py
+++ b/tests/test_cli_libraries.py
@@ -48,3 +48,35 @@ def test_run_cli_reports_missing_library_file(tmp_path):
 
     assert exit_code == 1
     assert f"Unable to read '{missing}': file not found." in stderr.getvalue()
+
+
+def test_run_cli_reports_library_file_in_diagnostics(tmp_path):
+    library = tmp_path / "bad.lock"
+    library.write_text("@", encoding="utf-8")
+    stderr = io.StringIO()
+
+    exit_code = run_cli(
+        ["--lib", str(library)],
+        stdin=io.StringIO("pipeline Main { bind { } }"),
+        stdout=io.StringIO(),
+        stderr=stderr,
+    )
+
+    assert exit_code == 1
+    assert f"{library}:1:" in stderr.getvalue()
+
+
+def test_run_cli_reports_stdin_file_in_diagnostics(tmp_path):
+    library = tmp_path / "math.lock"
+    library.write_text("struct Vec { float x; };", encoding="utf-8")
+    stderr = io.StringIO()
+
+    exit_code = run_cli(
+        ["--lib", str(library)],
+        stdin=io.StringIO("pipeline Main {"),
+        stdout=io.StringIO(),
+        stderr=stderr,
+    )
+
+    assert exit_code == 1
+    assert "<stdin>:1:" in stderr.getvalue()

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -234,6 +234,35 @@ def test_compile_lockstep_accepts_library_sources(monkeypatch):
     assert captured["source_code"].endswith("pipeline Main { bind { } }")
 
 
+def test_compile_lockstep_maps_parse_diagnostics_to_library_source_file():
+    library_source = "@"
+
+    with pytest.raises(lockstep_compiler.LockstepCompileError) as exc_info:
+        lockstep_compiler.compile_lockstep(
+            "pipeline Main { bind { } }",
+            source_file="main.lock",
+            library_sources=[library_source],
+            library_source_files=["lib/math.lock"],
+            verbose=False,
+        )
+
+    assert exc_info.value.errors[0].source_file == "lib/math.lock"
+    assert exc_info.value.errors[0].line == 1
+
+
+def test_compile_lockstep_maps_semantic_diagnostics_to_primary_source_file():
+    with pytest.raises(lockstep_compiler.LockstepCompileError) as exc_info:
+        lockstep_compiler.compile_lockstep(
+            "pipeline Main {\n    stream<MissingType, 1> values;\n    bind { }\n}",
+            source_file="main.lock",
+            library_sources=["struct Vec { float x; };"],
+            library_source_files=["lib/math.lock"],
+            verbose=False,
+        )
+
+    assert exc_info.value.errors[0].source_file == "main.lock"
+    assert exc_info.value.errors[0].line == 2
+
 def test_emit_llvm_ir_accepts_ast_program_input():
     from lockstep_compiler.ast import (
         AstKernelBindRoute,


### PR DESCRIPTION
### Motivation
- Avoid losing original source locations when library sources are concatenated with the primary source so diagnostics can be attributed to the correct file and line. 
- Ensure error objects consistently carry `(source_file, line, column)` metadata for parse, semantic and debug diagnostics. 
- Surface file-aware diagnostics in the CLI and LSP output so users and editors see the originating file in messages.

### Description
- Add source composition and remapping helpers in `compile_lockstep` (`_build_combined_source`, `_remap_diagnostic`, `_remap_diagnostics`) and use them to remap parse/semantic/debug diagnostics back to their originating file and line. 
- Extend `LockstepDiagnostic` with a `source_file` field and update `normalize_diagnostics` sorting/dedup keys to include `source_file`, and populate `ParseErrorCollector` and `LockstepCompileError` formatting with file-aware output. 
- Update CLI to collect `library_source_files`, pass `source_file`/`library_source_files` to compilers that support them, and print file-qualified diagnostics and debug JSON including `source_file`. 
- Include `source_file` in LSP diagnostic payloads and add tests that assert diagnostics point to the correct library vs primary source files (`tests/test_compiler_api.py`, `tests/test_cli_libraries.py`).

### Testing
- Ran the project tests with `pytest -q -o addopts='' tests/test_compiler_api.py tests/test_cli_libraries.py tests/test_debug_compiler.py` and observed all tests passing (`102 passed`).
- An initial `pytest -q` run failed in this environment due to the repository `addopts` including coverage plugins not installed, so the validated run overrides `addopts` to ensure deterministic, passing test output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b33a85e30c8328a3430f629a3983f8)