### PR TITLE
Fix hover struct detection in regex type inference

### DIFF
--- a/lockstep_compiler/lsp.py
+++ b/lockstep_compiler/lsp.py
@@ -315,7 +315,23 @@ def _infer_variable_types_from_regex(source: str) -> dict[str, str]:
         inferred.setdefault(name, declared_type)
 
     for declared_type, name in _TYPED_NAME_RE.findall(source):
-        if declared_type in {"return", "if", "for", "while", "bind", "stream", "uniform", "shader", "filter", "pure", "struct", "pipeline"}:
+        if declared_type in {
+            "return",
+            "if",
+            "for",
+            "while",
+            "bind",
+            "stream",
+            "uniform",
+            "in",
+            "out",
+            "accum",
+            "shader",
+            "filter",
+            "pure",
+            "struct",
+            "pipeline",
+        }:
             continue
         inferred.setdefault(name, declared_type)
     return inferred


### PR DESCRIPTION
### Motivation
- A regex-based fallback for inferring variable types misclassified struct names when prefixed by parameter direction qualifiers (e.g. `in Vec3 pos`), causing hover over a struct name to return the wrong kind.

### Description
- Add `"in"`, `"out"`, and `"accum"` to the skip-list in `_infer_variable_types_from_regex` so direction qualifiers are not treated as declared types.
- Update `lockstep_compiler/lsp.py` to use a multi-line set literal for the ignored keywords to make the intent clearer and maintainable.

### Testing
- Installed test extras with `python -m pip install -e '.[test]'` and ran the test suite with `pytest -q`.
- Result: the test suite passed after the change (`157 passed, 4 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c0a1be388328967bb28d94628dca)