### PR TITLE
Deprecate legacy string-based function bodies and lower AST nodes directly in _FunctionLowerer

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import re
-from dataclasses import dataclass
 from typing import Any
 
 from llvmlite import ir
@@ -38,135 +36,6 @@ class CodegenError(RuntimeError):
 
 def _type_name(value: AstType | str) -> str:
     return value.name if isinstance(value, AstType) else value
-
-
-def _tokenize_expr(expr: str) -> list[str]:
-    token_pattern = r"\s*(<<|>>|==|!=|<=|>=|&&|\|\||[()\-+*/%,<>!&|^]|[A-Za-z_][A-Za-z0-9_\.]*|\d+\.\d+|\d+|true|false)"
-    return [token for token in re.findall(token_pattern, expr) if token.strip()]
-
-
-@dataclass
-class _ExprParser:
-    tokens: list[str]
-    index: int = 0
-
-    def _peek(self) -> str | None:
-        return self.tokens[self.index] if self.index < len(self.tokens) else None
-
-    def _take(self, token: str | None = None) -> str:
-        current = self._peek()
-        if current is None:
-            raise ValueError("unexpected end of expression")
-        if token is not None and current != token:
-            raise ValueError(f"expected '{token}' but got '{current}'")
-        self.index += 1
-        return current
-
-    def parse(self):
-        return self._parse_or()
-
-    def _parse_or(self):
-        node = self._parse_and()
-        while self._peek() == "||":
-            op = self._take()
-            node = ("bin", op, node, self._parse_and())
-        return node
-
-    def _parse_and(self):
-        node = self._parse_bitor()
-        while self._peek() == "&&":
-            op = self._take()
-            node = ("bin", op, node, self._parse_bitor())
-        return node
-
-    def _parse_bitor(self):
-        node = self._parse_bitxor()
-        while self._peek() == "|":
-            op = self._take()
-            node = ("bin", op, node, self._parse_bitxor())
-        return node
-
-    def _parse_bitxor(self):
-        node = self._parse_bitand()
-        while self._peek() == "^":
-            op = self._take()
-            node = ("bin", op, node, self._parse_bitand())
-        return node
-
-    def _parse_bitand(self):
-        node = self._parse_equality()
-        while self._peek() == "&":
-            op = self._take()
-            node = ("bin", op, node, self._parse_equality())
-        return node
-
-    def _parse_equality(self):
-        node = self._parse_rel()
-        while self._peek() in {"==", "!="}:
-            op = self._take()
-            node = ("bin", op, node, self._parse_rel())
-        return node
-
-    def _parse_rel(self):
-        node = self._parse_shift()
-        while self._peek() in {"<", "<=", ">", ">="}:
-            op = self._take()
-            node = ("bin", op, node, self._parse_shift())
-        return node
-
-    def _parse_shift(self):
-        node = self._parse_add()
-        while self._peek() in {"<<", ">>"}:
-            op = self._take()
-            node = ("bin", op, node, self._parse_add())
-        return node
-
-    def _parse_add(self):
-        node = self._parse_mul()
-        while self._peek() in {"+", "-"}:
-            op = self._take()
-            node = ("bin", op, node, self._parse_mul())
-        return node
-
-    def _parse_mul(self):
-        node = self._parse_unary()
-        while self._peek() in {"*", "/", "%"}:
-            op = self._take()
-            node = ("bin", op, node, self._parse_unary())
-        return node
-
-    def _parse_unary(self):
-        if self._peek() in {"-", "!"}:
-            op = self._take()
-            return ("un", op, self._parse_unary())
-        return self._parse_primary()
-
-    def _parse_primary(self):
-        token = self._peek()
-        if token == "(":
-            self._take("(")
-            node = self._parse_or()
-            self._take(")")
-            return node
-        token = self._take()
-        if re.match(r"\d+\.\d+", token):
-            return ("float", float(token))
-        if re.match(r"\d+", token):
-            return ("int", int(token))
-        if token in {"true", "false"}:
-            return ("bool", token == "true")
-        if self._peek() == "(":
-            self._take("(")
-            args = []
-            if self._peek() != ")":
-                while True:
-                    args.append(self._parse_or())
-                    if self._peek() != ",":
-                        break
-                    self._take(",")
-            self._take(")")
-            return ("call", token, args)
-        return ("var", token)
 
 
 class _FunctionLowerer:
@@ -395,10 +264,6 @@ class _FunctionLowerer:
             return self._extract_field_path(base_value, parts[1:])
         self._compiler_error(f"undefined variable '{parts[0]}'")
 
-    def _parse_expr(self, expr: str):
-        parser = _ExprParser(_tokenize_expr(expr))
-        return parser.parse()
-
     def _lower_call(self, name: str, args: list[ir.Value]) -> ir.Value:
         if name in self.intrinsic_names:
             lowered_intrinsic = self._lower_intrinsic_call(name, args)
@@ -413,23 +278,6 @@ class _FunctionLowerer:
             coerced = [self._coerce_value_to_type(arg, param.type) for arg, param in zip(args, callee.args)]
             return self.builder.call(callee, coerced, name=f"call_{name}")
         self._compiler_error(f"unknown function '{name}'")
-
-    @staticmethod
-    def _normalize_expr_node(node) -> "AstExprLiteral | AstExprVar | AstExprUnary | AstExprBinary | AstExprCall":
-        """Convert legacy tuple-based expression nodes to typed AST nodes."""
-        if isinstance(node, (AstExprLiteral, AstExprVar, AstExprUnary, AstExprBinary, AstExprCall)):
-            return node
-        kind = node[0]
-        if kind in {"float", "int", "bool"}:
-            return AstExprLiteral(kind=kind, value=str(node[1]))
-        if kind == "var":
-            return AstExprVar(path=tuple(node[1].split(".")))
-        if kind == "un":
-            return AstExprUnary(op=node[1], operand=node[2])
-        if kind == "call":
-            return AstExprCall(name=node[1], args=tuple(node[2]))
-        # "bin" — binary operation
-        return AstExprBinary(op=node[1], left=node[2], right=node[3])
 
     def _lower_binary_op(self, op: str, lhs: ir.Value, rhs: ir.Value) -> ir.Value:
         if op in {"+", "-", "*", "/", "%"}:
@@ -456,8 +304,7 @@ class _FunctionLowerer:
             return self.builder.or_(lhs, rhs)
         self._compiler_error(f"unsupported binary operator '{op}'")
 
-    def _lower_expr(self, node):
-        node = self._normalize_expr_node(node)
+    def _lower_expr(self, node: AstExprLiteral | AstExprVar | AstExprUnary | AstExprBinary | AstExprCall):
 
         if isinstance(node, AstExprLiteral):
             if node.kind == "float":
@@ -474,7 +321,8 @@ class _FunctionLowerer:
             return self.builder.not_(operand)
         if isinstance(node, AstExprCall):
             return self._lower_call(node.name, [self._lower_expr(arg) for arg in node.args])
-        # AstExprBinary
+        if not isinstance(node, AstExprBinary):
+            self._compiler_error(f"unsupported expression node '{type(node).__name__}'")
         lhs, rhs = self._lower_expr(node.left), self._lower_expr(node.right)
         return self._lower_binary_op(node.op, lhs, rhs)
 
@@ -493,7 +341,7 @@ class _FunctionLowerer:
         updated = self._insert_field_path(current, field_path, value)
         self.builder.store(updated, self.locals[key])
 
-    def _lower_statement(self, statement: str | AstStatement, return_type: ir.Type):
+    def _lower_statement(self, statement: AstStatement, return_type: ir.Type):
         if isinstance(statement, AstReturnStmt):
             value = self._lower_expr(statement.value)
             if isinstance(return_type, ir.VoidType):
@@ -520,37 +368,9 @@ class _FunctionLowerer:
                 self.builder.store(self._coerce_value_to_type(value, slot_type), self.locals[key])
             return
 
-        statement = statement.strip()
-        if statement.startswith("return"):
-            expr = statement[len("return") :].strip().rstrip(";")
-            value = self._lower_expr(self._parse_expr(expr))
-            if isinstance(return_type, ir.VoidType):
-                self.builder.ret_void()
-            else:
-                self.builder.ret(self._coerce_value_to_type(value, return_type))
-            return
+        self._compiler_error(f"unsupported statement node '{type(statement).__name__}'")
 
-        if "=" in statement:
-            lhs, rhs = statement.rstrip(";").split("=", 1)
-            lhs = lhs.strip()
-            rhs = rhs.strip()
-            lhs_parts = lhs.split()
-            name = lhs_parts[-1]
-            self._lower_assignment(name, self._lower_expr(self._parse_expr(rhs)))
-            return
-
-        if statement.endswith(";"):
-            maybe_decl = statement[:-1].split()
-            if maybe_decl:
-                declared_type = maybe_decl[0] if len(maybe_decl) > 1 else "float"
-                key = _sanitize_symbol(maybe_decl[-1].replace(".", "_"))
-                if key not in self.locals:
-                    llvm_type = self._llvm_type(declared_type, self.known_structs)
-                    slot = self.builder.alloca(llvm_type, name=key)
-                    self.locals[key] = slot
-                    self.builder.store(ir.Constant(llvm_type, None), slot)
-
-    def lower_function(self, fn: ir.Function, statements: list[str | AstStatement], return_type: ir.Type):
+    def lower_function(self, fn: ir.Function, statements: list[AstStatement], return_type: ir.Type):
         block = fn.append_basic_block("entry")
         self.builder = ir.IRBuilder(block)
         self.locals = {}
@@ -577,6 +397,16 @@ def _normalize_codegen_input(program_or_entities: AstProgram | dict[str, Any]) -
     if isinstance(program_or_entities, AstProgram):
         return ast_to_entities(program_or_entities)
     return program_or_entities
+
+
+def _ast_body_for(entity: dict[str, Any], *, entity_kind: str) -> list[AstStatement]:
+    body_ast = entity.get("body_ast")
+    if body_ast is None:
+        name = entity.get("name", "<unknown>")
+        raise CodegenError(
+            f"{entity_kind} '{name}' is missing body_ast; string-based bodies are no longer supported"
+        )
+    return body_ast
 
 
 def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
@@ -675,15 +505,15 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
         fn = function_map[f"pure_{_sanitize_symbol(pure['name'])}"]
         if pure.get("intrinsic"):
             continue
-        lowerer.lower_function(fn, pure.get("body_ast", pure.get("body", [])), fn.function_type.return_type)
+        lowerer.lower_function(fn, _ast_body_for(pure, entity_kind="pure function"), fn.function_type.return_type)
 
     for shader in shaders:
         fn = function_map[f"shader_{_sanitize_symbol(shader['name'])}"]
-        lowerer.lower_function(fn, shader.get("body_ast", shader.get("body", [])), ir.VoidType())
+        lowerer.lower_function(fn, _ast_body_for(shader, entity_kind="shader"), ir.VoidType())
 
     for flt in filters:
         fn = function_map[f"filter_{_sanitize_symbol(flt['name'])}"]
-        lowerer.lower_function(fn, flt.get("body_ast", flt.get("body", [])), ir.VoidType())
+        lowerer.lower_function(fn, _ast_body_for(flt, entity_kind="filter"), ir.VoidType())
 
     arena_fields: list[tuple[str, str, ir.Type]] = []
     stream_slots: dict[str, int] = {}

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -10,6 +10,15 @@ import lockstep_compiler
 import lockstep_compiler.compiler as compiler_module
 from lockstep_compiler.c_header import emit_c_header
 from lockstep_compiler.codegen import CodegenError, emit_llvm_ir
+from lockstep_compiler.ast import (
+    AstAssignStmt,
+    AstExprBinary,
+    AstExprCall,
+    AstExprLiteral,
+    AstExprVar,
+    AstReturnStmt,
+    AstVarDeclStmt,
+)
 import pytest
 
 
@@ -105,14 +114,49 @@ def test_emit_llvm_ir_generates_expected_declarations():
                     ],
                 }
             ],
-            "shaders": [{"name": "ApplyGravity"}],
-            "filters": [{"name": "Cull"}],
+            "shaders": [{"name": "ApplyGravity", "body_ast": []}],
+            "filters": [{"name": "Cull", "body_ast": []}],
             "pure_functions": [
                 {"name": "step", "return_type": "float", "params": [{"name": "edge", "type": "float"}, {"name": "x", "type": "float"}], "intrinsic": True},
                 {"name": "mix", "return_type": "float", "params": [{"name": "a", "type": "float"}, {"name": "b", "type": "float"}, {"name": "t", "type": "float"}], "intrinsic": True},
                 {"name": "clamp", "return_type": "float", "params": [{"name": "x", "type": "float"}, {"name": "min_value", "type": "float"}, {"name": "max_value", "type": "float"}], "intrinsic": True},
                 {"name": "max", "return_type": "float", "params": [{"name": "x", "type": "float"}, {"name": "y", "type": "float"}], "intrinsic": True},
-                {"name": "demo", "return_type": "float", "params": [], "body": ["return clamp(max(mix(0.0, 1.0, step(0.5, 1.0)), 0.25), 0.0, 1.0);"]},
+                {
+                    "name": "demo",
+                    "return_type": "float",
+                    "params": [],
+                    "body_ast": [
+                        AstReturnStmt(
+                            value=AstExprCall(
+                                name="clamp",
+                                args=(
+                                    AstExprCall(
+                                        name="max",
+                                        args=(
+                                            AstExprCall(
+                                                name="mix",
+                                                args=(
+                                                    AstExprLiteral(kind="float", value="0.0"),
+                                                    AstExprLiteral(kind="float", value="1.0"),
+                                                    AstExprCall(
+                                                        name="step",
+                                                        args=(
+                                                            AstExprLiteral(kind="float", value="0.5"),
+                                                            AstExprLiteral(kind="float", value="1.0"),
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                            AstExprLiteral(kind="float", value="0.25"),
+                                        ),
+                                    ),
+                                    AstExprLiteral(kind="float", value="0.0"),
+                                    AstExprLiteral(kind="float", value="1.0"),
+                                ),
+                            )
+                        )
+                    ],
+                },
             ],
             "streams": [{"name": "raw_positions", "type": "Vec3"}],
             "accumulators": [{"name": "energy", "type": "float"}],
@@ -152,7 +196,14 @@ def test_emit_llvm_ir_lowers_struct_member_extract_and_insert():
                     "name": "set_and_get_x",
                     "return_type": "float",
                     "params": [],
-                    "body": ["Vec3 v;", "v.x = 1.0;", "return v.x;"],
+                    "body_ast": [
+                        AstVarDeclStmt(declared_type="Vec3", name="v", initializer=None),
+                        AstAssignStmt(
+                            target=("v", "x"),
+                            value=AstExprLiteral(kind="float", value="1.0"),
+                        ),
+                        AstReturnStmt(value=AstExprVar(path=("v", "x"))),
+                    ],
                 }
             ],
             "shaders": [],
@@ -320,7 +371,7 @@ def test_emit_llvm_ir_lowers_kernel_bind_routes_into_counted_loops():
                         {"modifier": "out", "type": "float", "name": "out"},
                         {"modifier": "uniform", "type": "float", "name": "dt"},
                     ],
-                    "body": [],
+                    "body_ast": [],
                 }
             ],
             "filters": [],
@@ -358,7 +409,15 @@ def test_emit_llvm_ir_keeps_integer_arithmetic_in_integer_domain():
                     "name": "sum_ints",
                     "return_type": "int",
                     "params": [{"type": "int", "name": "v"}],
-                    "body": ["return v + 1;"],
+                    "body_ast": [
+                        AstReturnStmt(
+                            value=AstExprBinary(
+                                op="+",
+                                left=AstExprVar(path=("v",)),
+                                right=AstExprLiteral(kind="int", value="1"),
+                            )
+                        )
+                    ],
                 }
             ],
             "shaders": [],
@@ -412,7 +471,15 @@ def test_emit_llvm_ir_raises_on_mixed_int_float_expression():
                         "name": "bad_mix",
                         "return_type": "float",
                         "params": [],
-                        "body": ["return 1 + 1.0;"],
+                        "body_ast": [
+                            AstReturnStmt(
+                                value=AstExprBinary(
+                                    op="+",
+                                    left=AstExprLiteral(kind="int", value="1"),
+                                    right=AstExprLiteral(kind="float", value="1.0"),
+                                )
+                            )
+                        ],
                     }
                 ],
                 "shaders": [],
@@ -572,7 +639,12 @@ def test_emit_llvm_ir_raises_on_undefined_variable_reference():
         emit_llvm_ir(
             {
                 "pure_functions": [
-                    {"name": "demo", "return_type": "float", "params": [], "body": ["return missing;"]}
+                    {
+                        "name": "demo",
+                        "return_type": "float",
+                        "params": [],
+                        "body_ast": [AstReturnStmt(value=AstExprVar(path=("missing",)))],
+                    }
                 ],
                 "shaders": [],
                 "filters": [],
@@ -599,7 +671,17 @@ def test_emit_llvm_ir_raises_on_intrinsic_type_mismatch():
                         "name": "demo",
                         "return_type": "float",
                         "params": [],
-                        "body": ["return max(1, 2);"]
+                        "body_ast": [
+                            AstReturnStmt(
+                                value=AstExprCall(
+                                    name="max",
+                                    args=(
+                                        AstExprLiteral(kind="int", value="1"),
+                                        AstExprLiteral(kind="int", value="2"),
+                                    ),
+                                )
+                            )
+                        ]
                     }
                 ],
                 "shaders": [],

--- a/tests/test_improvements.py
+++ b/tests/test_improvements.py
@@ -10,6 +10,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from lockstep_compiler.cli import build_arg_parser, run_cli
+from lockstep_compiler.ast import AstExprCall, AstExprVar, AstReturnStmt
 from lockstep_compiler.codegen import emit_llvm_ir
 from lockstep_compiler.lsp import provide_hover_info
 from lockstep_compiler.prelude import load_intrinsics
@@ -79,7 +80,7 @@ def _entities_with_pure(name, params, body, return_type="float"):
                 "name": name,
                 "return_type": return_type,
                 "params": params,
-                "body": body,
+                "body_ast": body,
                 "intrinsic": False,
             },
             *_intrinsic_defs(),
@@ -91,7 +92,11 @@ def test_codegen_min_intrinsic():
     entities = _entities_with_pure(
         "test_min",
         [{"type": "float", "name": "a"}, {"type": "float", "name": "b"}],
-        ["return min(a, b);"],
+        [
+            AstReturnStmt(
+                value=AstExprCall(name="min", args=(AstExprVar(path=("a",)), AstExprVar(path=("b",))))
+            )
+        ],
     )
     ir_text = emit_llvm_ir(entities)
     assert "llvm.minnum.f32" in ir_text
@@ -101,7 +106,11 @@ def test_codegen_max_intrinsic():
     entities = _entities_with_pure(
         "test_max",
         [{"type": "float", "name": "a"}, {"type": "float", "name": "b"}],
-        ["return max(a, b);"],
+        [
+            AstReturnStmt(
+                value=AstExprCall(name="max", args=(AstExprVar(path=("a",)), AstExprVar(path=("b",))))
+            )
+        ],
     )
     ir_text = emit_llvm_ir(entities)
     assert "llvm.maxnum.f32" in ir_text
@@ -111,7 +120,7 @@ def test_codegen_abs_intrinsic():
     entities = _entities_with_pure(
         "test_abs",
         [{"type": "float", "name": "x"}],
-        ["return abs(x);"],
+        [AstReturnStmt(value=AstExprCall(name="abs", args=(AstExprVar(path=("x",)),)))],
     )
     ir_text = emit_llvm_ir(entities)
     assert "llvm.fabs.f32" in ir_text
@@ -121,7 +130,7 @@ def test_codegen_sign_intrinsic():
     entities = _entities_with_pure(
         "test_sign",
         [{"type": "float", "name": "x"}],
-        ["return sign(x);"],
+        [AstReturnStmt(value=AstExprCall(name="sign", args=(AstExprVar(path=("x",)),)))],
     )
     ir_text = emit_llvm_ir(entities)
     assert "sign_pos" in ir_text or "sign" in ir_text
@@ -135,7 +144,14 @@ def test_codegen_smoothstep_intrinsic():
             {"type": "float", "name": "e1"},
             {"type": "float", "name": "x"},
         ],
-        ["return smoothstep(e0, e1, x);"],
+        [
+            AstReturnStmt(
+                value=AstExprCall(
+                    name="smoothstep",
+                    args=(AstExprVar(path=("e0",)), AstExprVar(path=("e1",)), AstExprVar(path=("x",))),
+                )
+            )
+        ],
     )
     ir_text = emit_llvm_ir(entities)
     assert "smoothstep" in ir_text


### PR DESCRIPTION
### Motivation
- Remove the legacy string/tuple expression bridge and make codegen operate on the typed AST end-to-end to simplify lowering and avoid duplicating parsing logic.
- Ensure the lowerer natively traverses `AstExprCall`, `AstExprBinary`, `AstExprUnary`, `AstExprVar`, and `AstExprLiteral` instead of converting ad-hoc legacy shapes. 
- Fail fast when non-AST, string-based bodies are supplied so callers must provide stable `body_ast` structures.

### Description
- Deleted legacy expression parsing and normalization pieces (`_tokenize_expr`, `_ExprParser`, `_parse_expr`, and `_normalize_expr_node`) and associated bridging code. 
- Updated `_FunctionLowerer` to lower typed AST nodes directly by tightening `_lower_expr` and `_lower_statement` signatures and emitting `CodegenError` for unsupported node types. 
- Added `_ast_body_for` in `emit_llvm_ir` and changed lowering call sites to require `body_ast` for pure functions, shaders, and filters, rejecting string `body` payloads. 
- Migrated codegen-focused tests to provide `body_ast` AST nodes (including nested `AstExprCall` trees and `AstVarDeclStmt`/`AstAssignStmt`/`AstReturnStmt`) and adjusted shader/filter fixtures to include empty `body_ast` where appropriate. 

### Testing
- Ran `pytest -q -o addopts='' tests/test_compiler_api.py tests/test_improvements.py` and all tests passed (`43 passed`).
- Note: running `pytest -q tests/...` without overriding `addopts` failed in this environment due to project-level coverage `addopts`, so the `-o addopts=''` override was used to execute and validate the updated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c35359b483288064fed84f83e32b)