### PR TITLE
Restrict lvalue member access depth to one level

### DIFF
--- a/Lockstep.g4
+++ b/Lockstep.g4
@@ -88,7 +88,7 @@ primaryExpr
     ;
 
 exprList: expr (',' expr)*;
-lvalue: ID ('.' ID)*;
+lvalue: ID ('.' ID)?;
 typeName: ID typeSuffix*;
 typeSuffix
     : '[' INT ']'

--- a/lockstep_compiler/visitors.py
+++ b/lockstep_compiler/visitors.py
@@ -644,6 +644,20 @@ def build_semantic_validator(base_visitor_cls):
             if not id_tokens:
                 return None
 
+            if len(id_tokens) > 2:
+                access_path = ".".join(token.getText() for token in id_tokens)
+                self._add_diagnostic(
+                    severity="error",
+                    code=SEMANTIC_DIAGNOSTIC_CODES["invalid_field_access_non_struct"],
+                    message=(
+                        "Nested field access deeper than one member is not supported "
+                        f"for lvalues ('{access_path}')."
+                    ),
+                    ctx=ctx,
+                    hint="Rewrite the expression to use at most one '.field' dereference.",
+                )
+                return None
+
             root_identifier = id_tokens[0].getText()
             current_type = self._check_expression_identifier(
                 root_identifier,

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1760,6 +1760,34 @@ def test_semantic_validator_lvalue_reports_unknown_struct_field(debug_compiler_m
     ]
 
 
+def test_semantic_validator_lvalue_reports_excessive_member_depth(debug_compiler_module):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+    validator._push_scope()
+    validator._declare("entity", "Particle", _ctx(), duplicate_code="LCK306", kind="local")
+
+    lvalue_ctx = _ctx(
+        start_line=60,
+        start_col=2,
+        ID=lambda: [_token("entity"), _token("position"), _token("x")],
+    )
+
+    validator.visitLvalue(lvalue_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK302",
+            message=(
+                "Nested field access deeper than one member is not supported for lvalues "
+                "('entity.position.x')."
+            ),
+            line=60,
+            column=2,
+            hint="Rewrite the expression to use at most one '.field' dereference.",
+        )
+    ]
+
+
 def test_semantic_validator_reports_assignment_type_mismatch(debug_compiler_module):
     validator = debug_compiler_module.LockstepSemanticValidator()
     validator._push_scope()


### PR DESCRIPTION
### Motivation
- The frontend grammar allowed arbitrarily deep lvalue member chains (`ID ('.' ID)*`) while the backend SoA arena layout and lowering only support a single nested member, creating a mismatch between language semantics and codegen capabilities. 
- Make the language contract explicit and surface a clear diagnostic when source uses deeper member chains so users get actionable feedback instead of silent codegen failures.

### Description
- Tightened the parser rule in `Lockstep.g4` from `lvalue: ID ('.' ID)*;` to `lvalue: ID ('.' ID)?;` so the grammar only permits at most one member dereference. 
- Added a semantic guard in `lockstep_compiler/visitors.py` that detects lvalues with depth > 1 and emits an error diagnostic (`LCK302`) with a human-friendly message and a fix-it hint. 
- Added a regression test in `tests/test_debug_compiler.py` that verifies the new diagnostic triggers for an excessive-member-depth lvalue like `entity.position.x`.

### Testing
- Running `pytest -q -o addopts='' tests/test_debug_compiler.py -k "lvalue_reports_unknown_struct_field or lvalue_reports_excessive_member_depth"` completed successfully with `2 passed, 76 deselected`. 
- A plain `pytest -q tests/test_debug_compiler.py -k ...` invocation initially failed due to repository `addopts` coverage options in `pyproject.toml` requiring unavailable plugins, so the adjusted `-o addopts=''` invocation was used to run the targeted tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d1540b7883288b056176a1e962d6)