### PR TITLE
Wrap codegen failures in LockstepCompileError

### DIFF
--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -6,7 +6,7 @@ from antlr4 import CommonTokenStream, InputStream
 
 from .ast import ast_to_entities, build_program_ast
 from .c_header import emit_c_header
-from .codegen import emit_llvm_ir
+from .codegen import CodegenError, emit_llvm_ir
 from .errors import LockstepCompileError, ParseErrorCollector
 from .models import LockstepCompileResult, LockstepDiagnostic, normalize_diagnostics
 from .optimizer import optimize_bind_routes
@@ -199,11 +199,30 @@ def _compile_lockstep_with_dependencies(
         "fused_bind_groups": bind_optimization["fused_groups"],
     }
 
+    try:
+        llvm_ir = emit_llvm_ir(typed_ast or entities)
+    except CodegenError as error:
+        codegen_diagnostic = LockstepDiagnostic(
+            severity="error",
+            code="LCK501",
+            message=str(error),
+            line=1,
+            column=0,
+            source_file=source_file,
+            hint="Fix semantic inconsistencies that prevent LLVM IR emission.",
+        )
+        raise LockstepCompileError(
+            [codegen_diagnostic],
+            diagnostics=normalize_diagnostics([*all_diagnostics, codegen_diagnostic]),
+            phase="codegen",
+            source_file=source_file,
+        ) from error
+
     return LockstepCompileResult(
         parse_tree=tree,
         entities=entities,
         ast=typed_ast,
-        llvm_ir=emit_llvm_ir(typed_ast or entities),
+        llvm_ir=llvm_ir,
         c_header=emit_c_header(typed_ast or entities),
         diagnostics=all_diagnostics,
     )

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -10,6 +10,7 @@ import lockstep_compiler
 import lockstep_compiler.compiler as compiler_module
 from lockstep_compiler.c_header import emit_c_header
 from lockstep_compiler.codegen import CodegenError, emit_llvm_ir
+from lockstep_compiler.models import LockstepDiagnostic
 from lockstep_compiler.ast import (
     AstAssignStmt,
     AstExprBinary,
@@ -314,6 +315,87 @@ def test_compile_lockstep_maps_semantic_diagnostics_to_primary_source_file():
 
     assert exc_info.value.errors[0].source_file == "main.lock"
     assert exc_info.value.errors[0].line == 2
+
+
+def test_compile_lockstep_wraps_codegen_errors_with_compile_error(monkeypatch):
+    class StubLexer:
+        def __init__(self, input_stream):
+            self.input_stream = input_stream
+
+        def removeErrorListeners(self):
+            pass
+
+        def addErrorListener(self, listener):
+            pass
+
+    class StubParser:
+        def __init__(self, stream):
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            return "TREE"
+
+    class StubVisitor:
+        pass
+
+    class StubDebugVisitor:
+        def __init__(self, verbose=True):
+            self.verbose = verbose
+            self.structs = []
+            self.shaders = []
+            self.filters = []
+            self.pure_functions = []
+            self.streams = []
+            self.accumulators = []
+            self.uniforms = []
+            self.bind_routes = []
+            self.bind_routes_ir = []
+            self.diagnostics = [
+                LockstepDiagnostic(
+                    severity="warning",
+                    code="LCK421",
+                    message="unused symbol 'x'",
+                    line=2,
+                    column=4,
+                )
+            ]
+
+        def visit(self, tree):
+            return None
+
+    monkeypatch.setattr(
+        compiler_module,
+        "_load_default_parser_classes",
+        lambda: (StubLexer, StubParser, StubVisitor),
+    )
+    monkeypatch.setattr(
+        compiler_module,
+        "emit_llvm_ir",
+        lambda _program: (_ for _ in ()).throw(CodegenError("undefined variable 'missing'")),
+    )
+
+    with pytest.raises(lockstep_compiler.LockstepCompileError) as exc_info:
+        lockstep_compiler.compile_lockstep(
+            "pipeline Main { bind { } }",
+            source_file="main.lock",
+            verbose=False,
+            semantic_validator=lambda _tree: [],
+            token_stream_cls=lambda lexer: object(),
+            debug_visitor_cls=StubDebugVisitor,
+        )
+
+    error = exc_info.value
+    assert error.phase == "codegen"
+    assert [diag.code for diag in error.errors] == ["LCK501"]
+    assert error.errors[0].message == "undefined variable 'missing'"
+    assert error.errors[0].source_file == "main.lock"
+    assert {diag.code for diag in error.diagnostics} == {"LCK421", "LCK501"}
 
 def test_emit_llvm_ir_accepts_ast_program_input():
     from lockstep_compiler.ast import (


### PR DESCRIPTION
### Motivation
- Prevent unhandled `CodegenError` from propagating to the CLI and crashing the process by surfacing codegen failures as structured compile diagnostics.
- Provide a clear, actionable diagnostic when LLVM IR emission fails so callers and the CLI can present a friendly error and include prior diagnostics.

### Description
- Catch `CodegenError` around `emit_llvm_ir(...)` in `_compile_lockstep_with_dependencies` and re-raise it as `LockstepCompileError` with `phase="codegen"` and a new diagnostic code `LCK501` (`lockstep_compiler/compiler.py`).
- Construct a `LockstepDiagnostic` for the codegen failure (message from the `CodegenError`, `source_file`, hint) and merge it into existing diagnostics using `normalize_diagnostics` before raising.
- Import `CodegenError` in the compiler module to enable the guarded path (`lockstep_compiler/compiler.py`).
- Add a regression test that stubs `emit_llvm_ir` to raise `CodegenError` and asserts that `compile_lockstep(...)` raises `LockstepCompileError` with `phase == "codegen"`, `LCK501`, and merged diagnostics (`tests/test_compiler_api.py`).

### Testing
- Added `test_compile_lockstep_wraps_codegen_errors_with_compile_error` to validate the new behavior and assertions about diagnostics and phase.
- Ran targeted tests with: `cd /workspace/lockstep && pytest -q -o addopts='' tests/test_compiler_api.py -k "wraps_codegen_errors_with_compile_error or works_without_passing_parser_classes or maps_semantic_diagnostics_to_primary_source_file"`, which returned `3 passed, 21 deselected`.
- No changes to successful compilation behavior were observed; existing tests for normal compile paths continue to pass in the targeted run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d197a3a483288ac9c10ff45241e8)