### PR TITLE
Pin antlr4 and llvmlite dependency ranges

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 name = "Lockstep"
 version = "0.1.0"
 dependencies = [
-    "antlr4-python3-runtime",
-    "llvmlite",
+    "antlr4-python3-runtime>=4.13,<4.14",
+    "llvmlite>=0.43,<0.44",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Motivation
- Ensure the installed ANTLR runtime matches the generated parser (ANTLR 4.13.x) and constrain `llvmlite` to a compatible LLVM-coupled wheel range to avoid runtime incompatibilities.

### Description
- Update `pyproject.toml` to require `antlr4-python3-runtime>=4.13,<4.14` and `llvmlite>=0.43,<0.44`.

### Testing
- Ran `python -m pip install -e .` (which installed `antlr4-python3-runtime 4.13.2` and `llvmlite 0.43.0`) and then `pytest -q -o addopts=''`, resulting in `163 passed, 4 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d2b0b91083289e6ba7477b8a91f8)