### PR TITLE
Add Black configuration to pyproject.toml to enforce formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ lockstep-lsp = "lockstep_compiler.lsp:run_lsp_server"
 addopts = "-q -ra --cov=. --cov-branch --cov-report=term-missing --cov-report=xml:coverage.xml"
 testpaths = ["tests"]
 
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+include = "\\.pyi?$"
+
 [tool.coverage.run]
 branch = true
 source = ["."]


### PR DESCRIPTION
### Motivation
- Enforce consistent Python formatting via Black configuration in the project metadata instead of relying on convention.

### Description
- Add a `[tool.black]` section to `pyproject.toml` setting `line-length = 88`, `target-version = ["py311"]`, and `include = "\\.pyi?$"`.

### Testing
- `python -m pytest -q tests/test_formatter.py` failed in this environment due to repo `pytest` `addopts` including coverage flags without the `pytest-cov` plugin available.
- `python -m pytest -q -o addopts='' tests/test_formatter.py` ran and passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d54bb55483289d25faef293ef836)