### PR TITLE
Replace ad-hoc intrinsic and semantic payloads with frozen dataclasses

### DIFF
--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -8,13 +8,31 @@ from .ast import ast_to_entities, build_program_ast
 from .c_header import emit_c_header
 from .codegen import CodegenError, emit_llvm_ir
 from .errors import LockstepCompileError, ParseErrorCollector
-from .models import LockstepCompileResult, LockstepDiagnostic, normalize_diagnostics
+from .models import (
+    IntrinsicSignature,
+    LockstepCompileResult,
+    LockstepDiagnostic,
+    normalize_diagnostics,
+)
 from .optimizer import optimize_bind_routes
 from .prelude import load_intrinsics
 from .visitors import build_debug_visitor, validate_semantics as _validate_semantics
 
 
 DEFAULT_SOURCE_FILE = "<stdin>"
+
+
+def _intrinsic_to_entity(intrinsic: IntrinsicSignature) -> dict[str, Any]:
+    return {
+        "name": intrinsic.name,
+        "return_type": intrinsic.return_type,
+        "params": [
+            {"type": param.type_name, "name": param.name}
+            for param in intrinsic.params
+        ],
+        "body": [],
+        "intrinsic": True,
+    }
 
 
 def _merge_intrinsic_pure_functions(
@@ -27,7 +45,7 @@ def _merge_intrinsic_pure_functions(
     }
     for name, intrinsic in load_intrinsics().items():
         if name not in merged:
-            merged[name] = intrinsic
+            merged[name] = _intrinsic_to_entity(intrinsic)
     return list(merged.values())
 
 

--- a/lockstep_compiler/models.py
+++ b/lockstep_compiler/models.py
@@ -43,6 +43,43 @@ class SemanticStructField:
     declared_type: str
 
 
+@dataclass(frozen=True)
+class SemanticPureFunctionSignature:
+    return_type: str
+    params: tuple[SemanticKernelParam, ...]
+    intrinsic: bool = False
+
+
+@dataclass(frozen=True)
+class IntrinsicParam:
+    type_name: str
+    name: str
+
+
+@dataclass(frozen=True)
+class IntrinsicSignature:
+    name: str
+    return_type: str
+    params: tuple[IntrinsicParam, ...]
+
+
+@dataclass(frozen=True)
+class ParsedTypeArraySuffix:
+    size: int
+
+
+@dataclass(frozen=True)
+class ParsedTypeName:
+    base: str
+    inner: tuple["ParsedTypeArraySuffix | ParsedTypeGenericSuffix", ...] = ()
+
+
+@dataclass(frozen=True)
+class ParsedTypeGenericSuffix:
+    type_name: ParsedTypeName
+    arity: int | None = None
+
+
 _SEVERITY_PRIORITY = {"error": 0, "warning": 1, "info": 2}
 
 

--- a/lockstep_compiler/prelude.py
+++ b/lockstep_compiler/prelude.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import functools
 import re
 from pathlib import Path
-from typing import Any
+
+from .models import IntrinsicParam, IntrinsicSignature
 
 _INTRINSIC_DECL_RE = re.compile(
     r"^\s*intrinsic\s+(?P<return_type>[A-Za-z_][A-Za-z0-9_]*)\s+"
@@ -13,29 +14,30 @@ _PARAM_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)
 
 
 @functools.lru_cache(maxsize=1)
-def load_intrinsics() -> dict[str, dict[str, Any]]:
+def load_intrinsics() -> dict[str, IntrinsicSignature]:
     prelude_path = Path(__file__).with_name("prelude.lock")
-    intrinsics: dict[str, dict[str, Any]] = {}
+    intrinsics: dict[str, IntrinsicSignature] = {}
     for line in prelude_path.read_text(encoding="utf-8").splitlines():
         match = _INTRINSIC_DECL_RE.match(line)
         if match is None:
             continue
         params_raw = match.group("params").strip()
-        params: list[dict[str, str]] = []
+        params: list[IntrinsicParam] = []
         if params_raw:
             for piece in params_raw.split(","):
                 param_match = _PARAM_RE.match(piece)
                 if param_match is None:
                     continue
                 params.append(
-                    {"type": param_match.group(1), "name": param_match.group(2)}
+                    IntrinsicParam(
+                        type_name=param_match.group(1), name=param_match.group(2)
+                    )
                 )
 
-        intrinsics[match.group("name")] = {
-            "name": match.group("name"),
-            "return_type": match.group("return_type"),
-            "params": params,
-            "body": [],
-            "intrinsic": True,
-        }
+        intrinsic = IntrinsicSignature(
+            name=match.group("name"),
+            return_type=match.group("return_type"),
+            params=tuple(params),
+        )
+        intrinsics[intrinsic.name] = intrinsic
     return intrinsics

--- a/lockstep_compiler/semantic_validator.py
+++ b/lockstep_compiler/semantic_validator.py
@@ -5,7 +5,11 @@ from .prelude import load_intrinsics
 
 from .models import (
     LockstepDiagnostic,
+    ParsedTypeArraySuffix,
+    ParsedTypeGenericSuffix,
+    ParsedTypeName,
     SemanticKernelParam,
+    SemanticPureFunctionSignature,
     SemanticStructField,
     SemanticSymbol,
 )
@@ -21,19 +25,19 @@ def build_semantic_validator(base_visitor_cls):
             self.scopes: list[Scope] = []
             self.shaders: dict[str, list[SemanticKernelParam]] = {}
             self.filters: dict[str, list[SemanticKernelParam]] = {}
-            self.pure_functions: dict[str, dict[str, Any]] = {
-                name: {
-                    "return_type": signature["return_type"],
-                    "params": [
+            self.pure_functions: dict[str, SemanticPureFunctionSignature] = {
+                name: SemanticPureFunctionSignature(
+                    return_type=signature.return_type,
+                    params=tuple(
                         SemanticKernelParam(
-                            name=param["name"],
-                            declared_type=param["type"],
+                            name=param.name,
+                            declared_type=param.type_name,
                             modifier="value",
                         )
-                        for param in signature["params"]
-                    ],
-                    "intrinsic": True,
-                }
+                        for param in signature.params
+                    ),
+                    intrinsic=True,
+                )
                 for name, signature in load_intrinsics().items()
             }
             self.structs: dict[str, dict[str, SemanticStructField]] = {}
@@ -171,12 +175,12 @@ def build_semantic_validator(base_visitor_cls):
 
         def _parse_type_name(
             self, type_name: str, index: int = 0
-        ) -> tuple[dict[str, Any] | None, int]:
+        ) -> tuple[ParsedTypeName | None, int]:
             base_name, index = self._consume_identifier(type_name, index)
             if base_name is None:
                 return None, index
 
-            parsed_type: dict[str, Any] = {"base": base_name, "inner": []}
+            suffixes: list[ParsedTypeArraySuffix | ParsedTypeGenericSuffix] = []
             while index < len(type_name):
                 if type_name[index] == "[":
                     index += 1
@@ -187,7 +191,7 @@ def build_semantic_validator(base_visitor_cls):
                         or type_name[index] != "]"
                     ):
                         return None, index
-                    parsed_type["inner"].append({"kind": "array", "size": int(length)})
+                    suffixes.append(ParsedTypeArraySuffix(size=int(length)))
                     index += 1
                     continue
 
@@ -207,27 +211,27 @@ def build_semantic_validator(base_visitor_cls):
 
                     if index >= len(type_name) or type_name[index] != ">":
                         return None, index
-                    parsed_type["inner"].append(
-                        {"kind": "generic", "type": inner_type, "arity": arity}
+                    suffixes.append(
+                        ParsedTypeGenericSuffix(type_name=inner_type, arity=arity)
                     )
                     index += 1
                     continue
 
                 break
 
-            return parsed_type, index
+            return ParsedTypeName(base=base_name, inner=tuple(suffixes)), index
 
         def _collect_referenced_type_names(
-            self, parsed_type: dict[str, Any]
+            self, parsed_type: ParsedTypeName
         ) -> list[str]:
             has_generic_suffix = any(
-                suffix["kind"] == "generic" for suffix in parsed_type["inner"]
+                isinstance(suffix, ParsedTypeGenericSuffix) for suffix in parsed_type.inner
             )
-            referenced_names = [] if has_generic_suffix else [parsed_type["base"]]
-            for suffix in parsed_type["inner"]:
-                if suffix["kind"] == "generic":
+            referenced_names = [] if has_generic_suffix else [parsed_type.base]
+            for suffix in parsed_type.inner:
+                if isinstance(suffix, ParsedTypeGenericSuffix):
                     referenced_names.extend(
-                        self._collect_referenced_type_names(suffix["type"])
+                        self._collect_referenced_type_names(suffix.type_name)
                     )
             return referenced_names
 
@@ -689,10 +693,10 @@ def build_semantic_validator(base_visitor_cls):
                         )
                     )
 
-            self.pure_functions[name] = {
-                "return_type": return_type,
-                "params": params,
-            }
+            self.pure_functions[name] = SemanticPureFunctionSignature(
+                return_type=return_type,
+                params=tuple(params),
+            )
 
             statements = []
             if hasattr(ctx, "statement") and callable(ctx.statement):
@@ -1070,7 +1074,7 @@ def build_semantic_validator(base_visitor_cls):
                         return function_name
                     function_signature = self.pure_functions.get(function_name)
                     if function_signature is not None:
-                        return function_signature["return_type"]
+                        return function_signature.return_type
                     return None
                 return self._check_expression_identifier(ctx.ID().getText(), ctx)
 
@@ -1105,7 +1109,7 @@ def build_semantic_validator(base_visitor_cls):
                 )
                 return
 
-            expected_params: list[SemanticKernelParam] = signature["params"]
+            expected_params = signature.params
             actual_args = []
             if ctx.exprList() is not None:
                 actual_args = ctx.exprList().expr()

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -15,6 +15,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from lockstep_compiler.models import (
     SemanticKernelParam,
+    SemanticPureFunctionSignature,
     SemanticStructField,
     SemanticSymbol,
 )
@@ -1298,17 +1299,15 @@ def test_semantic_validator_records_pure_signature_from_declaration(
     validator.visitPureDecl(pure_decl_ctx)
 
     assert "blend" in validator.pure_functions
-    assert validator.pure_functions["blend"] == {
-        "return_type": "float",
-        "params": [
-            SemanticKernelParam(name="left", declared_type="float", modifier="value"),
-            SemanticKernelParam(name="right", declared_type="int", modifier="value"),
-        ],
-    }
+    assert validator.pure_functions["blend"].return_type == "float"
+    assert validator.pure_functions["blend"].params == (
+        SemanticKernelParam(name="left", declared_type="float", modifier="value"),
+        SemanticKernelParam(name="right", declared_type="int", modifier="value"),
+    )
     assert {
         name
         for name, signature in validator.pure_functions.items()
-        if signature.get("intrinsic")
+        if signature.intrinsic
     } == {
         "step",
         "mix",
@@ -1509,13 +1508,13 @@ def test_semantic_validator_reports_undefined_pure_function_call(debug_compiler_
 def test_semantic_validator_reports_pure_call_arity_mismatch(debug_compiler_module):
     validator = debug_compiler_module.LockstepSemanticValidator()
     validator.pure_functions = {
-        "mix": {
-            "return_type": "float",
-            "params": [
+        "mix": SemanticPureFunctionSignature(
+            return_type="float",
+            params=(
                 SemanticKernelParam(name="a", declared_type="float", modifier="value"),
                 SemanticKernelParam(name="b", declared_type="float", modifier="value"),
-            ],
-        }
+            ),
+        )
     }
 
     call_ctx = _ctx(
@@ -1544,14 +1543,14 @@ def test_semantic_validator_reports_pure_call_argument_type_mismatch(
 ):
     validator = debug_compiler_module.LockstepSemanticValidator()
     validator.pure_functions = {
-        "negate": {
-            "return_type": "float",
-            "params": [
+        "negate": SemanticPureFunctionSignature(
+            return_type="float",
+            params=(
                 SemanticKernelParam(
                     name="value", declared_type="float", modifier="value"
-                )
-            ],
-        }
+                ),
+            ),
+        )
     }
 
     call_ctx = _ctx(
@@ -1578,13 +1577,13 @@ def test_semantic_validator_reports_pure_call_argument_type_mismatch(
 def test_semantic_validator_accepts_valid_pure_call(debug_compiler_module):
     validator = debug_compiler_module.LockstepSemanticValidator()
     validator.pure_functions = {
-        "dot": {
-            "return_type": "float",
-            "params": [
+        "dot": SemanticPureFunctionSignature(
+            return_type="float",
+            params=(
                 SemanticKernelParam(name="x", declared_type="float", modifier="value"),
                 SemanticKernelParam(name="y", declared_type="float", modifier="value"),
-            ],
-        }
+            ),
+        )
     }
 
     call_ctx = _ctx(

--- a/tests/test_improvements.py
+++ b/tests/test_improvements.py
@@ -24,29 +24,29 @@ from lockstep_compiler.prelude import load_intrinsics
 def test_prelude_declares_min():
     intrinsics = load_intrinsics()
     assert "min" in intrinsics
-    assert intrinsics["min"]["return_type"] == "float"
-    assert len(intrinsics["min"]["params"]) == 2
+    assert intrinsics["min"].return_type == "float"
+    assert len(intrinsics["min"].params) == 2
 
 
 def test_prelude_declares_abs():
     intrinsics = load_intrinsics()
     assert "abs" in intrinsics
-    assert intrinsics["abs"]["return_type"] == "float"
-    assert len(intrinsics["abs"]["params"]) == 1
+    assert intrinsics["abs"].return_type == "float"
+    assert len(intrinsics["abs"].params) == 1
 
 
 def test_prelude_declares_sign():
     intrinsics = load_intrinsics()
     assert "sign" in intrinsics
-    assert intrinsics["sign"]["return_type"] == "float"
-    assert len(intrinsics["sign"]["params"]) == 1
+    assert intrinsics["sign"].return_type == "float"
+    assert len(intrinsics["sign"].params) == 1
 
 
 def test_prelude_declares_smoothstep():
     intrinsics = load_intrinsics()
     assert "smoothstep" in intrinsics
-    assert intrinsics["smoothstep"]["return_type"] == "float"
-    assert len(intrinsics["smoothstep"]["params"]) == 3
+    assert intrinsics["smoothstep"].return_type == "float"
+    assert len(intrinsics["smoothstep"].params) == 3
 
 
 # ---------------------------------------------------------------------------
@@ -57,7 +57,19 @@ def test_prelude_declares_smoothstep():
 def _intrinsic_defs():
     """Return intrinsic pure function declarations needed by codegen."""
     intrinsics = load_intrinsics()
-    return [decl for decl in intrinsics.values()]
+    return [
+        {
+            "name": decl.name,
+            "return_type": decl.return_type,
+            "params": [
+                {"type": param.type_name, "name": param.name}
+                for param in decl.params
+            ],
+            "body": [],
+            "intrinsic": True,
+        }
+        for decl in intrinsics.values()
+    ]
 
 
 _CODEGEN_ENTITIES_BASE = {


### PR DESCRIPTION
### Motivation
- Improve type safety and make the semantic/intrinsic AST flow uniform by replacing untyped dict payloads with explicit, frozen dataclasses.
- Make parsed-type nodes first-class, immutable types to simplify downstream validation and avoid ad-hoc nested dict manipulation.

### Description
- Introduce frozen dataclasses in `lockstep_compiler/models.py`: `IntrinsicSignature`, `IntrinsicParam`, `SemanticPureFunctionSignature`, `ParsedTypeName`, `ParsedTypeArraySuffix`, and `ParsedTypeGenericSuffix` to represent intrinsics, pure function signatures, and parsed-type suffixes.
- Update `lockstep_compiler/prelude.py` so `load_intrinsics()` returns `dict[str, IntrinsicSignature]` and build typed parameter tuples instead of nested dicts.
- Migrate `lockstep_compiler/semantic_validator.py` internals to use `SemanticPureFunctionSignature` for pure-function storage and to construct typed parsed-type nodes during `_parse_type_name` and `_collect_referenced_type_names`.
- Preserve external/entity compatibility by converting `IntrinsicSignature` instances back to the legacy entity `dict` representation at the compiler merge boundary in `lockstep_compiler/compiler.py` and update tests to assert the new typed APIs.

### Testing
- Ran `pytest -q -o addopts='' tests/test_improvements.py tests/test_type_syntax.py tests/test_debug_compiler.py`, which passed with `103 passed`.
- An initial `pytest` invocation failed due to repository `addopts` including coverage flags not available in the environment, so the successful run used `-o addopts=''` to run the targeted tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d7e6b0e883289f6d223be8c231a4)