### PR TITLE
Add Makefile build/test/test-cov targets and simplify pytest addopts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: verify-parser-toolchain generate-parser check-generated-parser
+.PHONY: verify-parser-toolchain generate-parser check-generated-parser build test test-cov
 
 verify-parser-toolchain:
 	python scripts/generate_parser.py --verify-toolchain
@@ -11,3 +11,12 @@ check-generated-parser:
 	$(MAKE) verify-parser-toolchain
 	python scripts/generate_parser.py
 	git diff --exit-code -- generated/parser/LockstepLexer.py generated/parser/LockstepListener.py generated/parser/LockstepParser.py generated/parser/LockstepVisitor.py
+
+build:
+	python -m pip wheel . --no-deps --wheel-dir dist
+
+test:
+	pytest
+
+test-cov:
+	pytest --cov=. --cov-branch --cov-report=term-missing --cov-report=xml:coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ lockstepc = "lockstep_compiler.cli:main"
 lockstep-lsp = "lockstep_compiler.lsp:run_lsp_server"
 
 [tool.pytest.ini_options]
-addopts = "-q -ra --cov=. --cov-branch --cov-report=term-missing --cov-report=xml:coverage.xml"
+addopts = "-q -ra"
 testpaths = ["tests"]
 
 [tool.black]


### PR DESCRIPTION
### Motivation
- Provide convenient Makefile targets to build a wheel and run the test suite with and without coverage in a consistent way.
- Remove coverage flags from the default `pytest` addopts so tests run quickly by default and coverage is invoked explicitly when needed.

### Description
- Added `build`, `test`, and `test-cov` targets to the `Makefile` and included them in `.PHONY`.
- Implemented `build` to produce a wheel with `python -m pip wheel . --no-deps --wheel-dir dist`.
- Implemented `test` to run `pytest` and `test-cov` to run `pytest --cov=...` with coverage reporting.
- Updated `pyproject.toml` to change `tool.pytest.ini_options.addopts` from including coverage flags to `"-q -ra"`, keeping coverage configuration in `[tool.coverage.*]` for use by `test-cov`.

### Testing
- Ran `make test` which invokes `pytest`; the test suite completed successfully.
- Ran `make test-cov` which invokes `pytest --cov=. --cov-branch --cov-report=term-missing --cov-report=xml:coverage.xml`; coverage run completed successfully.
- Ran `make build` which produced a wheel in `dist/` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6daa79dfc83288ada9579f1c5933a)