### PR TITLE
Warn users that `--format` strips comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ lockstepc path/to/program.lock --emit-header
 lockstepc --version
 ```
 
+> ⚠️ `--format` currently strips source comments from the emitted output.
+
 `debug_compiler.py` exposes `compile_lockstep(source_code, verbose=True)` and returns a `LockstepCompileResult` containing:
 
 * `parse_tree`: ANTLR parse tree for the source.

--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -151,6 +151,10 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
         library_source_files.append(str(Path(library_path)))
 
     if args.format:
+        print(
+            "warning: --format currently strips comments from output.",
+            file=stderr,
+        )
         print(format_lockstep_source(source), end="", file=stdout)
         return 0
 

--- a/tests/test_cli_format.py
+++ b/tests/test_cli_format.py
@@ -10,13 +10,16 @@ def test_run_cli_format_outputs_formatted_source_without_compiling():
         called["compiler"] = True
 
     stdout = io.StringIO()
+    stderr = io.StringIO()
     exit_code = run_cli(
         ["--format"],
         stdin=io.StringIO("pipeline P{stream<float,4> in0;}"),
         stdout=stdout,
+        stderr=stderr,
         compiler=fake_compiler,
     )
 
     assert exit_code == 0
     assert called["compiler"] is False
     assert stdout.getvalue() == "pipeline P {\n    stream<float,4> in0;\n}\n"
+    assert stderr.getvalue() == "warning: --format currently strips comments from output.\n"


### PR DESCRIPTION
### Motivation
- Prevent silent data loss by warning users that `--format` currently strips comments from the formatted output.

### Description
- Print a runtime warning to `stderr` when `--format` is used, update the CLI format test to assert the warning is emitted while keeping the formatted output unchanged, and document the caveat in the `README`.

### Testing
- Initial `pytest -q tests/test_cli_format.py tests/test_formatter.py` failed during import collection due to environment `PYTHONPATH` differences, then `PYTHONPATH=. pytest -q tests/test_cli_format.py tests/test_formatter.py` was run and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6e1b9e9e88328aa78d25f973303c0)