### PR TITLE
Improve LSP document lifecycle handling and definition lookups

### DIFF
--- a/lockstep_compiler/lsp.py
+++ b/lockstep_compiler/lsp.py
@@ -22,6 +22,7 @@ class AnalysisContext:
     variable_types: dict[str, str]
     struct_member_index: dict[str, dict[str, MemberDefinition]]
     struct_field_types: dict[str, dict[str, str]]
+    callable_index: dict[str, "DefinitionTarget"]
     entities: dict[str, Any]
 
 
@@ -29,6 +30,13 @@ class AnalysisContext:
 class CompiledLspContext:
     entities: dict[str, Any]
     diagnostics: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class DefinitionTarget:
+    line: int
+    column: int
+    symbol: str
 
 
 _MEMBER_ACCESS_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)")
@@ -201,8 +209,78 @@ def build_analysis_context(
         variable_types=_infer_variable_types_from_entities(entities),
         struct_member_index=_build_struct_member_index_from_entities(entities),
         struct_field_types=_build_struct_field_type_index_from_entities(entities),
+        callable_index=_build_callable_index(source, entities),
         entities=entities,
     )
+
+
+def _offset_to_line_column(source: str, offset: int) -> tuple[int, int]:
+    clamped = min(max(offset, 0), len(source))
+    line = source.count("\n", 0, clamped)
+    line_start = source.rfind("\n", 0, clamped)
+    if line_start == -1:
+        return line, clamped
+    return line, clamped - line_start - 1
+
+
+def _find_callable_definition(
+    source: str,
+    pattern: re.Pattern[str],
+    symbol: str,
+) -> DefinitionTarget | None:
+    match = pattern.search(source)
+    if match is None:
+        return None
+
+    line, column = _offset_to_line_column(source, match.start("name"))
+    return DefinitionTarget(line=line, column=column, symbol=symbol)
+
+
+def _build_callable_index(
+    source: str,
+    entities: dict[str, Any],
+) -> dict[str, DefinitionTarget]:
+    callable_index: dict[str, DefinitionTarget] = {}
+
+    for shader in entities.get("shaders", []):
+        name = shader.get("name")
+        if not name or name in callable_index:
+            continue
+        target = _find_callable_definition(
+            source,
+            re.compile(rf"\bshader\s+(?P<name>{re.escape(name)})\s*\("),
+            name,
+        )
+        if target is not None:
+            callable_index[name] = target
+
+    for filter_decl in entities.get("filters", []):
+        name = filter_decl.get("name")
+        if not name or name in callable_index:
+            continue
+        target = _find_callable_definition(
+            source,
+            re.compile(rf"\bfilter\s+(?P<name>{re.escape(name)})\s*\("),
+            name,
+        )
+        if target is not None:
+            callable_index[name] = target
+
+    for pure in entities.get("pure_functions", []):
+        name = pure.get("name")
+        if not name or pure.get("intrinsic") or name in callable_index:
+            continue
+        target = _find_callable_definition(
+            source,
+            re.compile(
+                rf"\bpure\b[\s\S]*?\b(?P<name>{re.escape(name)})\s*\("
+            ),
+            name,
+        )
+        if target is not None:
+            callable_index[name] = target
+
+    return callable_index
 
 
 def find_member_definition(
@@ -227,6 +305,39 @@ def find_member_definition(
         if not struct_name:
             return None
         return context.struct_member_index.get(struct_name, {}).get(field_name)
+    return None
+
+
+def find_definition_target(
+    source: str,
+    line: int,
+    column: int,
+    analysis_context: AnalysisContext | None = None,
+) -> DefinitionTarget | None:
+    member = find_member_definition(
+        source,
+        line,
+        column,
+        analysis_context=analysis_context,
+    )
+    if member is not None:
+        return DefinitionTarget(
+            line=member.line,
+            column=member.column,
+            symbol=member.field_name,
+        )
+
+    lines = source.splitlines()
+    if line < 0 or line >= len(lines):
+        return None
+
+    line_text = lines[line]
+    context = analysis_context or build_analysis_context(source)
+    for match in re.finditer(r"\b([A-Za-z_][A-Za-z0-9_]*)\b", line_text):
+        start, end = match.span(1)
+        if not (start <= column < end):
+            continue
+        return context.callable_index.get(match.group(1))
     return None
 
 
@@ -394,8 +505,9 @@ def run_lsp_server() -> int:
             message=diag.get("message", ""),
         )
 
-    async def _debounced_validate(uri: str):
-        await asyncio.sleep(debounce_seconds)
+    async def _validate(uri: str, *, debounced: bool):
+        if debounced:
+            await asyncio.sleep(debounce_seconds)
         document = server.workspace.get_text_document(uri)
         compiled = compile_context_for_lsp(document.source)
         doc_contexts[uri] = compiled
@@ -404,11 +516,17 @@ def run_lsp_server() -> int:
         )
         pending_tasks.pop(uri, None)
 
-    def _schedule_validate(uri: str):
+    def _schedule_validate(uri: str, *, debounced: bool = True):
         task = pending_tasks.get(uri)
         if task is not None and not task.done():
             task.cancel()
-        pending_tasks[uri] = asyncio.create_task(_debounced_validate(uri))
+        pending_tasks[uri] = asyncio.create_task(_validate(uri, debounced=debounced))
+
+    def _clear_document_context(uri: str):
+        task = pending_tasks.pop(uri, None)
+        if task is not None and not task.done():
+            task.cancel()
+        doc_contexts.pop(uri, None)
 
     def _context_for_document(uri: str, source: str) -> CompiledLspContext:
         context = doc_contexts.get(uri)
@@ -421,6 +539,15 @@ def run_lsp_server() -> int:
     @server.feature(types.TEXT_DOCUMENT_DID_CHANGE)
     def validate(params):
         _schedule_validate(params.text_document.uri)
+
+    @server.feature(types.TEXT_DOCUMENT_DID_SAVE)
+    def validate_on_save(params):
+        _schedule_validate(params.text_document.uri, debounced=False)
+
+    @server.feature(types.TEXT_DOCUMENT_DID_CLOSE)
+    def close_document(params):
+        _clear_document_context(params.text_document.uri)
+        server.publish_diagnostics(params.text_document.uri, [])
 
     @server.feature(types.TEXT_DOCUMENT_COMPLETION)
     def completion(params: types.CompletionParams):
@@ -481,21 +608,21 @@ def run_lsp_server() -> int:
         analysis_context = build_analysis_context(
             document.source, compiled_context=compiled
         )
-        member = find_member_definition(
+        target = find_definition_target(
             document.source,
             params.position.line,
             params.position.character,
             analysis_context=analysis_context,
         )
-        if member is None:
+        if target is None:
             return None
-        target = types.Range(
-            start=types.Position(line=member.line, character=member.column),
+        target_range = types.Range(
+            start=types.Position(line=target.line, character=target.column),
             end=types.Position(
-                line=member.line, character=member.column + len(member.field_name)
+                line=target.line, character=target.column + len(target.symbol)
             ),
         )
-        return types.Location(uri=document.uri, range=target)
+        return types.Location(uri=document.uri, range=target_range)
 
     server.start_io()
     return 0

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -1,6 +1,7 @@
 from lockstep_compiler.lsp import (
     build_analysis_context,
     build_struct_member_index,
+    find_definition_target,
     find_member_definition,
     provide_bind_completion_items,
     provide_hover_info,
@@ -207,3 +208,65 @@ def test_large_source_hover_matches_default_and_context_path():
 
     assert expected == "(field) `Payload.value: float`"
     assert actual == expected
+
+
+def test_find_definition_target_resolves_shader_filter_and_pure_function_names():
+    source = """
+shader Integrate(in float src, out float dst) { dst = src; }
+
+filter Blur(in float src, out float dst) { dst = src; }
+
+pure float
+blend(float a, float b)
+{
+    return a;
+}
+
+pipeline P {
+    stream<float, 32> src;
+    stream<float, 32> dst;
+
+    bind {
+        dst = Integrate(src, dst);
+        dst = Blur(src, dst);
+    }
+}
+
+shader Wrap(in float src, out float dst) {
+    dst = blend(src, src);
+}
+"""
+
+    lines = source.splitlines()
+    integrate_line = next(i for i, text in enumerate(lines) if "Integrate(src, dst)" in text)
+    blur_line = next(i for i, text in enumerate(lines) if "Blur(src, dst)" in text)
+    blend_line = next(i for i, text in enumerate(lines) if "blend(src, src)" in text)
+
+    integrate_target = find_definition_target(
+        source,
+        integrate_line,
+        lines[integrate_line].index("Integrate") + 1,
+    )
+    blur_target = find_definition_target(
+        source,
+        blur_line,
+        lines[blur_line].index("Blur") + 1,
+    )
+    blend_target = find_definition_target(
+        source,
+        blend_line,
+        lines[blend_line].index("blend") + 1,
+    )
+
+    assert integrate_target is not None
+    assert (integrate_target.line, integrate_target.column, integrate_target.symbol) == (
+        1,
+        7,
+        "Integrate",
+    )
+
+    assert blur_target is not None
+    assert (blur_target.line, blur_target.column, blur_target.symbol) == (3, 7, "Blur")
+
+    assert blend_target is not None
+    assert (blend_target.line, blend_target.column, blend_target.symbol) == (6, 0, "blend")


### PR DESCRIPTION
### Motivation

- Prevent stale cached analysis contexts and memory leaks by cleaning up document contexts when documents close.
- Ensure diagnostics are emitted immediately on save via `textDocument/didSave` rather than only on debounced change events.
- Make go-to-definition work for callable symbols (`shader`/`filter`/non-intrinsic `pure` functions) in addition to struct member access (`foo.bar`).

### Description

- Add a unified `DefinitionTarget` dataclass and extend `AnalysisContext` with a `callable_index`, and populate it via new helpers `
_offset_to_line_column`, `
_find_callable_definition`, and `
_build_callable_index` in `lockstep_compiler/lsp.py` so callable declarations can be located by source offset.
- Add `find_definition_target` which returns a `DefinitionTarget` and falls back from member-definition resolution to callable-index lookups, and update the LSP definition handler to use it.
- Improve LSP lifecycle handling in `run_lsp_server` by refactoring validation into `_validate(debounced=...)`, adding `textDocument/didSave` to request immediate validation, and adding `textDocument/didClose` to cancel pending validations and clear cached `doc_contexts` and diagnostics.
- Update tests in `tests/test_lsp.py` to import `find_definition_target` and add `test_find_definition_target_resolves_shader_filter_and_pure_function_names` covering callable-definition resolution.

### Testing

- Ran `PYTHONPATH=. pytest -q tests/test_lsp.py` after fixes and the test file passed completely (all tests in `tests/test_lsp.py` succeeded).
- Earlier test runs during development revealed and helped fix a regex escaping error and an import invocation, both of which were resolved before the final test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6e1739c888328ba3b1907a23c13e6)