### PR TITLE
Add minimal end-to-end C host example under examples/

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ The compiler generates a C-compatible header for the Host application (C/C++, Ru
 3. **Prime:** Host writes initial data into the SoA offsets provided by the header.
 4. **Tick:** Host calls `Lockstep_Tick()` to execute the pipeline.
 
+See [`examples/`](examples/) for a minimal end-to-end host app in C (`examples/minimal_host.c`) that includes a generated header, allocates arena memory, primes initial data, and calls `Lockstep_Tick`.
+
 ---
 
 ## 6. Compiler Frontend Usage

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,36 @@
+# Minimal host integration example
+
+This example shows the full host integration loop with generated artifacts:
+
+1. compile a Lockstep source file,
+2. emit LLVM IR + C header,
+3. compile/link with a C host,
+4. allocate arena memory,
+5. initialize data,
+6. call `Lockstep_Tick`.
+
+## Files
+
+- `minimal.lock`: a tiny Lockstep program that declares one stream and one uniform.
+- `minimal_host.c`: a C host that includes the generated header and executes one tick.
+
+## Build and run
+
+From the repository root:
+
+```bash
+mkdir -p examples/build
+lockstepc examples/minimal.lock --emit-ir > examples/build/minimal.ll
+lockstepc examples/minimal.lock --emit-header > examples/build/lockstep_generated.h
+clang -c examples/build/minimal.ll -o examples/build/minimal.o
+clang -std=c11 examples/minimal_host.c examples/build/minimal.o -Iexamples/build -o examples/build/minimal_host
+./examples/build/minimal_host
+```
+
+Expected output:
+
+```text
+After tick: pos=10.00 vel=2.00 dt=0.50
+```
+
+This verifies the generated ABI end-to-end (header + LLVM IR + host application wiring).

--- a/examples/minimal.lock
+++ b/examples/minimal.lock
@@ -1,0 +1,12 @@
+struct Particle {
+    float pos;
+    float vel;
+};
+
+pipeline Demo {
+    stream<Particle, 4> particles;
+    uniform float dt = 0.5;
+
+    bind {
+    }
+}

--- a/examples/minimal_host.c
+++ b/examples/minimal_host.c
@@ -1,0 +1,24 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "lockstep_generated.h"
+
+int main(void) {
+    uint8_t arena_bytes[LOCKSTEP_ARENA_BYTES];
+    memset(arena_bytes, 0, sizeof(arena_bytes));
+
+    struct Lockstep_Arena* arena = (struct Lockstep_Arena*)arena_bytes;
+
+    arena->stream_particles.pos = 10.0f;
+    arena->stream_particles.vel = 2.0f;
+    arena->uniform_dt = 0.5f;
+
+    Lockstep_Tick(arena);
+
+    printf("After tick: pos=%.2f vel=%.2f dt=%.2f\n",
+           arena->stream_particles.pos,
+           arena->stream_particles.vel,
+           arena->uniform_dt);
+    return 0;
+}


### PR DESCRIPTION
### Motivation

- Provide a concrete, minimal host-side example that demonstrates how to use the generated C header and LLVM IR to run a Lockstep pipeline end-to-end so users can validate the emitted ABI and runtime integration.

### Description

- Add `examples/minimal.lock`, a tiny Lockstep program declaring a `Particle` stream and a `dt` uniform for the example flow. 
- Add `examples/minimal_host.c`, a minimal C host that `#include`s the generated header, allocates an arena with `LOCKSTEP_ARENA_BYTES`, primes stream/uniform fields, invokes `Lockstep_Tick`, and prints results. 
- Add `examples/README.md` with step-by-step build/run instructions that show how to generate LLVM IR and the C header and then compile/link the host. 
- Link the new examples directory from the main `README.md` Host Integration section to improve discoverability.

### Testing

- Emitted artifacts with the CLI using `lockstepc examples/minimal.lock --emit-ir` and `--emit-header` and saved outputs to `examples/build`, which completed successfully. 
- Compiled the emitted LLVM IR with `clang -c examples/build/minimal.ll -o examples/build/minimal.o` and built the host with `clang -std=c11 examples/minimal_host.c examples/build/minimal.o -Iexamples/build -o examples/build/minimal_host`, both of which succeeded. 
- Ran the built example binary `./examples/build/minimal_host` and verified it printed the expected output `After tick: pos=10.00 vel=2.00 dt=0.50`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6e1a64f0c83288679a9548319ccc9)