### PR TITLE
Narrow compile_lockstep typed AST fallback to parser-stub incompatibilities

### DIFF
--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -158,7 +158,7 @@ def _compile_lockstep_with_dependencies(
     if debug_visitor_cls is None:
         try:
             typed_ast = build_program_ast(tree, visitor_cls)
-        except Exception:
+        except TypeError:
             # Keep the legacy parse-tree visitor flow for parser stubs used by unit tests.
             typed_ast = None
 

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -112,6 +112,124 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
     assert 'define void @"Lockstep_Tick"()' in result.llvm_ir
 
 
+def test_compile_lockstep_falls_back_to_legacy_flow_on_typed_ast_type_error(
+    monkeypatch,
+):
+    class StubLexer:
+        def __init__(self, input_stream):
+            self.input_stream = input_stream
+
+        def removeErrorListeners(self):
+            pass
+
+        def addErrorListener(self, listener):
+            pass
+
+    class StubParser:
+        def __init__(self, stream):
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            return "TREE"
+
+    class StubVisitor:
+        pass
+
+    class StubDebugVisitor:
+        def __init__(self, verbose=True):
+            self.verbose = verbose
+            self.structs = []
+            self.shaders = []
+            self.filters = []
+            self.pure_functions = []
+            self.streams = []
+            self.accumulators = []
+            self.uniforms = []
+            self.bind_routes = []
+            self.bind_routes_ir = []
+            self.diagnostics = []
+
+        def visit(self, tree):
+            return None
+
+    monkeypatch.setattr(
+        compiler_module,
+        "_load_default_parser_classes",
+        lambda: (StubLexer, StubParser, StubVisitor),
+    )
+    monkeypatch.setattr(
+        compiler_module,
+        "build_program_ast",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            TypeError("stub incompatibility")
+        ),
+    )
+
+    result = lockstep_compiler.compile_lockstep(
+        "pipeline P { }",
+        verbose=False,
+        semantic_validator=lambda _tree: [],
+        token_stream_cls=lambda lexer: object(),
+        debug_visitor_cls=StubDebugVisitor,
+    )
+
+    assert result.ast is None
+    assert result.entities["streams"] == []
+
+
+def test_compile_lockstep_surfaces_typed_ast_builder_bugs(monkeypatch):
+    class StubLexer:
+        def __init__(self, input_stream):
+            self.input_stream = input_stream
+
+        def removeErrorListeners(self):
+            pass
+
+        def addErrorListener(self, listener):
+            pass
+
+    class StubParser:
+        def __init__(self, stream):
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            return "TREE"
+
+    class StubVisitor:
+        pass
+
+    monkeypatch.setattr(
+        compiler_module,
+        "_load_default_parser_classes",
+        lambda: (StubLexer, StubParser, StubVisitor),
+    )
+    monkeypatch.setattr(
+        compiler_module,
+        "build_program_ast",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(KeyError("missing key")),
+    )
+
+    with pytest.raises(KeyError, match="missing key"):
+        lockstep_compiler.compile_lockstep(
+            "pipeline P { }",
+            verbose=False,
+            semantic_validator=lambda _tree: [],
+            token_stream_cls=lambda lexer: object(),
+        )
+
+
 def test_emit_llvm_ir_generates_expected_declarations():
     llvm_ir = emit_llvm_ir(
         {


### PR DESCRIPTION
### Motivation
- Avoid silently swallowing unexpected bugs in the typed-AST builder by limiting the fallback condition to the intended incompatibility case.  The previous `except Exception` caused true errors (e.g. `KeyError`, `AttributeError`) in `build_program_ast` to be hidden and fall back to the legacy visitor.

### Description
- Changed the generic `except Exception` in `compile_lockstep` to `except TypeError` so only `TypeError`-style parser-stub incompatibilities trigger the legacy parse-tree visitor fallback in `lockstep_compiler/compiler.py`.
- Added two regression tests to `tests/test_compiler_api.py`: `test_compile_lockstep_falls_back_to_legacy_flow_on_typed_ast_type_error` and `test_compile_lockstep_surfaces_typed_ast_builder_bugs` to validate the new behavior.
- Files modified: `lockstep_compiler/compiler.py` and `tests/test_compiler_api.py`.

### Testing
- Ran `pytest -q tests/test_compiler_api.py -k "typed_ast or works_without_passing_parser_classes"`, which passed.
- Ran `pytest -q tests/test_compiler_api.py` (full file), which also passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6e1f29ccc832884b57c730148fec2)