### PR TITLE
Add proper LLVM lowering for string literals

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -28,6 +28,7 @@ _PRIMITIVE_TYPE_MAP: dict[str, ir.Type] = {
     "uint": ir.IntType(32),
     "float": ir.FloatType(),
     "double": ir.DoubleType(),
+    "string": ir.IntType(8).as_pointer(),
 }
 
 
@@ -55,6 +56,7 @@ class _FunctionLowerer:
         self.intrinsic_names = intrinsic_names or set()
         self.builder: ir.IRBuilder | None = None
         self.locals: dict[str, ir.AllocaInstr] = {}
+        self._string_literal_counter = 0
 
     def _compiler_error(self, message: str) -> None:
         raise CodegenError(message)
@@ -290,6 +292,30 @@ class _FunctionLowerer:
 
         self._compiler_error(f"operator '{op}' is unsupported for type '{lhs.type}'")
 
+    @staticmethod
+    def _decode_string_literal(token_text: str) -> str:
+        if len(token_text) >= 2 and token_text[0] == '"' and token_text[-1] == '"':
+            token_text = token_text[1:-1]
+        return bytes(token_text, "utf-8").decode("unicode_escape")
+
+    def _lower_string_literal(self, token_text: str) -> ir.Value:
+        decoded = self._decode_string_literal(token_text)
+        payload = decoded.encode("utf-8") + b"\x00"
+        array_type = ir.ArrayType(ir.IntType(8), len(payload))
+        global_name = f".str.{self._string_literal_counter}"
+        self._string_literal_counter += 1
+        global_value = ir.GlobalVariable(self.module, array_type, name=global_name)
+        global_value.global_constant = True
+        global_value.linkage = "private"
+        global_value.unnamed_addr = True
+        global_value.initializer = ir.Constant(array_type, bytearray(payload))
+        return self.builder.gep(
+            global_value,
+            [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), 0)],
+            inbounds=True,
+            name="strptr",
+        )
+
     def _emit_relational_compare(
         self, op: str, lhs: ir.Value, rhs: ir.Value
     ) -> ir.Value:
@@ -389,6 +415,8 @@ class _FunctionLowerer:
                 return ir.Constant(ir.FloatType(), float(node.value))
             if node.kind == "int":
                 return ir.Constant(ir.IntType(32), int(node.value))
+            if node.kind == "string":
+                return self._lower_string_literal(node.value)
             return ir.Constant(ir.IntType(1), int(node.value == "true"))
         if isinstance(node, AstExprVar):
             return self._load_var(".".join(node.path))

--- a/tests/test_type_syntax.py
+++ b/tests/test_type_syntax.py
@@ -76,7 +76,7 @@ pipeline Main {
     assert "no viable alternative" in exc_info.value.errors[0].message
 
 
-def test_dependency_declarations_and_string_literals_compile_successfully(monkeypatch):
+def test_dependency_declarations_and_string_literals_compile_successfully():
     source = """
 import "core/math.lock";
 #include "runtime/platform.lock";
@@ -92,15 +92,9 @@ pipeline Main {
 }
 """
 
-    monkeypatch.setattr(
-        "lockstep_compiler.compiler.emit_llvm_ir", lambda *_args, **_kwargs: "; mock"
-    )
-    monkeypatch.setattr(
-        "lockstep_compiler.compiler.emit_c_header",
-        lambda *_args, **_kwargs: "/* mock */",
-    )
-
     result = compile_lockstep(source, verbose=False)
 
     assert all(diag.severity != "error" for diag in result.diagnostics)
     assert any(uniform["type"] == "string" for uniform in result.entities["uniforms"])
+    assert "private unnamed_addr constant" in result.llvm_ir
+    assert "c\"asset://textures/noise\\00\"" in result.llvm_ir


### PR DESCRIPTION
### Motivation

- The codegen previously lacked first-class handling for `string` types and string literals, causing strings to fall through to the unknown-type path and produce confusing IR/coercion errors at compile time. 
- The existing test only passed because it monkeypatched `emit_llvm_ir`/`emit_c_header`, so real lowering of string literals was untested and broken.

### Description

- Add a `string` primitive mapping in `_PRIMITIVE_TYPE_MAP` to `i8*` so `string` is treated explicitly in lowering. 
- Implement real string-literal lowering: decode/unescape token text, emit a private `unnamed_addr` null-terminated global byte array, and return an `i8*` pointer via a `getelementptr` (unique global names tracked with a counter). 
- Wire string-literal lowering into `_lower_expr` so `AstExprLiteral(kind="string")` yields an `i8*` value suitable for assignments/returns/calls. 
- Update the regression test to remove the monkeypatches and assert the generated LLVM IR contains the emitted string constant and private global metadata.

### Testing

- Ran `pytest -q tests/test_type_syntax.py::test_dependency_declarations_and_string_literals_compile_successfully`, which passed. 
- Ran `pytest -q tests/test_type_syntax.py`, which passed. 
- Performed a manual compile invocation via `compile_lockstep(...)` to inspect emitted IR for a `pure string` function and string literals, and verified the IR contains the `private unnamed_addr constant` string global and expected `c"...\00"` payload.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6e237008883288f964a15afdfa624)