### PR TITLE
Make LLVM fold SIMD width target-dependent

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from llvmlite import ir
+from llvmlite import binding, ir
 
 from .ast import (
     AstAssignStmt,
@@ -536,10 +536,29 @@ def _ast_body_for(entity: dict[str, Any], *, entity_kind: str) -> list[AstStatem
     return body_ast
 
 
+def _simd_width_for_target(target_triple: str | None) -> int:
+    triple = (target_triple or "").strip().lower()
+    arch = triple.split("-", 1)[0]
+
+    if arch in {"x86_64", "amd64"}:
+        return 8
+    if arch in {"x86", "i386", "i486", "i586", "i686"}:
+        return 4
+    if arch in {"aarch64", "arm64", "arm", "thumb", "wasm32", "wasm64"}:
+        return 4
+    if arch.startswith("riscv"):
+        return 4
+    return 4
+
+
 def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
     """Generate LLVM IR using llvmlite lowering for pure/kernels."""
 
     entities = _normalize_codegen_input(program_or_entities)
+    target_triple = entities.get("target_triple")
+    if not isinstance(target_triple, str) or not target_triple.strip():
+        target_triple = binding.get_default_triple()
+    simd_width = _simd_width_for_target(target_triple)
 
     structs = entities.get("structs", [])
     shaders = entities.get("shaders", [])
@@ -762,8 +781,6 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
 
     tick_entry = tick.append_basic_block("entry")
     tick_builder = ir.IRBuilder(tick_entry)
-    simd_width = 8
-
     def _zero_value(llvm_type: ir.Type) -> ir.Value:
         if isinstance(llvm_type, ir.VoidType):
             return ir.Constant(ir.IntType(32), 0)

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -734,6 +734,58 @@ def test_emit_llvm_ir_lowers_fold_routes_to_vector_reduce_intrinsics():
     assert 'store float %"fold_reduce", float* %"arena_slot_1"' in llvm_ir
 
 
+def test_emit_llvm_ir_selects_target_dependent_simd_width_for_fold_intrinsics():
+    ir_x86 = emit_llvm_ir(
+        {
+            "structs": [],
+            "pure_functions": [],
+            "shaders": [],
+            "filters": [],
+            "streams": [],
+            "accumulators": [{"name": "energy", "type": "float"}],
+            "uniforms": [{"name": "total", "type": "float"}],
+            "bind_routes": ["uniform float total = fold sum(energy);"],
+            "bind_routes_ir": [
+                {
+                    "kind": "fold",
+                    "uniform_type": "float",
+                    "uniform_name": "total",
+                    "operator": "sum",
+                    "source": "energy",
+                    "route": "uniform float total = fold sum(energy);",
+                }
+            ],
+            "target_triple": "x86_64-unknown-linux-gnu",
+        }
+    )
+    ir_arm = emit_llvm_ir(
+        {
+            "structs": [],
+            "pure_functions": [],
+            "shaders": [],
+            "filters": [],
+            "streams": [],
+            "accumulators": [{"name": "energy", "type": "float"}],
+            "uniforms": [{"name": "total", "type": "float"}],
+            "bind_routes": ["uniform float total = fold sum(energy);"],
+            "bind_routes_ir": [
+                {
+                    "kind": "fold",
+                    "uniform_type": "float",
+                    "uniform_name": "total",
+                    "operator": "sum",
+                    "source": "energy",
+                    "route": "uniform float total = fold sum(energy);",
+                }
+            ],
+            "target_triple": "aarch64-unknown-linux-gnu",
+        }
+    )
+
+    assert 'call fast float @"llvm.vector.reduce.fadd.v8f32"' in ir_x86
+    assert 'call fast float @"llvm.vector.reduce.fadd.v4f32"' in ir_arm
+
+
 def test_emit_llvm_ir_raises_on_mixed_int_float_expression():
     with pytest.raises(CodegenError, match="requires matching operand types"):
         emit_llvm_ir(


### PR DESCRIPTION
### Motivation
- The LLVM codegen used a hardcoded SIMD lane width of `8`, which is incorrect for non-x86 targets and prevents generating target-appropriate vector reduction intrinsics.

### Description
- Import `llvmlite.binding` and add a `_simd_width_for_target(target_triple)` helper to map canonical target triples to a SIMD lane width (returns `8` for `x86_64`/`amd64`, `4` for common ARM/RISCV/wasm/32-bit x86 variants, fallback `4`).
- Update `emit_llvm_ir(...)` to accept a `target_triple` key in the entities map (falling back to `binding.get_default_triple()` when missing) and compute `simd_width` from the helper instead of the previous hardcoded `simd_width = 8`.
- Remove the hardcoded `simd_width` and use the computed `simd_width` when building vector splats and selecting the `llvm.vector.reduce.*.v{N}...` intrinsic names.
- Add a regression test `test_emit_llvm_ir_selects_target_dependent_simd_width_for_fold_intrinsics` in `tests/test_compiler_api.py` that asserts `x86_64` emits `v8f32` and `aarch64` emits `v4f32` reductions.

### Testing
- Ran `pytest -q tests/test_compiler_api.py -k "fold_routes_to_vector_reduce_intrinsics or target_dependent_simd_width"`, which executed the existing fold reduction test and the new target-dependent SIMD test and both passed (2 tests, `..`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7296a49208328922e42db696dda69)