### PR TITLE
Simulator: run fold reductions out-of-process via clang/lli with fallback

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,16 +50,17 @@ The `--emit-header` flag produces a C header file containing struct definitions,
 - **Identifier injection.** Struct names, stream names, and field names from the Lockstep source are embedded in the C header as identifiers and macro names. The `sanitize_symbol()` utility restricts identifiers to `[A-Za-z0-9_]`, but adversarial identifiers in the source could produce confusing or conflicting macro definitions (for example, a stream named `ARENA_BYTES` would collide with `LOCKSTEP_ARENA_BYTES`). Macro names are prefixed with `LOCKSTEP_` to reduce collision risk, but no namespace isolation is enforced.
 - **Integer overflow in arena size calculation.** The arena byte-offset computation sums field sizes without overflow checking. A source program declaring extremely large stream capacities (for example, `stream<Entity, 4294967295>`) could produce a `LOCKSTEP_ARENA_BYTES` value that overflows the host platform's `size_t`. The host application is responsible for validating the arena size before allocation.
 
-### Pipeline simulator and JIT execution
+### Pipeline simulator and subprocess reduction execution
 
-The `--simulate` flag executes a lightweight simulation of the pipeline's bind routes to validate wiring and cardinality. Fold reductions (`fold sum`, `fold avg`) are JIT-compiled via `llvmlite`'s MCJIT engine and executed in-process.
+The `--simulate` flag executes a lightweight simulation of the pipeline's bind routes to validate wiring and cardinality. Fold reductions (`fold sum`, `fold avg`) are lowered to LLVM IR in-process, written to a temporary file, and executed via an external subprocess (`clang`-compiled executable when available, otherwise `lli`).
 
 **Trust assumption:** The simulator operates on data derived from the developer's own source program. It is a development-time validation tool, not a production execution environment.
 
 **Known risks:**
 
-- **In-process native code execution.** The JIT compiler generates and executes native machine code within the Python process. There is no sandboxing, no address space isolation, and no resource limiting. A bug in the JIT code generation path (for example, incorrect buffer sizing for the fold input array) could cause memory corruption in the compiler process. This is the highest-severity risk in the current toolchain.
-- **No timeout or resource limits.** The simulator does not limit execution time or memory consumption. A program with very large stream capacities could cause the simulator to allocate excessive memory for the fold input buffer.
+- **Native-code execution still occurs, but out-of-process.** The simulator no longer executes generated native code in the compiler process address space. This removes the highest-severity in-process memory-corruption risk from MCJIT execution. However, a subprocess still executes generated code and therefore still carries host-level execution risk if used on untrusted input.
+- **Toolchain dependency and fallback behavior.** Subprocess execution depends on `clang` or `lli` being present at runtime. If neither is available (or subprocess compilation/execution fails), the simulator falls back to Python `sum` semantics for numeric folds to preserve simulator availability.
+- **Timeout-bounded subprocesses.** Compilation and execution subprocess calls are timeout-bounded to reduce runaway execution risk, but they are not cgroup/namespace isolated by Lockstep itself.
 
 ### LSP server
 
@@ -85,7 +86,7 @@ Lockstep depends on two runtime packages:
 - **antlr4-python3-runtime** — the ANTLR4 parser runtime for Python. This is a widely used, mature package maintained by the ANTLR project.
 - **llvmlite** — Python bindings for LLVM, maintained by the Numba project. This package ships platform-specific binary wheels containing compiled LLVM libraries.
 
-Both dependencies are sourced from PyPI. Lockstep does not vendor either dependency. A supply-chain compromise of either package would directly affect Lockstep's security, particularly `llvmlite` which provides the JIT execution capability.
+Both dependencies are sourced from PyPI. Lockstep does not vendor either dependency. A supply-chain compromise of either package would directly affect Lockstep's security, particularly `llvmlite` which is used to construct LLVM IR for code generation and simulator fold reductions.
 
 The optional `lsp` dependency group adds `pygls` and `lsprotocol`, which are used only by the LSP server and do not affect compiler output.
 
@@ -94,7 +95,7 @@ The optional `lsp` dependency group adds `pygls` and `lsprotocol`, which are use
 The following improvements are planned for future releases:
 
 - **Input size and complexity limits** for the parser frontend (maximum file size, maximum nesting depth, parse timeout).
-- **Sandboxed JIT execution** for the simulator, either via subprocess isolation or by replacing in-process MCJIT with out-of-process compilation and execution.
+- **Stronger process isolation** for simulator subprocesses (for example, optional namespace/cgroup sandboxing when available).
 - **Formal verification** of the `noalias` correctness invariant, confirming that the memory model guarantees no pointer aliasing across all valid Lockstep programs.
 - **Dependency pinning and hash verification** in the build system.
 - **Automated dependency vulnerability scanning** via Dependabot or similar tooling in CI.

--- a/lockstep_compiler/simulator.py
+++ b/lockstep_compiler/simulator.py
@@ -1,10 +1,12 @@
 import json
-import ctypes
 from dataclasses import dataclass
 from functools import lru_cache
+import shutil
+import subprocess
+import tempfile
 from typing import Any
 
-from llvmlite import binding, ir
+from llvmlite import ir
 
 from .compiler import compile_lockstep
 
@@ -33,19 +35,7 @@ def _fold_values(operator: str, values: list[Any]) -> Any:
     return None
 
 
-@lru_cache(maxsize=1)
-def _get_execution_engine() -> Any:
-    binding.initialize()
-    binding.initialize_native_target()
-    binding.initialize_native_asmprinter()
-    target = binding.Target.from_default_triple()
-    target_machine = target.create_target_machine()
-    backing_module = binding.parse_assembly("")
-    return binding.create_mcjit_compiler(backing_module, target_machine)
-
-
-@lru_cache(maxsize=1)
-def _jit_reduce_callable() -> Any:
+def _build_reduce_program_ir(values: list[float]) -> str:
     module = ir.Module(name="lockstep_simulator_fold")
     float_ty = ir.DoubleType()
     int_ty = ir.IntType(32)
@@ -86,17 +76,83 @@ def _jit_reduce_callable() -> Any:
     builder.position_at_end(loop_exit)
     builder.ret(acc_phi)
 
-    llvm_module = binding.parse_assembly(str(module))
-    llvm_module.verify()
-    engine = _get_execution_engine()
-    engine.add_module(llvm_module)
-    engine.finalize_object()
-    address = engine.get_function_address("lockstep_fold_sum")
-    if address == 0:
-        raise RuntimeError("failed to JIT compile lockstep_fold_sum")
-    return ctypes.CFUNCTYPE(
-        ctypes.c_double, ctypes.POINTER(ctypes.c_double), ctypes.c_int32
-    )(address)
+    array_ty = ir.ArrayType(float_ty, len(values))
+    data_const = ir.Constant(array_ty, values)
+    data_global = ir.GlobalVariable(module, array_ty, name="fold_data")
+    data_global.global_constant = True
+    data_global.initializer = data_const
+
+    printf_ty = ir.FunctionType(int_ty, [ir.IntType(8).as_pointer()], var_arg=True)
+    printf = ir.Function(module, printf_ty, name="printf")
+
+    fmt_ty = ir.ArrayType(ir.IntType(8), 7)
+    fmt_const = ir.Constant(fmt_ty, bytearray(b"%.17g\n\x00"))
+    fmt_global = ir.GlobalVariable(module, fmt_ty, name="fmt")
+    fmt_global.global_constant = True
+    fmt_global.initializer = fmt_const
+
+    main_ty = ir.FunctionType(int_ty, [])
+    main_fn = ir.Function(module, main_ty, name="main")
+    main_entry = main_fn.append_basic_block("entry")
+    main_builder = ir.IRBuilder(main_entry)
+
+    zero = ir.Constant(int_ty, 0)
+    data_ptr = main_builder.gep(data_global, [zero, zero], inbounds=True)
+    sum_value = main_builder.call(
+        function,
+        [data_ptr, ir.Constant(int_ty, len(values))],
+        name="sum_value",
+    )
+    fmt_ptr = main_builder.gep(fmt_global, [zero, zero], inbounds=True)
+    main_builder.call(printf, [fmt_ptr, sum_value])
+    main_builder.ret(zero)
+
+    return str(module)
+
+
+@lru_cache(maxsize=1)
+def _simulator_runtime_command() -> tuple[str, ...] | None:
+    clang_path = shutil.which("clang")
+    if clang_path:
+        return (clang_path,)
+    lli_path = shutil.which("lli")
+    if lli_path:
+        return (lli_path,)
+    return None
+
+
+def _run_reduce_subprocess(values: list[float]) -> float:
+    command = _simulator_runtime_command()
+    if command is None:
+        raise RuntimeError("missing clang/lli runtime toolchain")
+
+    with tempfile.TemporaryDirectory(prefix="lockstep-sim-") as temp_dir:
+        ir_path = f"{temp_dir}/fold.ll"
+        with open(ir_path, "w", encoding="utf-8") as handle:
+            handle.write(_build_reduce_program_ir(values))
+
+        if len(command) == 1 and "clang" in command[0].split("/")[-1]:
+            exe_path = f"{temp_dir}/fold_reduce"
+            subprocess.run(
+                [command[0], "-O2", ir_path, "-o", exe_path],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            run_command = [exe_path]
+        else:
+            run_command = [command[0], ir_path]
+
+        completed = subprocess.run(
+            run_command,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+    return float(completed.stdout.strip())
 
 
 def _jit_numeric_reduce(operator: str, values: list[Any]) -> Any:
@@ -105,9 +161,7 @@ def _jit_numeric_reduce(operator: str, values: list[Any]) -> Any:
         return None
 
     try:
-        reduce_fn = _jit_reduce_callable()
-        raw_values = (ctypes.c_double * len(numeric_values))(*numeric_values)
-        reduced = float(reduce_fn(raw_values, len(numeric_values)))
+        reduced = _run_reduce_subprocess(numeric_values)
     except Exception:
         reduced = float(sum(numeric_values))
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -332,8 +332,8 @@ def test_fold_values_uses_jit_reduce_for_sum_and_avg(monkeypatch):
 
 def test_jit_numeric_reduce_falls_back_to_python_sum_on_error(monkeypatch):
     monkeypatch.setattr(
-        "lockstep_compiler.simulator._jit_reduce_callable",
-        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        "lockstep_compiler.simulator._run_reduce_subprocess",
+        lambda _values: (_ for _ in ()).throw(RuntimeError("boom")),
     )
 
     assert (


### PR DESCRIPTION
### Motivation
- Eliminate the security risk of in-process native code execution via `llvmlite` MCJIT by moving reduction execution to a subprocess. 
- Preserve simulator availability with a resilient fallback when external toolchain invocation fails.

### Description
- Replaced the MCJIT-based in-process reduction path with an LLVM-IR writer and subprocess runner that emits a small module to a temp file and runs it with `clang` (preferred) or `lli` as a fallback using `_build_reduce_program_ir`, `_simulator_runtime_command`, and `_run_reduce_subprocess`.
- Removed `llvmlite.binding`/`ctypes` based JIT plumbing and instead construct IR with `llvmlite.ir` only, then parse numeric result from subprocess stdout; added discovery of `clang`/`lli` via `shutil.which` and a 5s timeout on compile/run subprocesses.
- Kept safe fallback behavior by catching subprocess errors and falling back to Python `sum` semantics in `_jit_numeric_reduce`.
- Updated tests to patch the new subprocess reducer hook (`_run_reduce_subprocess`) and refreshed `SECURITY.md` text to document the out-of-process execution model and revised risk posture.

### Testing
- Ran `pytest -q tests/test_simulator.py`, which completed successfully with all tests passing.
- Unit tests updated to monkeypatch `lockstep_compiler.simulator._run_reduce_subprocess` to validate the fallback path, and those tests passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b729ea084483289c2fbc02761e3f45)