### PR TITLE
Use typed AstProgram as single source-of-truth for internal compiler passes

### DIFF
--- a/lockstep_compiler/ast.py
+++ b/lockstep_compiler/ast.py
@@ -145,6 +145,7 @@ class AstPureDecl:
     return_type: AstType
     params: tuple[AstKernelParam, ...] = ()
     body: tuple[AstStatement, ...] = ()
+    intrinsic: bool = False
     location: AstLocation = AstLocation()
 
     def __post_init__(self):
@@ -792,6 +793,7 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                 ],
                 "body": [_statement_to_text(statement) for statement in pure.body],
                 "body_ast": list(pure.body),
+                "intrinsic": pure.intrinsic,
             }
             for pure in program.pure_functions
         ],

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -4,71 +4,51 @@ from typing import Any
 
 from antlr4 import CommonTokenStream, InputStream
 
-from .ast import ast_to_entities, build_program_ast
+from .ast import AstKernelParam, AstProgram, AstPureDecl, AstType, ast_to_entities, build_program_ast
 from .c_header import emit_c_header
 from .codegen import CodegenError, emit_llvm_ir
 from .errors import LockstepCompileError, ParseErrorCollector
 from .models import (
-    IntrinsicSignature,
     LockstepCompileResult,
     LockstepDiagnostic,
-    PureFunctionEntity,
-    PureFunctionParamEntity,
     normalize_diagnostics,
 )
 from .optimizer import optimize_bind_routes
 from .prelude import load_intrinsics
-from .visitors import build_debug_visitor, validate_semantics as _validate_semantics
+from .visitors import validate_semantics as _validate_semantics
 
 
 DEFAULT_SOURCE_FILE = "<stdin>"
 
 
-def _intrinsic_to_entity(intrinsic: IntrinsicSignature) -> PureFunctionEntity:
-    return PureFunctionEntity(
-        name=intrinsic.name,
-        return_type=intrinsic.return_type,
-        params=tuple(
-            PureFunctionParamEntity(type=param.type_name, name=param.name)
-            for param in intrinsic.params
-        ),
-        body=(),
-        intrinsic=True,
+def _merge_intrinsic_pure_functions_into_ast(program: AstProgram) -> AstProgram:
+    existing_names = {pure.name for pure in program.pure_functions}
+    intrinsic_decls = tuple(
+        AstPureDecl(
+            name=intrinsic.name,
+            return_type=AstType(name=intrinsic.return_type, kind="primitive"),
+            params=tuple(
+                AstKernelParam(
+                    modifier="value",
+                    declared_type=AstType(name=param.type_name, kind="primitive"),
+                    name=param.name,
+                )
+                for param in intrinsic.params
+            ),
+            intrinsic=True,
+        )
+        for intrinsic in load_intrinsics().values()
+        if intrinsic.name not in existing_names
     )
-
-
-def _pure_function_name(entity: dict[str, Any] | PureFunctionEntity) -> str | None:
-    if isinstance(entity, PureFunctionEntity):
-        return entity.name
-    if isinstance(entity, dict):
-        value = entity.get("name")
-        return value if isinstance(value, str) else None
-    return None
-
-
-def _normalize_pure_function_entity(
-    entity: dict[str, Any] | PureFunctionEntity,
-) -> dict[str, Any] | PureFunctionEntity:
-    if isinstance(entity, PureFunctionEntity):
-        return entity
-    if isinstance(entity, dict):
-        return entity
-    return {}
-
-
-def _merge_intrinsic_pure_functions(
-    pure_functions: list[dict[str, Any] | PureFunctionEntity],
-) -> list[dict[str, Any] | PureFunctionEntity]:
-    merged: dict[str, dict[str, Any] | PureFunctionEntity] = {}
-    for pure_function in pure_functions:
-        normalized = _normalize_pure_function_entity(pure_function)
-        name = _pure_function_name(normalized)
-        if name is not None:
-            merged[name] = normalized
-    for name, intrinsic in load_intrinsics().items():
-        if name not in merged:
-            merged[name] = _intrinsic_to_entity(intrinsic)
-    return list(merged.values())
+    if not intrinsic_decls:
+        return program
+    return AstProgram(
+        structs=program.structs,
+        shaders=program.shaders,
+        filters=program.filters,
+        pure_functions=(*program.pure_functions, *intrinsic_decls),
+        pipelines=program.pipelines,
+    )
 
 
 def _line_count(source: str) -> int:
@@ -177,16 +157,14 @@ def _compile_lockstep_with_dependencies(
             source_file=parse_errors[0].source_file if parse_errors else source_file,
         )
 
-    typed_ast = None
-    if debug_visitor_cls is None:
-        try:
-            typed_ast = build_program_ast(tree, visitor_cls)
-        except TypeError:
-            # Keep the legacy parse-tree visitor flow for parser stubs used by unit tests.
-            typed_ast = None
+    typed_ast = _merge_intrinsic_pure_functions_into_ast(
+        build_program_ast(tree, visitor_cls)
+    )
 
     semantic_validator = semantic_validator or (
-        lambda parse_tree: validate_semantics(parse_tree, visitor_cls)
+        lambda parse_tree, *, typed_ast: validate_semantics(
+            parse_tree, visitor_cls, typed_ast=typed_ast
+        )
     )
     try:
         semantic_diagnostics = normalize_diagnostics(
@@ -208,41 +186,9 @@ def _compile_lockstep_with_dependencies(
             source_file=semantic_errors[0].source_file,
         )
 
-    debug_diagnostics = []
-    entities = None
-    if typed_ast is not None:
-        entities = ast_to_entities(typed_ast)
-    else:
-        debug_visitor_cls = debug_visitor_cls or build_debug_visitor(visitor_cls)
-        visitor = debug_visitor_cls(verbose=verbose)
-        visitor.visit(tree)
-        debug_diagnostics = _remap_diagnostics(
-            visitor.diagnostics,
-            source_map=source_map,
-            default_source_file=source_file,
-        )
-        entities = {
-            "structs": visitor.structs,
-            "shaders": visitor.shaders,
-            "filters": visitor.filters,
-            "pure_functions": visitor.pure_functions,
-            "streams": visitor.streams,
-            "accumulators": visitor.accumulators,
-            "uniforms": visitor.uniforms,
-            "bind_routes": visitor.bind_routes,
-            "bind_routes_ir": getattr(visitor, "bind_routes_ir", []),
-        }
+    entities = ast_to_entities(typed_ast)
 
-    entities["pure_functions"] = [
-        pure_function.to_dict()
-        if isinstance(pure_function, PureFunctionEntity)
-        else pure_function
-        for pure_function in _merge_intrinsic_pure_functions(
-            entities.get("pure_functions", [])
-        )
-    ]
-
-    all_diagnostics = normalize_diagnostics([*semantic_diagnostics, *debug_diagnostics])
+    all_diagnostics = normalize_diagnostics(semantic_diagnostics)
     bind_optimization = optimize_bind_routes(
         entities["bind_routes"],
         shader_names={shader["name"] for shader in entities["shaders"]},
@@ -256,7 +202,7 @@ def _compile_lockstep_with_dependencies(
     }
 
     try:
-        llvm_ir = emit_llvm_ir(typed_ast or entities)
+        llvm_ir = emit_llvm_ir(typed_ast)
     except CodegenError as error:
         codegen_diagnostic = LockstepDiagnostic(
             severity="error",
@@ -279,7 +225,7 @@ def _compile_lockstep_with_dependencies(
         entities=entities,
         ast=typed_ast,
         llvm_ir=llvm_ir,
-        c_header=emit_c_header(typed_ast or entities),
+        c_header=emit_c_header(typed_ast),
         diagnostics=all_diagnostics,
     )
 
@@ -298,10 +244,10 @@ def load_default_parser_classes() -> tuple[Any, Any, Any]:
     return LockstepLexer, LockstepParser, LockstepVisitor
 
 
-def validate_semantics(parse_tree: Any, visitor_cls=None):
+def validate_semantics(parse_tree: Any, visitor_cls=None, *, typed_ast=None):
     if visitor_cls is None:
         _, _, visitor_cls = load_default_parser_classes()
-    return _validate_semantics(parse_tree, visitor_cls)
+    return _validate_semantics(parse_tree, visitor_cls, typed_ast=typed_ast)
 
 
 def compile_lockstep(

--- a/lockstep_compiler/semantic_validator.py
+++ b/lockstep_compiler/semantic_validator.py
@@ -1508,6 +1508,8 @@ def build_semantic_validator(base_visitor_cls):
     return LockstepSemanticValidator
 
 
-def validate_semantics(parse_tree: Any, visitor_cls) -> list[LockstepDiagnostic]:
+def validate_semantics(
+    parse_tree: Any, visitor_cls, *, typed_ast=None
+) -> list[LockstepDiagnostic]:
     validator = build_semantic_validator(visitor_cls)()
     return validator.validate(parse_tree)

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -53,7 +53,8 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
             return "TREE"
 
     class StubVisitor:
-        pass
+        def visit(self, _tree):
+            return None
 
     class StubDebugVisitor:
         def __init__(self, verbose=True):
@@ -81,7 +82,7 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
     result = lockstep_compiler.compile_lockstep(
         "pipeline P { }",
         verbose=False,
-        semantic_validator=lambda _tree: [],
+        semantic_validator=lambda _tree, **_kwargs: [],
         token_stream_cls=lambda lexer: object(),
         debug_visitor_cls=StubDebugVisitor,
     )
@@ -112,7 +113,7 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
     assert 'define void @"Lockstep_Tick"()' in result.llvm_ir
 
 
-def test_compile_lockstep_falls_back_to_legacy_flow_on_typed_ast_type_error(
+def test_compile_lockstep_surfaces_typed_ast_type_error_without_legacy_fallback(
     monkeypatch,
 ):
     class StubLexer:
@@ -139,7 +140,8 @@ def test_compile_lockstep_falls_back_to_legacy_flow_on_typed_ast_type_error(
             return "TREE"
 
     class StubVisitor:
-        pass
+        def visit(self, _tree):
+            return None
 
     class StubDebugVisitor:
         def __init__(self, verbose=True):
@@ -171,16 +173,14 @@ def test_compile_lockstep_falls_back_to_legacy_flow_on_typed_ast_type_error(
         ),
     )
 
-    result = lockstep_compiler.compile_lockstep(
-        "pipeline P { }",
-        verbose=False,
-        semantic_validator=lambda _tree: [],
-        token_stream_cls=lambda lexer: object(),
-        debug_visitor_cls=StubDebugVisitor,
-    )
-
-    assert result.ast is None
-    assert result.entities["streams"] == []
+    with pytest.raises(TypeError, match="stub incompatibility"):
+        lockstep_compiler.compile_lockstep(
+            "pipeline P { }",
+            verbose=False,
+            semantic_validator=lambda _tree, **_kwargs: [],
+            token_stream_cls=lambda lexer: object(),
+            debug_visitor_cls=StubDebugVisitor,
+        )
 
 
 def test_compile_lockstep_surfaces_typed_ast_builder_bugs(monkeypatch):
@@ -208,7 +208,8 @@ def test_compile_lockstep_surfaces_typed_ast_builder_bugs(monkeypatch):
             return "TREE"
 
     class StubVisitor:
-        pass
+        def visit(self, _tree):
+            return None
 
     monkeypatch.setattr(
         compiler_module,
@@ -225,7 +226,7 @@ def test_compile_lockstep_surfaces_typed_ast_builder_bugs(monkeypatch):
         lockstep_compiler.compile_lockstep(
             "pipeline P { }",
             verbose=False,
-            semantic_validator=lambda _tree: [],
+            semantic_validator=lambda _tree, **_kwargs: [],
             token_stream_cls=lambda lexer: object(),
         )
 
@@ -525,7 +526,8 @@ def test_compile_lockstep_wraps_codegen_errors_with_compile_error(monkeypatch):
             return "TREE"
 
     class StubVisitor:
-        pass
+        def visit(self, _tree):
+            return None
 
     class StubDebugVisitor:
         def __init__(self, verbose=True):
@@ -570,7 +572,7 @@ def test_compile_lockstep_wraps_codegen_errors_with_compile_error(monkeypatch):
             "pipeline Main { bind { } }",
             source_file="main.lock",
             verbose=False,
-            semantic_validator=lambda _tree: [],
+            semantic_validator=lambda _tree, **_kwargs: [],
             token_stream_cls=lambda lexer: object(),
             debug_visitor_cls=StubDebugVisitor,
         )
@@ -580,7 +582,7 @@ def test_compile_lockstep_wraps_codegen_errors_with_compile_error(monkeypatch):
     assert [diag.code for diag in error.errors] == ["LCK501"]
     assert error.errors[0].message == "undefined variable 'missing'"
     assert error.errors[0].source_file == "main.lock"
-    assert {diag.code for diag in error.diagnostics} == {"LCK421", "LCK501"}
+    assert {diag.code for diag in error.diagnostics} == {"LCK501"}
 
 
 def test_emit_llvm_ir_accepts_ast_program_input():
@@ -941,7 +943,8 @@ def test_compile_result_includes_c_header(monkeypatch):
             return "TREE"
 
     class StubVisitor:
-        pass
+        def visit(self, _tree):
+            return None
 
     class StubDebugVisitor:
         def __init__(self, verbose=True):
@@ -969,12 +972,12 @@ def test_compile_result_includes_c_header(monkeypatch):
     result = lockstep_compiler.compile_lockstep(
         "pipeline P { }",
         verbose=False,
-        semantic_validator=lambda _tree: [],
+        semantic_validator=lambda _tree, **_kwargs: [],
         token_stream_cls=lambda lexer: object(),
         debug_visitor_cls=StubDebugVisitor,
     )
 
-    assert "#define LOCKSTEP_ARENA_BYTES 4" in result.c_header
+    assert "#define LOCKSTEP_ARENA_BYTES 0" in result.c_header
     assert "void Lockstep_Tick(struct Lockstep_Arena* arena);" in result.c_header
 
 


### PR DESCRIPTION
### Motivation
- Eliminate the legacy entity-dictionary fallback so downstream phases (validation, codegen, header emission) consume a single, typed AST representation instead of ad-hoc dicts.
- Preserve builtin intrinsics while keeping the AST authoritative by ensuring intrinsic pure functions are present on the `AstProgram` passed through the pipeline.
- Keep the semantic validator and codegen interfaces compatible while removing implicit conversions and dual-representation complexity.

### Description
- Require a typed `AstProgram` as the internal handoff by always building an `AstProgram` via `build_program_ast` and merging intrinsics into it with `_merge_intrinsic_pure_functions_into_ast` before validation and codegen.
- Extend `AstPureDecl` with an `intrinsic: bool` flag and include that flag in `ast_to_entities` so entity exports retain intrinsic metadata.
- Replace the legacy debug-visitor / entity-dict fallback in `compiler.py` so `emit_llvm_ir` and `emit_c_header` are invoked from the typed AST and `entities` are derived from `ast_to_entities(typed_ast)`.
- Update the semantic validator entrypoint to accept `typed_ast` as a keyword for compatibility and adjust compiler test stubs and expectations to match the AST-first flow.

### Testing
- Ran `pytest -q tests/test_compiler_api.py -q` and all tests in that file passed.
- Ran `pytest -q tests/test_improvements.py tests/test_optimizer.py -q` and both test modules passed.
- Ran `python -m py_compile lockstep_compiler/*.py tests/test_compiler_api.py` to validate source-level syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b729cf0f4483289e02910bf37ae19b)