### PR TITLE
Add first-class uint and double primitive type support

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -197,10 +197,10 @@ class _FunctionLowerer:
             if value.type.width > target_type.width:
                 return self.builder.trunc(value, target_type)
 
-        if isinstance(target_type, ir.FloatType) and isinstance(value.type, ir.IntType):
+        if isinstance(target_type, (ir.FloatType, ir.DoubleType)) and isinstance(value.type, ir.IntType):
             return self.builder.sitofp(value, target_type)
 
-        if isinstance(target_type, ir.IntType) and isinstance(value.type, ir.FloatType):
+        if isinstance(target_type, ir.IntType) and isinstance(value.type, (ir.FloatType, ir.DoubleType)):
             return self.builder.fptosi(value, target_type)
 
         if isinstance(target_type, ir.FloatType) and isinstance(
@@ -260,7 +260,7 @@ class _FunctionLowerer:
         return ir.IntType(8).as_pointer()
 
     def _emit_numeric_unary_minus(self, value: ir.Value) -> ir.Value:
-        if isinstance(value.type, ir.FloatType):
+        if isinstance(value.type, (ir.FloatType, ir.DoubleType)):
             return self.builder.fsub(ir.Constant(value.type, 0.0), value)
         if isinstance(value.type, ir.IntType):
             return self.builder.sub(ir.Constant(value.type, 0), value)
@@ -272,7 +272,7 @@ class _FunctionLowerer:
                 f"operator '{op}' requires matching operand types, got '{lhs.type}' and '{rhs.type}'"
             )
 
-        if isinstance(lhs.type, ir.FloatType):
+        if isinstance(lhs.type, (ir.FloatType, ir.DoubleType)):
             return {
                 "+": self.builder.fadd,
                 "-": self.builder.fsub,
@@ -325,7 +325,7 @@ class _FunctionLowerer:
             )
 
         rel_map = {"<": "<", "<=": "<=", ">": ">", ">=": ">=", "==": "==", "!=": "!="}
-        if isinstance(lhs.type, ir.FloatType):
+        if isinstance(lhs.type, (ir.FloatType, ir.DoubleType)):
             return self.builder.fcmp_ordered(rel_map[op], lhs, rhs)
         if isinstance(lhs.type, ir.IntType):
             return self.builder.icmp_signed(rel_map[op], lhs, rhs)

--- a/lockstep_compiler/semantic_validator.py
+++ b/lockstep_compiler/semantic_validator.py
@@ -43,7 +43,7 @@ def build_semantic_validator(base_visitor_cls):
                 for name, signature in load_intrinsics().items()
             }
             self.structs: dict[str, dict[str, SemanticStructField]] = {}
-            self._primitive_types = {"int", "float", "bool", "string"}
+            self._primitive_types = {"int", "uint", "float", "double", "bool", "string"}
             self._current_pure_function: SemanticPureFunctionContext | None = None
             self._pipeline_resource_stack: list[dict[str, SemanticPipelineResource]] = []
             self._pipeline_bind_usage_stack: list[set[str]] = []
@@ -835,17 +835,18 @@ def build_semantic_validator(base_visitor_cls):
                     for operand_type in operand_types
                     if operand_type is not None
                 ]
-                if any(operand_type not in {"int", "float"} for operand_type in known):
+                numeric_types = {"int", "uint", "float", "double"}
+                if any(operand_type not in numeric_types for operand_type in known):
                     _report_operand_error(operator, "numeric", operand_types)
                     return None
                 if len(known) != len(operand_contexts):
                     return None
-                if "int" in known and "float" in known:
+                if len(set(known)) > 1:
                     self._add_diagnostic(
                         severity="error",
                         code=SEMANTIC_DIAGNOSTIC_CODES["implicit_numeric_widening"],
                         message=(
-                            f"Operator '{operator}' mixes int and float operands without an explicit cast."
+                            f"Operator '{operator}' mixes numeric operand types without an explicit cast."
                         ),
                         ctx=ctx,
                         hint="Use explicit casts so numeric widening is intentional and target-compatible.",
@@ -880,12 +881,12 @@ def build_semantic_validator(base_visitor_cls):
                     for operand_type in operand_types
                     if operand_type is not None
                 ]
-                if any(operand_type != "int" for operand_type in known):
-                    _report_operand_error(operator, "int", operand_types)
+                if any(operand_type not in {"int", "uint"} for operand_type in known):
+                    _report_operand_error(operator, "integer", operand_types)
                     return None
                 if len(known) != len(operand_contexts):
                     return None
-                return "int"
+                return known[0] if known else None
 
             if hasattr(ctx, "logicalAndExpr") and callable(ctx.logicalAndExpr):
                 operands = _as_list(ctx.logicalAndExpr())
@@ -934,7 +935,7 @@ def build_semantic_validator(base_visitor_cls):
                         if operand_type is not None
                     ]
                     if any(
-                        operand_type not in {"int", "float", "bool"}
+                        operand_type not in {"int", "uint", "float", "double", "bool"}
                         for operand_type in known
                     ):
                         operator = _child_text(1) or "=="
@@ -963,7 +964,7 @@ def build_semantic_validator(base_visitor_cls):
                         if operand_type is not None
                     ]
                     if any(
-                        operand_type not in {"int", "float", "bool"}
+                        operand_type not in {"int", "uint", "float", "double", "bool"}
                         for operand_type in known
                     ):
                         _report_operand_error(operator, "comparable", operand_types)
@@ -1015,7 +1016,9 @@ def build_semantic_validator(base_visitor_cls):
                 if operator == "-":
                     if operand_type is not None and operand_type not in {
                         "int",
+                        "uint",
                         "float",
+                        "double",
                     }:
                         _report_operand_error(operator, "numeric", [operand_type])
                         return None

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -2293,7 +2293,7 @@ def test_semantic_validator_rejects_implicit_numeric_widening(debug_compiler_mod
         debug_compiler_module.LockstepDiagnostic(
             severity="error",
             code="LCK424",
-            message="Operator '+' mixes int and float operands without an explicit cast.",
+            message="Operator '+' mixes numeric operand types without an explicit cast.",
             line=0,
             column=0,
             hint="Use explicit casts so numeric widening is intentional and target-compatible.",
@@ -2400,7 +2400,7 @@ def test_semantic_validator_reports_invalid_bitwise_operand_types(
         debug_compiler_module.LockstepDiagnostic(
             severity="error",
             code="LCK420",
-            message="Operator '|' expects int operand type(s), but got [int, bool].",
+            message="Operator '|' expects integer operand type(s), but got [int, bool].",
             line=0,
             column=0,
             hint="Adjust operand types so they match the operator semantics.",

--- a/tests/test_type_syntax.py
+++ b/tests/test_type_syntax.py
@@ -98,3 +98,27 @@ pipeline Main {
     assert any(uniform["type"] == "string" for uniform in result.entities["uniforms"])
     assert "private unnamed_addr constant" in result.llvm_ir
     assert "c\"asset://textures/noise\\00\"" in result.llvm_ir
+
+
+def test_uint_and_double_are_supported_as_primitive_declared_types():
+    source = """
+pure uint advance(uint value) {
+    return value + uint(1);
+}
+
+pure double amplify(double value) {
+    return value * double(2.0);
+}
+
+pipeline Main {
+    uniform uint frame = uint(0);
+    uniform double exposure = double(1.0);
+    bind { }
+}
+"""
+
+    result = compile_lockstep(source, verbose=False)
+
+    assert all(diag.severity != "error" for diag in result.diagnostics)
+    assert any(uniform["type"] == "uint" for uniform in result.entities["uniforms"])
+    assert any(uniform["type"] == "double" for uniform in result.entities["uniforms"])


### PR DESCRIPTION
### Motivation
- Treat `uint` and `double` as first-class declared primitive types so source-level type resolution and diagnostics accept them natively.
- Ensure expression resolution and codegen correctly handle mixed numeric kinds and unsigned semantics where appropriate.

### Description
- Expand the registered primitive set to include `uint` and `double` in `lockstep_compiler/semantic_validator.py` so declared types recognize them. 
- Update expression type resolver logic in `lockstep_compiler/semantic_validator.py` to accept numeric operands from the set `{int, uint, float, double}`, to enforce integer-only operators against `{int, uint}`, to include `uint`/`double` in comparable checks, and to validate unary numeric negation for the expanded numeric set.
- Extend `lockstep_compiler/codegen.py` lowering logic to support `double` alongside `float` in coercions, arithmetic, unary minus, and relational comparisons so LLVM IR emission covers `double` operations.
- Add a test `test_uint_and_double_are_supported_as_primitive_declared_types` to `tests/test_type_syntax.py` that verifies compiling programs declaring `uint` and `double` (pure functions and uniforms) produces no semantic errors and emits the declared uniform types.
- Update a couple of expectations in `tests/test_debug_compiler.py` to reflect the generalized diagnostic wording for numeric/integer expectations.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_type_syntax.py` and the test suite passed.
- Ran `PYTHONPATH=. pytest -q tests/test_debug_compiler.py -k "implicit_numeric_widening or invalid_bitwise_operand_types"` and the selected tests passed.
- Ran `PYTHONPATH=. pytest -q tests/test_compiler_api.py -k "cast or primitive or llvm_ir"` and the targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b729daf16c83289a7fd36f7e66c4fe)