### PR TITLE
Add parser resource limits for file size, nesting depth, and timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ lockstepc path/to/program.lock --format
 lockstepc path/to/program.lock --emit-ir
 # emit C host header
 lockstepc path/to/program.lock --emit-header
+# parser resource limits (DoS hardening)
+lockstepc path/to/program.lock --max-file-size-bytes 1048576 --max-expression-nesting-depth 256 --parse-timeout-seconds 2.0
 # print compiler version
 lockstepc --version
 ```

--- a/lockstep_compiler/__init__.py
+++ b/lockstep_compiler/__init__.py
@@ -1,6 +1,11 @@
 from .c_header import emit_c_header
 from .cli import build_arg_parser, run_cli
-from .compiler import compile_lockstep, load_default_parser_classes, validate_semantics
+from .compiler import (
+    ParserResourceLimits,
+    compile_lockstep,
+    load_default_parser_classes,
+    validate_semantics,
+)
 from .errors import LockstepCompileError, ParseErrorCollector
 from .formatter import format_lockstep_source
 from .models import LockstepCompileResult, LockstepDiagnostic, normalize_diagnostics
@@ -17,6 +22,7 @@ __all__ = [
     "build_debug_visitor",
     "build_semantic_validator",
     "compile_lockstep",
+    "ParserResourceLimits",
     "format_lockstep_source",
     "load_default_parser_classes",
     "normalize_diagnostics",

--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -5,6 +5,7 @@ import sys
 import traceback
 from pathlib import Path
 
+from .compiler import ParserResourceLimits
 from .errors import LockstepCompileError
 from .simulator import parse_simulation_inputs, simulate_pipeline_entities
 from .formatter import format_lockstep_source
@@ -86,6 +87,24 @@ def build_arg_parser():
     parser.add_argument(
         "--simulate-input",
         help="Path to a JSON file containing simulation inputs with `streams` and optional `accumulators` maps.",
+    )
+    parser.add_argument(
+        "--max-file-size-bytes",
+        type=int,
+        default=1024 * 1024,
+        help="Maximum accepted source size in bytes before parsing (default: 1048576). Use 0 to disable.",
+    )
+    parser.add_argument(
+        "--max-expression-nesting-depth",
+        type=int,
+        default=256,
+        help="Maximum allowed expression nesting depth in typed AST (default: 256). Use 0 to disable.",
+    )
+    parser.add_argument(
+        "--parse-timeout-seconds",
+        type=float,
+        default=2.0,
+        help="Maximum parser runtime in seconds (default: 2.0). Use 0 to disable.",
     )
     return parser
 
@@ -170,6 +189,7 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
     supports_library_sources = False
     supports_source_file = False
     supports_library_source_files = False
+    supports_parser_limits = False
     try:
         signature = inspect.signature(compiler)
     except (TypeError, ValueError):
@@ -196,6 +216,11 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
             or parameter.name == "library_source_files"
             for parameter in signature.parameters.values()
         )
+        supports_parser_limits = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            or parameter.name == "parser_limits"
+            for parameter in signature.parameters.values()
+        )
 
     compile_kwargs = {}
     if supports_verbose:
@@ -206,6 +231,20 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
         compile_kwargs["source_file"] = str(source_path) if args.path else "<stdin>"
     if supports_library_source_files:
         compile_kwargs["library_source_files"] = library_source_files
+    if supports_parser_limits:
+        compile_kwargs["parser_limits"] = ParserResourceLimits(
+            max_file_size_bytes=(
+                None if args.max_file_size_bytes == 0 else args.max_file_size_bytes
+            ),
+            max_expression_nesting_depth=(
+                None
+                if args.max_expression_nesting_depth == 0
+                else args.max_expression_nesting_depth
+            ),
+            parse_timeout_seconds=(
+                None if args.parse_timeout_seconds == 0 else args.parse_timeout_seconds
+            ),
+        )
 
     try:
         if compile_kwargs:

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -1,4 +1,7 @@
 import functools
+import signal
+from contextlib import contextmanager
+from dataclasses import dataclass
 from dataclasses import replace
 from typing import Any
 
@@ -22,6 +25,117 @@ from .visitors import build_debug_visitor, validate_semantics as _validate_seman
 
 
 DEFAULT_SOURCE_FILE = "<stdin>"
+
+
+@dataclass(frozen=True)
+class ParserResourceLimits:
+    """Configurable limits for parser resource consumption."""
+
+    max_file_size_bytes: int | None = 1024 * 1024
+    max_expression_nesting_depth: int | None = 256
+    parse_timeout_seconds: float | None = 2.0
+
+
+class ParserLimitError(RuntimeError):
+    pass
+
+
+def _parser_limit_diagnostic(
+    *,
+    code: str,
+    message: str,
+    source_file: str,
+    hint: str,
+) -> LockstepDiagnostic:
+    return LockstepDiagnostic(
+        severity="error",
+        code=code,
+        message=message,
+        line=1,
+        column=0,
+        source_file=source_file,
+        hint=hint,
+    )
+
+
+def _validate_parser_limits(limits: ParserResourceLimits):
+    if (
+        limits.max_file_size_bytes is not None
+        and limits.max_file_size_bytes <= 0
+    ):
+        raise ValueError("max_file_size_bytes must be positive when provided.")
+    if (
+        limits.max_expression_nesting_depth is not None
+        and limits.max_expression_nesting_depth <= 0
+    ):
+        raise ValueError(
+            "max_expression_nesting_depth must be positive when provided."
+        )
+    if limits.parse_timeout_seconds is not None and limits.parse_timeout_seconds <= 0:
+        raise ValueError("parse_timeout_seconds must be positive when provided.")
+
+
+@contextmanager
+def _parse_timeout(timeout_seconds: float | None):
+    if timeout_seconds is None:
+        yield
+        return
+    if not hasattr(signal, "setitimer"):
+        yield
+        return
+
+    def _handle_timeout(_signum, _frame):
+        raise ParserLimitError(f"Parse timeout exceeded ({timeout_seconds:.3f}s).")
+
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    signal.signal(signal.SIGALRM, _handle_timeout)
+    signal.setitimer(signal.ITIMER_REAL, timeout_seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+
+
+def _expr_nesting_depth(expr: Any) -> int:
+    from .ast import AstExprBinary, AstExprCall, AstExprCast, AstExprUnary
+
+    if isinstance(expr, AstExprBinary):
+        return 1 + max(_expr_nesting_depth(expr.left), _expr_nesting_depth(expr.right))
+    if isinstance(expr, AstExprUnary):
+        return 1 + _expr_nesting_depth(expr.operand)
+    if isinstance(expr, AstExprCall):
+        if not expr.args:
+            return 1
+        return 1 + max(_expr_nesting_depth(arg) for arg in expr.args)
+    if isinstance(expr, AstExprCast):
+        return 1 + _expr_nesting_depth(expr.value)
+    return 1
+
+
+def _statement_expr_depth(stmt: Any) -> int:
+    from .ast import AstAssignStmt, AstReturnStmt, AstVarDeclStmt
+
+    if isinstance(stmt, AstAssignStmt):
+        return _expr_nesting_depth(stmt.value)
+    if isinstance(stmt, AstReturnStmt):
+        return _expr_nesting_depth(stmt.value)
+    if isinstance(stmt, AstVarDeclStmt) and stmt.initializer is not None:
+        return _expr_nesting_depth(stmt.initializer)
+    return 0
+
+
+def _typed_ast_max_expr_nesting(typed_ast: Any) -> int:
+    if typed_ast is None:
+        return 0
+    max_depth = 0
+    for pure_decl in getattr(typed_ast, "pure_functions", ()):
+        for stmt in pure_decl.body:
+            max_depth = max(max_depth, _statement_expr_depth(stmt))
+    for kernel_decl in (*getattr(typed_ast, "shaders", ()), *getattr(typed_ast, "filters", ())):
+        for stmt in kernel_decl.body:
+            max_depth = max(max_depth, _statement_expr_depth(stmt))
+    return max_depth
 
 
 def _intrinsic_to_entity(intrinsic: IntrinsicSignature) -> PureFunctionEntity:
@@ -150,8 +264,28 @@ def _compile_lockstep_with_dependencies(
     semantic_validator=None,
     token_stream_cls=CommonTokenStream,
     debug_visitor_cls=None,
+    parser_limits: ParserResourceLimits | None = None,
 ) -> LockstepCompileResult:
     source_map = source_map or [(1, _line_count(source_code), source_file)]
+    parser_limits = parser_limits or ParserResourceLimits()
+    _validate_parser_limits(parser_limits)
+
+    max_file_size_bytes = parser_limits.max_file_size_bytes
+    if max_file_size_bytes is not None and len(source_code.encode("utf-8")) > max_file_size_bytes:
+        file_size_diagnostic = _parser_limit_diagnostic(
+            code="LCK002",
+            message=(
+                "Source file exceeds parser file size limit "
+                f"({max_file_size_bytes} bytes)."
+            ),
+            source_file=source_file,
+            hint="Increase --max-file-size-bytes or reduce input size.",
+        )
+        raise LockstepCompileError(
+            [file_size_diagnostic],
+            diagnostics=[file_size_diagnostic],
+            source_file=source_file,
+        )
 
     input_stream = InputStream(source_code)
     lexer = lexer_cls(input_stream)
@@ -163,7 +297,21 @@ def _compile_lockstep_with_dependencies(
     parser = parser_cls(stream)
     parser.removeErrorListeners()
     parser.addErrorListener(error_listener)
-    tree = parser.program()
+    try:
+        with _parse_timeout(parser_limits.parse_timeout_seconds):
+            tree = parser.program()
+    except ParserLimitError as error:
+        timeout_diagnostic = _parser_limit_diagnostic(
+            code="LCK004",
+            message=str(error),
+            source_file=source_file,
+            hint="Increase --parse-timeout-seconds or simplify pathological input.",
+        )
+        raise LockstepCompileError(
+            [timeout_diagnostic],
+            diagnostics=[timeout_diagnostic],
+            source_file=source_file,
+        ) from error
 
     if error_listener.errors:
         parse_errors = _remap_diagnostics(
@@ -184,6 +332,27 @@ def _compile_lockstep_with_dependencies(
         except TypeError:
             # Keep the legacy parse-tree visitor flow for parser stubs used by unit tests.
             typed_ast = None
+
+    if (
+        parser_limits.max_expression_nesting_depth is not None
+        and typed_ast is not None
+    ):
+        max_depth = _typed_ast_max_expr_nesting(typed_ast)
+        if max_depth > parser_limits.max_expression_nesting_depth:
+            depth_diagnostic = _parser_limit_diagnostic(
+                code="LCK003",
+                message=(
+                    "Expression nesting depth exceeds parser limit "
+                    f"({max_depth} > {parser_limits.max_expression_nesting_depth})."
+                ),
+                source_file=source_file,
+                hint="Increase --max-expression-nesting-depth or simplify nested expressions.",
+            )
+            raise LockstepCompileError(
+                [depth_diagnostic],
+                diagnostics=[depth_diagnostic],
+                source_file=source_file,
+            )
 
     semantic_validator = semantic_validator or (
         lambda parse_tree: validate_semantics(parse_tree, visitor_cls)
@@ -317,6 +486,7 @@ def compile_lockstep(
     semantic_validator=None,
     token_stream_cls=CommonTokenStream,
     debug_visitor_cls=None,
+    parser_limits: ParserResourceLimits | None = None,
 ) -> LockstepCompileResult:
     source_code, source_map = _build_combined_source(
         source_code,
@@ -344,6 +514,7 @@ def compile_lockstep(
         semantic_validator=semantic_validator,
         token_stream_cls=token_stream_cls,
         debug_visitor_cls=debug_visitor_cls,
+        parser_limits=parser_limits,
     )
 
 

--- a/tests/test_cli_libraries.py
+++ b/tests/test_cli_libraries.py
@@ -87,3 +87,40 @@ def test_run_cli_reports_stdin_file_in_diagnostics(tmp_path):
 
     assert exit_code == 1
     assert "<stdin>:1:" in stderr.getvalue()
+
+
+def test_run_cli_passes_parser_limits_to_compiler(tmp_path):
+    captured = {}
+
+    def fake_compiler(source, *, verbose=False, parser_limits=None):
+        captured["source"] = source
+        captured["parser_limits"] = parser_limits
+        return {
+            "streams": [],
+            "accumulators": [],
+            "uniforms": [],
+            "shaders": [],
+            "filters": [],
+            "bind_routes": [],
+        }
+
+    exit_code = run_cli(
+        [
+            "--simulate",
+            "--max-file-size-bytes",
+            "4096",
+            "--max-expression-nesting-depth",
+            "32",
+            "--parse-timeout-seconds",
+            "0.5",
+        ],
+        stdin=io.StringIO("pipeline Main { bind { } }"),
+        stdout=io.StringIO(),
+        compiler=fake_compiler,
+    )
+
+    assert exit_code == 0
+    assert captured["source"] == "pipeline Main { bind { } }"
+    assert captured["parser_limits"].max_file_size_bytes == 4096
+    assert captured["parser_limits"].max_expression_nesting_depth == 32
+    assert captured["parser_limits"].parse_timeout_seconds == 0.5

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -1041,3 +1041,176 @@ def test_emit_llvm_ir_raises_on_intrinsic_type_mismatch():
                 "bind_routes": [],
             }
         )
+
+
+def test_compile_lockstep_rejects_inputs_over_file_size_limit(monkeypatch):
+    class StubLexer:
+        def __init__(self, input_stream):
+            self.input_stream = input_stream
+
+        def removeErrorListeners(self):
+            pass
+
+        def addErrorListener(self, listener):
+            pass
+
+    class StubParser:
+        def __init__(self, stream):
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            return "TREE"
+
+    class StubVisitor:
+        pass
+
+    monkeypatch.setattr(
+        compiler_module,
+        "_load_default_parser_classes",
+        lambda: (StubLexer, StubParser, StubVisitor),
+    )
+
+    with pytest.raises(compiler_module.LockstepCompileError) as exc_info:
+        lockstep_compiler.compile_lockstep(
+            "pipeline P { }",
+            verbose=False,
+            semantic_validator=lambda _tree: [],
+            token_stream_cls=lambda lexer: object(),
+            parser_limits=compiler_module.ParserResourceLimits(max_file_size_bytes=1),
+        )
+
+    assert exc_info.value.errors[0].code == "LCK002"
+
+
+def test_compile_lockstep_rejects_excess_expression_nesting(monkeypatch):
+    class StubLexer:
+        def __init__(self, input_stream):
+            self.input_stream = input_stream
+
+        def removeErrorListeners(self):
+            pass
+
+        def addErrorListener(self, listener):
+            pass
+
+    class StubParser:
+        def __init__(self, stream):
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            return "TREE"
+
+    class StubVisitor:
+        pass
+
+    monkeypatch.setattr(
+        compiler_module,
+        "_load_default_parser_classes",
+        lambda: (StubLexer, StubParser, StubVisitor),
+    )
+
+    expr = AstExprBinary(
+        op="+",
+        left=AstExprLiteral(kind="int", value="1"),
+        right=AstExprBinary(
+            op="+",
+            left=AstExprLiteral(kind="int", value="2"),
+            right=AstExprLiteral(kind="int", value="3"),
+        ),
+    )
+    # build_program_ast is complex for stubs; provide a lightweight substitute.
+    monkeypatch.setattr(
+        compiler_module,
+        "build_program_ast",
+        lambda *_args, **_kwargs: type(
+            "Program",
+            (),
+            {
+                "pure_functions": (
+                    type("Pure", (), {"body": (AstReturnStmt(value=expr),)})(),
+                ),
+                "shaders": (),
+                "filters": (),
+                "pipelines": (),
+            },
+        )(),
+    )
+
+    with pytest.raises(compiler_module.LockstepCompileError) as exc_info:
+        lockstep_compiler.compile_lockstep(
+            "pipeline P { }",
+            verbose=False,
+            semantic_validator=lambda _tree, **_kwargs: [],
+            token_stream_cls=lambda lexer: object(),
+            parser_limits=compiler_module.ParserResourceLimits(
+                max_expression_nesting_depth=2,
+            ),
+        )
+
+    assert exc_info.value.errors[0].code == "LCK003"
+
+
+def test_compile_lockstep_rejects_parse_timeout(monkeypatch):
+    class StubLexer:
+        def __init__(self, input_stream):
+            self.input_stream = input_stream
+
+        def removeErrorListeners(self):
+            pass
+
+        def addErrorListener(self, listener):
+            pass
+
+    class StubParser:
+        def __init__(self, stream):
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            return "TREE"
+
+    class StubVisitor:
+        pass
+
+    monkeypatch.setattr(
+        compiler_module,
+        "_load_default_parser_classes",
+        lambda: (StubLexer, StubParser, StubVisitor),
+    )
+
+    class _ExplodingContext:
+        def __enter__(self):
+            raise compiler_module.ParserLimitError("Parse timeout exceeded (0.001s).")
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(compiler_module, "_parse_timeout", lambda _seconds: _ExplodingContext())
+
+    with pytest.raises(compiler_module.LockstepCompileError) as exc_info:
+        lockstep_compiler.compile_lockstep(
+            "pipeline P { }",
+            verbose=False,
+            semantic_validator=lambda _tree: [],
+            token_stream_cls=lambda lexer: object(),
+            parser_limits=compiler_module.ParserResourceLimits(parse_timeout_seconds=0.001),
+        )
+
+    assert exc_info.value.errors[0].code == "LCK004"


### PR DESCRIPTION
### Motivation
- Harden the frontend against pathological inputs that can cause DoS by bounding accepted source size, parse runtime, and expression nesting.
- Provide a programmable API and CLI knobs so host apps and CI can tune or disable limits as needed.
- Surface limit violations as first-class diagnostics so callers can handle them consistently with existing parse/semantic errors.

### Description
- Introduce a new `@dataclass` `ParserResourceLimits` with fields `max_file_size_bytes`, `max_expression_nesting_depth`, and `parse_timeout_seconds` and validation via `_validate_parser_limits` in `lockstep_compiler/compiler.py`.
- Enforce file-size pre-check (fails with `LCK002`) before lex/parse, wrap parse execution in a timeout context using `_parse_timeout` (raises `LCK004` on timeout), and check typed-AST expression nesting depth (fails with `LCK003`) before semantic/codegen phases.
- Add helper utilities to compute expression nesting depth (`_expr_nesting_depth`, `_statement_expr_depth`, `_typed_ast_max_expr_nesting`) and a small `ParserLimitError`/diagnostic helper `_parser_limit_diagnostic` to create `LockstepDiagnostic` errors.
- Add CLI flags `--max-file-size-bytes`, `--max-expression-nesting-depth`, and `--parse-timeout-seconds` (use `0` to disable), wire them through `run_cli` into `compile_lockstep` as a `ParserResourceLimits` instance, and export `ParserResourceLimits` from the package root.

### Testing
- Added unit tests exercising the new limits in `tests/test_compiler_api.py` and a CLI propagation test in `tests/test_cli_libraries.py` that cover file-size, nesting, and timeout behavior (asserting `LCK002`, `LCK003`, `LCK004` respectively). 
- Ran targeted tests: `pytest -q tests/test_compiler_api.py::test_compile_lockstep_rejects_inputs_over_file_size_limit tests/test_compiler_api.py::test_compile_lockstep_rejects_excess_expression_nesting tests/test_compiler_api.py::test_compile_lockstep_rejects_parse_timeout tests/test_cli_libraries.py::test_run_cli_passes_parser_limits_to_compiler`, which all passed. 
- Ran the combined frontend test suites `pytest -q tests/test_cli_libraries.py tests/test_compiler_api.py`, and all tests passed.
- Updated `README.md` to document CLI usage examples for the new parser resource flags.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b729ef8d3083289b8109164cea8b0d)