### PR TITLE
SoA decomposition: flatten nested structs into per-field arena fields and LLVM tick params

### DIFF
--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -88,6 +88,32 @@ def _c_type(type_name: str, known_structs: set[str]) -> str:
     return "void*"
 
 
+def _flatten_struct_fields(
+    type_name: str,
+    struct_map: dict[str, dict[str, Any]],
+    prefix: tuple[str, ...] = (),
+    trail: tuple[str, ...] = (),
+) -> list[tuple[tuple[str, ...], str]]:
+    if type_name not in struct_map:
+        return [(prefix, type_name)]
+    if type_name in trail:
+        return [(prefix, "uint")]
+
+    flattened: list[tuple[tuple[str, ...], str]] = []
+    for field in struct_map[type_name].get("fields", []):
+        field_name = field.get("name", "field")
+        field_type = field.get("type", "float")
+        flattened.extend(
+            _flatten_struct_fields(
+                field_type,
+                struct_map,
+                prefix + (field_name,),
+                trail + (type_name,),
+            )
+        )
+    return flattened or [(prefix, "uint")]
+
+
 def emit_c_header(
     program_or_entities: AstProgram | dict[str, Any],
     guard: str = "LOCKSTEP_GENERATED_H",
@@ -100,20 +126,24 @@ def emit_c_header(
 
     normalized_structs = _normalize_structs(entities.get("structs", []))
     known_structs = {struct["name"] for struct in normalized_structs}
+    struct_map = {struct["name"]: struct for struct in normalized_structs}
     struct_sizes, opaque_structs = _resolve_struct_layouts(normalized_structs)
 
-    arena_fields: list[tuple[str, str, str]] = []
+    arena_fields: list[tuple[str, str, tuple[str, ...], str]] = []
     for stream in entities.get("streams", []):
-        arena_fields.append(("stream", stream["name"], stream["type"]))
+        for path, leaf_type in _flatten_struct_fields(stream["type"], struct_map):
+            arena_fields.append(("stream", stream["name"], path, leaf_type))
     for accumulator in entities.get("accumulators", []):
-        arena_fields.append(("accum", accumulator["name"], accumulator["type"]))
+        for path, leaf_type in _flatten_struct_fields(accumulator["type"], struct_map):
+            arena_fields.append(("accum", accumulator["name"], path, leaf_type))
     for uniform in entities.get("uniforms", []):
-        arena_fields.append(("uniform", uniform["name"], uniform["type"]))
+        for path, leaf_type in _flatten_struct_fields(uniform["type"], struct_map):
+            arena_fields.append(("uniform", uniform["name"], path, leaf_type))
 
-    offsets: list[tuple[str, str, int]] = []
+    offsets: list[tuple[str, str, tuple[str, ...], int]] = []
     cursor = 0
-    for kind, name, type_name in arena_fields:
-        offsets.append((kind, name, cursor))
+    for kind, name, path, type_name in arena_fields:
+        offsets.append((kind, name, path, cursor))
         cursor += _field_size(type_name, struct_sizes)
 
     lines = [
@@ -153,15 +183,24 @@ def emit_c_header(
         lines.append("")
 
     lines.append("LOCKSTEP_PACKED_STRUCT(struct Lockstep_Arena {")
-    for kind, name, type_name in arena_fields:
+    for kind, name, path, type_name in arena_fields:
         c_type_name = _c_type(type_name, known_structs)
-        lines.append(f"    {c_type_name} {kind}_{_sanitize_symbol(name)};")
+        suffix = "_".join(_sanitize_symbol(part) for part in path)
+        field_name = f"{kind}_{_sanitize_symbol(name)}"
+        if suffix:
+            field_name = f"{field_name}_{suffix}"
+        lines.append(f"    {c_type_name} {field_name};")
     lines.append("});")
     lines.append("")
 
     lines.append(f"#define LOCKSTEP_ARENA_BYTES {cursor}")
-    for kind, name, offset in offsets:
-        macro_suffix = f"{kind}_{_sanitize_symbol(name)}".upper()
+    for kind, name, path, offset in offsets:
+        macro_suffix = f"{kind}_{_sanitize_symbol(name)}"
+        if path:
+            macro_suffix = (
+                f"{macro_suffix}_{'_'.join(_sanitize_symbol(part) for part in path)}"
+            )
+        macro_suffix = macro_suffix.upper()
         lines.append(f"#define LOCKSTEP_OFFSET_{macro_suffix} {offset}")
     for stream in entities.get("streams", []):
         stream_name = _sanitize_symbol(stream["name"]).upper()

--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -536,6 +536,35 @@ def _ast_body_for(entity: dict[str, Any], *, entity_kind: str) -> list[AstStatem
     return body_ast
 
 
+def _flatten_llvm_leaf_types(
+    type_name: str,
+    *,
+    lowerer: _FunctionLowerer,
+    known_structs: dict[str, ir.IdentifiedStructType],
+    struct_fields: dict[str, list[dict[str, str]]],
+    prefix: tuple[str, ...] = (),
+    trail: tuple[str, ...] = (),
+) -> list[tuple[tuple[str, ...], ir.Type]]:
+    if type_name not in struct_fields:
+        return [(prefix, lowerer._llvm_type(type_name, known_structs))]
+    if type_name in trail:
+        return [(prefix, ir.IntType(32))]
+
+    flattened: list[tuple[tuple[str, ...], ir.Type]] = []
+    for field in struct_fields.get(type_name, []):
+        flattened.extend(
+            _flatten_llvm_leaf_types(
+                field.get("type", "float"),
+                lowerer=lowerer,
+                known_structs=known_structs,
+                struct_fields=struct_fields,
+                prefix=prefix + (field.get("name", "field"),),
+                trail=trail + (type_name,),
+            )
+        )
+    return flattened or [(prefix, ir.IntType(32))]
+
+
 def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
     """Generate LLVM IR using llvmlite lowering for pure/kernels."""
 
@@ -677,35 +706,25 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
             fn, _ast_body_for(flt, entity_kind="filter"), ir.VoidType()
         )
 
-    arena_fields: list[tuple[str, str, ir.Type]] = []
-    stream_slots: dict[str, int] = {}
+    stream_names: set[str] = set()
     stream_capacities: dict[str, int] = {}
+    stream_types: dict[str, str] = {}
     for stream in streams:
-        stream_slots[stream["name"]] = len(arena_fields)
-        arena_fields.append(
-            (
-                "stream",
-                stream["name"],
-                lowerer._llvm_type(stream["type"], known_structs),
-            )
-        )
+        stream_names.add(stream["name"])
+        stream_types[stream["name"]] = stream["type"]
         stream_capacities[stream["name"]] = int(stream.get("capacity", 0))
-    accum_slots: dict[str, int] = {}
+
+    accum_names: set[str] = set()
+    accum_types: dict[str, str] = {}
     for accum in accumulators:
-        accum_slots[accum["name"]] = len(arena_fields)
-        arena_fields.append(
-            ("accum", accum["name"], lowerer._llvm_type(accum["type"], known_structs))
-        )
-    uniform_slots: dict[str, int] = {}
+        accum_names.add(accum["name"])
+        accum_types[accum["name"]] = accum["type"]
+
+    uniform_names: set[str] = set()
+    uniform_types: dict[str, str] = {}
     for uniform in uniforms:
-        uniform_slots[uniform["name"]] = len(arena_fields)
-        arena_fields.append(
-            (
-                "uniform",
-                uniform["name"],
-                lowerer._llvm_type(uniform["type"], known_structs),
-            )
-        )
+        uniform_names.add(uniform["name"])
+        uniform_types[uniform["name"]] = uniform["type"]
 
     kernel_signatures = {
         shader["name"]: {"kind": "shader", "params": shader.get("params", [])}
@@ -718,47 +737,39 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
         }
     )
 
-    tick_arg_specs: list[tuple[str, str, ir.Type, bool]] = []
+    tick_arg_specs: list[tuple[str, str, tuple[str, ...], ir.Type, bool]] = []
+
+    def _append_tick_args(kind: str, name: str, type_name: str, apply_noalias: bool):
+        for path, leaf_type in _flatten_llvm_leaf_types(
+            type_name,
+            lowerer=lowerer,
+            known_structs=known_structs,
+            struct_fields=struct_fields,
+        ):
+            tick_arg_specs.append((kind, name, path, leaf_type, apply_noalias))
+
     for stream in streams:
-        tick_arg_specs.append(
-            (
-                "stream",
-                stream["name"],
-                lowerer._llvm_type(stream["type"], known_structs),
-                True,
-            )
-        )
+        _append_tick_args("stream", stream["name"], stream["type"], True)
     for accum in accumulators:
-        tick_arg_specs.append(
-            (
-                "accum",
-                accum["name"],
-                lowerer._llvm_type(accum["type"], known_structs),
-                True,
-            )
-        )
+        _append_tick_args("accum", accum["name"], accum["type"], True)
     for uniform in uniforms:
-        tick_arg_specs.append(
-            (
-                "uniform",
-                uniform["name"],
-                lowerer._llvm_type(uniform["type"], known_structs),
-                False,
-            )
-        )
+        _append_tick_args("uniform", uniform["name"], uniform["type"], False)
 
     tick_param_types = [
-        field_type.as_pointer() for _, _, field_type, _ in tick_arg_specs
+        field_type.as_pointer() for _, _, _, field_type, _ in tick_arg_specs
     ]
     tick = ir.Function(
         module, ir.FunctionType(ir.VoidType(), tick_param_types), name="Lockstep_Tick"
     )
-    tick_param_ptrs: dict[tuple[str, str], ir.Argument] = {}
-    for arg, (kind, name, _, apply_noalias) in zip(tick.args, tick_arg_specs):
+    tick_param_ptrs: dict[tuple[str, str, tuple[str, ...]], ir.Argument] = {}
+    for arg, (kind, name, path, _, apply_noalias) in zip(tick.args, tick_arg_specs):
+        suffix = "_".join(_sanitize_symbol(part) for part in path)
         arg.name = f"{kind}_{_sanitize_symbol(name)}"
+        if suffix:
+            arg.name = f"{arg.name}_{suffix}"
         if apply_noalias:
             arg.add_attribute("noalias")
-        tick_param_ptrs[(kind, name)] = arg
+        tick_param_ptrs[(kind, name, path)] = arg
 
     tick_entry = tick.append_basic_block("entry")
     tick_builder = ir.IRBuilder(tick_entry)
@@ -769,22 +780,69 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
             return ir.Constant(ir.IntType(32), 0)
         return ir.Constant(llvm_type, None)
 
-    def _load_tick_param(kind: str, name: str, field_type: ir.Type) -> ir.Value:
-        ptr = tick_param_ptrs.get((kind, name))
+    def _load_tick_leaf(
+        kind: str, name: str, path: tuple[str, ...], field_type: ir.Type
+    ) -> ir.Value:
+        ptr = tick_param_ptrs.get((kind, name, path))
         if ptr is None:
             return _zero_value(field_type)
-        return tick_builder.load(ptr, name=f"{kind}_{_sanitize_symbol(name)}_val")
+        leaf_name = "_".join(_sanitize_symbol(part) for part in path)
+        value_name = f"{kind}_{_sanitize_symbol(name)}_val"
+        if leaf_name:
+            value_name = f"{value_name}_{leaf_name}"
+        return tick_builder.load(ptr, name=value_name)
 
-    def _store_arena_slot(field_index: int, value: ir.Value):
-        if field_index < 0 or field_index >= len(arena_fields):
-            return
-        kind, name, _ = arena_fields[field_index]
-        ptr = tick_param_ptrs.get((kind, name))
+    def _load_tick_value(
+        kind: str,
+        name: str,
+        type_name: str,
+        field_type: ir.Type,
+        path: tuple[str, ...] = (),
+    ) -> ir.Value:
+        if type_name not in struct_fields:
+            return _load_tick_leaf(kind, name, path, field_type)
+
+        value = ir.Constant(field_type, None)
+        for index, field in enumerate(struct_fields.get(type_name, [])):
+            child_type_name = field.get("type", "float")
+            child_type = lowerer._llvm_type(child_type_name, known_structs)
+            child = _load_tick_value(
+                kind,
+                name,
+                child_type_name,
+                child_type,
+                path + (field.get("name", "field"),),
+            )
+            value = tick_builder.insert_value(value, child, index, name="soa_insert")
+        return value
+
+    def _store_tick_leaf(kind: str, name: str, path: tuple[str, ...], value: ir.Value):
+        ptr = tick_param_ptrs.get((kind, name, path))
         if ptr is None:
             return
-        slot_ptr = tick_builder.alloca(value.type, name=f"arena_slot_{field_index}")
-        tick_builder.store(value, slot_ptr)
-        tick_builder.store(tick_builder.load(slot_ptr), ptr)
+        tick_builder.store(value, ptr)
+
+    def _store_tick_value(
+        kind: str,
+        name: str,
+        type_name: str,
+        value: ir.Value,
+        path: tuple[str, ...] = (),
+    ):
+        if type_name not in struct_fields:
+            _store_tick_leaf(kind, name, path, value)
+            return
+
+        for index, field in enumerate(struct_fields.get(type_name, [])):
+            child_type_name = field.get("type", "float")
+            child_value = tick_builder.extract_value(value, index, name="soa_extract")
+            _store_tick_value(
+                kind,
+                name,
+                child_type_name,
+                child_value,
+                path + (field.get("name", "field"),),
+            )
 
     def _build_vector_splat(value: ir.Value, width: int) -> ir.Value:
         vec_ty = ir.VectorType(value.type, width)
@@ -925,12 +983,21 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
             arg_name = arg_names[index] if index < len(arg_names) else ""
             modifier = params[index].get("modifier") if index < len(params) else None
             value = None
-            if modifier in {"in", "out"} and arg_name in stream_slots:
-                value = _load_tick_param("stream", arg_name, param.type)
-            elif modifier == "accum" and arg_name in accum_slots:
-                value = _load_tick_param("accum", arg_name, param.type)
-            elif modifier == "uniform" and arg_name in uniform_slots:
-                value = _load_tick_param("uniform", arg_name, param.type)
+            if modifier in {"in", "out"} and arg_name in stream_names:
+                value = _load_tick_value(
+                    "stream", arg_name, stream_types.get(arg_name, "float"), param.type
+                )
+            elif modifier == "accum" and arg_name in accum_names:
+                value = _load_tick_value(
+                    "accum", arg_name, accum_types.get(arg_name, "float"), param.type
+                )
+            elif modifier == "uniform" and arg_name in uniform_names:
+                value = _load_tick_value(
+                    "uniform",
+                    arg_name,
+                    uniform_types.get(arg_name, "float"),
+                    param.type,
+                )
             if value is None:
                 value = _zero_value(param.type)
             call_args.append(value)
@@ -953,16 +1020,23 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
                 source_name = str(route.get("source", ""))
                 uniform_name = str(route.get("uniform_name", ""))
                 operator = str(route.get("operator", ""))
-                source_slot = accum_slots.get(source_name)
-                uniform_slot = uniform_slots.get(uniform_name)
-                if source_slot is None or uniform_slot is None:
+                if source_name not in accum_names or uniform_name not in uniform_names:
                     continue
                 uniform_type_name = str(route.get("uniform_type", "float"))
                 uniform_type = lowerer._llvm_type(uniform_type_name, known_structs)
-                accum_kind, accum_name, _ = arena_fields[source_slot]
-                accum_value = _load_tick_param(accum_kind, accum_name, uniform_type)
+                accum_value = _load_tick_value(
+                    "accum",
+                    source_name,
+                    accum_types.get(source_name, "float"),
+                    uniform_type,
+                )
                 reduced = _reduce_fold(operator, accum_value, uniform_type)
-                _store_arena_slot(uniform_slot, reduced)
+                _store_tick_value(
+                    "uniform",
+                    uniform_name,
+                    uniform_types.get(uniform_name, "float"),
+                    reduced,
+                )
                 continue
             asm_ty = ir.FunctionType(ir.VoidType(), [])
             escaped = (

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -342,10 +342,14 @@ def test_emit_llvm_ir_generates_expected_declarations():
     assert 'define float @"pure_demo"()' in llvm_ir
     assert 'define void @"shader_ApplyGravity"()' in llvm_ir
     assert 'define void @"filter_Cull"()' in llvm_ir
-    assert (
-        'define void @"Lockstep_Tick"(%"struct.Vec3"* noalias %"stream_raw_positions", float* noalias %"accum_energy", float* %"uniform_dt")'
-        in llvm_ir
+    tick_signature = next(
+        line for line in llvm_ir.splitlines() if 'define void @"Lockstep_Tick"' in line
     )
+    assert '%"stream_raw_positions_x"' in tick_signature
+    assert '_y"' in tick_signature and "stream_raw_positions" in tick_signature
+    assert '_z"' in tick_signature and "stream_raw_positions" in tick_signature
+    assert '%"accum_energy"' in tick_signature
+    assert '%"uniform_dt"' in tick_signature
     assert "; bind: out = ApplyGravity(inp, out, energy, dt);" in llvm_ir
     assert 'declare float @"llvm.maxnum.f32"(float %".1", float %".2")' in llvm_ir
     assert 'declare float @"llvm.minnum.f32"(float %".1", float %".2")' in llvm_ir
@@ -731,7 +735,7 @@ def test_emit_llvm_ir_lowers_fold_routes_to_vector_reduce_intrinsics():
     )
 
     assert 'call fast float @"llvm.vector.reduce.fadd.v8f32"' in llvm_ir
-    assert 'store float %"fold_reduce", float* %"arena_slot_1"' in llvm_ir
+    assert 'store float %"fold_reduce", float* %"uniform_total"' in llvm_ir
 
 
 def test_emit_llvm_ir_raises_on_mixed_int_float_expression():
@@ -887,10 +891,82 @@ def test_emit_c_header_generates_structs_offsets_and_tick_signature():
     assert "struct Lockstep_Vec3" in header
     assert "struct Lockstep_Arena" in header
     assert "#define LOCKSTEP_ARENA_BYTES 20" in header
-    assert "#define LOCKSTEP_OFFSET_STREAM_RAW_POSITIONS 0" in header
+    assert "#define LOCKSTEP_OFFSET_STREAM_RAW_POSITIONS_X 0" in header
+    assert "#define LOCKSTEP_OFFSET_STREAM_RAW_POSITIONS_Y 4" in header
+    assert "#define LOCKSTEP_OFFSET_STREAM_RAW_POSITIONS_Z 8" in header
     assert "#define LOCKSTEP_OFFSET_ACCUM_ENERGY 12" in header
     assert "#define LOCKSTEP_OFFSET_UNIFORM_DT 16" in header
     assert "void Lockstep_Tick(struct Lockstep_Arena* arena);" in header
+
+
+def test_emit_c_header_decomposes_nested_structs_into_soa_fields_and_offsets():
+    header = emit_c_header(
+        {
+            "structs": [
+                {
+                    "name": "Vec2",
+                    "fields": [
+                        {"type": "float", "name": "x"},
+                        {"type": "float", "name": "y"},
+                    ],
+                },
+                {
+                    "name": "Particle",
+                    "fields": [
+                        {"type": "Vec2", "name": "pos"},
+                        {"type": "float", "name": "mass"},
+                    ],
+                },
+            ],
+            "streams": [{"name": "particles", "type": "Particle"}],
+            "accumulators": [],
+            "uniforms": [],
+        }
+    )
+
+    assert "float stream_particles_pos_x;" in header
+    assert "float stream_particles_pos_y;" in header
+    assert "float stream_particles_mass;" in header
+    assert "#define LOCKSTEP_OFFSET_STREAM_PARTICLES_POS_X 0" in header
+    assert "#define LOCKSTEP_OFFSET_STREAM_PARTICLES_POS_Y 4" in header
+    assert "#define LOCKSTEP_OFFSET_STREAM_PARTICLES_MASS 8" in header
+
+
+def test_emit_llvm_ir_decomposes_nested_struct_tick_params_into_soa_pointers():
+    llvm_ir = emit_llvm_ir(
+        {
+            "structs": [
+                {
+                    "name": "Vec2",
+                    "fields": [
+                        {"type": "float", "name": "x"},
+                        {"type": "float", "name": "y"},
+                    ],
+                },
+                {
+                    "name": "Particle",
+                    "fields": [
+                        {"type": "Vec2", "name": "pos"},
+                        {"type": "float", "name": "mass"},
+                    ],
+                },
+            ],
+            "pure_functions": [],
+            "shaders": [],
+            "filters": [],
+            "streams": [{"name": "particles", "type": "Particle"}],
+            "accumulators": [],
+            "uniforms": [],
+            "bind_routes": [],
+        }
+    )
+
+    tick_signature = next(
+        line for line in llvm_ir.splitlines() if 'define void @"Lockstep_Tick"' in line
+    )
+    assert '%"stream_particles_pos_x"' in tick_signature
+    assert 'pos_y"' in tick_signature and "stream_particles" in tick_signature
+    assert '%"stream_particles' in tick_signature and 'mass"' in tick_signature
 
 
 def test_emit_c_header_includes_optional_saturated_write_debug_helpers():


### PR DESCRIPTION
### Motivation
- Improve memory layout and interoperability by decomposing nested struct types into contiguous Structure-of-Arrays (SoA) leaf fields for generated C headers and the LLVM `Lockstep_Tick` ABI.
- Preserve original struct declarations while exposing per-leaf arena fields and offsets so host code can efficiently access individual components.

### Description
- Added recursive flattening for struct declarations in `lockstep_compiler/c_header.py` via `_flatten_struct_fields` and changed arena generation to emit per-leaf fields in `struct Lockstep_Arena` and `LOCKSTEP_OFFSET_*` macros for nested paths.
- Updated LLVM lowering in `lockstep_compiler/codegen.py` with `_flatten_llvm_leaf_types` and changed tick argument construction so `Lockstep_Tick` now receives per-leaf SoA pointer parameters (path-aware naming), while retaining reconstruction/deconstruction helpers to assemble/disassemble aggregate struct values at call/store boundaries.
- Modified fold-route lowering to write reduced values directly into SoA leaf pointers using the new store helpers.
- Expanded tests in `tests/test_compiler_api.py` to validate SoA decomposition for C headers and LLVM IR tick signatures for nested structs, and kept existing struct declarations/extract/insert behavior intact.

### Testing
- Ran formatting with `python -m black lockstep_compiler/c_header.py lockstep_compiler/codegen.py tests/test_compiler_api.py`; formatting completed successfully.
- Executed targeted test suites with `pytest -q tests/test_compiler_api.py tests/test_improvements.py`; all tests in those files passed after iterative fixes (initial failing tests were diagnosed and corrected during the change).
- Committed changes as `Implement SoA decomposition for nested struct arena layouts` and re-ran the API/improvements tests to confirm green status.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b72a01ad508328bedb6f372a879ab5)