### PR TITLE
Add builtin `select(condition, true_value, false_value)` lowered to LLVM `select`

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -344,6 +344,26 @@ class _FunctionLowerer:
         self._compiler_error(f"undefined variable '{parts[0]}'")
 
     def _lower_call(self, name: str, args: list[ir.Value]) -> ir.Value:
+        if name == "select":
+            if len(args) != 3:
+                self._compiler_error(
+                    f"function 'select' expects 3 argument(s), got {len(args)}"
+                )
+            condition, true_value, false_value = args
+            if not isinstance(condition.type, ir.IntType) or condition.type.width != 1:
+                self._compiler_error(
+                    "builtin 'select' expects a boolean condition as the first argument"
+                )
+            if true_value.type != false_value.type:
+                self._compiler_error(
+                    "builtin 'select' expects matching true/false value types"
+                )
+            if not isinstance(true_value.type, (ir.IntType, ir.IdentifiedStructType)):
+                self._compiler_error(
+                    "builtin 'select' currently supports integer and struct values"
+                )
+            return self.builder.select(condition, true_value, false_value, name="select")
+
         if name in self.intrinsic_names:
             lowered_intrinsic = self._lower_intrinsic_call(name, args)
             if lowered_intrinsic is not None:

--- a/lockstep_compiler/prelude.lock
+++ b/lockstep_compiler/prelude.lock
@@ -9,3 +9,4 @@ intrinsic float min(float x, float y);
 intrinsic float abs(float x);
 intrinsic float sign(float x);
 intrinsic float smoothstep(float edge0, float edge1, float x);
+intrinsic int select(bool condition, int true_value, int false_value);

--- a/lockstep_compiler/semantic_validator.py
+++ b/lockstep_compiler/semantic_validator.py
@@ -1062,6 +1062,55 @@ def build_semantic_validator(base_visitor_cls):
                 ):
                     function_name = ctx.ID().getText()
                     args = ctx.exprList().expr() if ctx.exprList() is not None else []
+                    if function_name == "select":
+                        if len(args) != 3:
+                            self._add_diagnostic(
+                                severity="error",
+                                code=SEMANTIC_DIAGNOSTIC_CODES[
+                                    "pure_argument_count_mismatch"
+                                ],
+                                message=(
+                                    "Pure function 'select' expects 3 argument(s), "
+                                    f"but got {len(args)}."
+                                ),
+                                ctx=ctx,
+                                hint="Call select(condition, true_value, false_value) with exactly three arguments.",
+                            )
+                            return None
+                        condition_type = self._resolve_expr_type(args[0])
+                        if condition_type is not None and condition_type != "bool":
+                            self._add_diagnostic(
+                                severity="error",
+                                code=SEMANTIC_DIAGNOSTIC_CODES[
+                                    "pure_argument_type_mismatch"
+                                ],
+                                message=(
+                                    "Type mismatch for argument 1 in pure call 'select': "
+                                    f"expected bool, got {condition_type}."
+                                ),
+                                ctx=ctx,
+                                hint="Use a boolean expression for select's condition argument.",
+                            )
+                            return None
+                        true_type = self._resolve_expr_type(args[1])
+                        false_type = self._resolve_expr_type(args[2])
+                        if true_type is None or false_type is None:
+                            return None
+                        if true_type != false_type:
+                            self._add_diagnostic(
+                                severity="error",
+                                code=SEMANTIC_DIAGNOSTIC_CODES[
+                                    "pure_argument_type_mismatch"
+                                ],
+                                message=(
+                                    "Type mismatch for value arguments in pure call 'select': "
+                                    f"expected matching types, got {true_type} and {false_type}."
+                                ),
+                                ctx=ctx,
+                                hint="Ensure select true_value and false_value have the same type.",
+                            )
+                            return None
+                        return true_type
                     if _is_cast_function_name(function_name):
                         if len(args) != 1:
                             self._add_diagnostic(
@@ -1101,6 +1150,51 @@ def build_semantic_validator(base_visitor_cls):
                     return self._resolve_expr_type(child_expr)
 
             return None
+
+        def _type_check_select_call(self, ctx):
+            actual_args = []
+            if ctx.exprList() is not None:
+                actual_args = ctx.exprList().expr()
+
+            if len(actual_args) != 3:
+                self._add_diagnostic(
+                    severity="error",
+                    code=SEMANTIC_DIAGNOSTIC_CODES["pure_argument_count_mismatch"],
+                    message=(
+                        f"Pure function 'select' expects 3 argument(s), "
+                        f"but got {len(actual_args)}."
+                    ),
+                    ctx=ctx,
+                    hint="Call select(condition, true_value, false_value) with exactly three arguments.",
+                )
+                return
+
+            condition_type = self._resolve_expr_type(actual_args[0])
+            if condition_type is not None and condition_type != "bool":
+                self._add_diagnostic(
+                    severity="error",
+                    code=SEMANTIC_DIAGNOSTIC_CODES["pure_argument_type_mismatch"],
+                    message=(
+                        "Type mismatch for argument 1 in pure call 'select': "
+                        f"expected bool, got {condition_type}."
+                    ),
+                    ctx=ctx,
+                    hint="Use a boolean expression for select's condition argument.",
+                )
+
+            true_type = self._resolve_expr_type(actual_args[1])
+            false_type = self._resolve_expr_type(actual_args[2])
+            if true_type is not None and false_type is not None and true_type != false_type:
+                self._add_diagnostic(
+                    severity="error",
+                    code=SEMANTIC_DIAGNOSTIC_CODES["pure_argument_type_mismatch"],
+                    message=(
+                        "Type mismatch for value arguments in pure call 'select': "
+                        f"expected matching types, got {true_type} and {false_type}."
+                    ),
+                    ctx=ctx,
+                    hint="Ensure select true_value and false_value have the same type.",
+                )
 
         def _type_check_pure_call(self, ctx):
             callee_name = ctx.ID().getText()
@@ -1492,6 +1586,8 @@ def build_semantic_validator(base_visitor_cls):
                                 ctx=ctx,
                                 hint="Pass exactly one expression to a cast.",
                             )
+                    elif callee_name == "select":
+                        self._type_check_select_call(ctx)
                     else:
                         self._type_check_pure_call(ctx)
                 return self.visitChildren(ctx)

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -99,6 +99,7 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
         "abs",
         "sign",
         "smoothstep",
+        "select",
     }
     assert result.entities["streams"] == []
     assert result.entities["accumulators"] == []
@@ -1041,3 +1042,33 @@ def test_emit_llvm_ir_raises_on_intrinsic_type_mismatch():
                 "bind_routes": [],
             }
         )
+
+
+def test_compile_lockstep_accepts_select_builtin_for_struct_values():
+    source = """
+struct Pair { int x; int y; };
+
+pure Pair choose(bool cond, Pair a, Pair b) {
+    return select(cond, a, b);
+}
+
+pipeline Main { bind { } }
+"""
+    result = lockstep_compiler.compile_lockstep(source, verbose=False)
+    assert 'define %"struct.Pair" @"pure_choose"' in result.llvm_ir
+    assert '= select  i1' in result.llvm_ir
+
+
+def test_compile_lockstep_reports_select_condition_type_mismatch():
+    source = """
+pure int choose(int cond, int a, int b) {
+    return select(cond, a, b);
+}
+
+pipeline Main { bind { } }
+"""
+    with pytest.raises(lockstep_compiler.LockstepCompileError) as exc_info:
+        lockstep_compiler.compile_lockstep(source, verbose=False)
+
+    assert [diag.code for diag in exc_info.value.errors] == ["LCK501"]
+    assert "select" in exc_info.value.errors[0].message

--- a/tests/test_improvements.py
+++ b/tests/test_improvements.py
@@ -49,6 +49,17 @@ def test_prelude_declares_smoothstep():
     assert len(intrinsics["smoothstep"].params) == 3
 
 
+def test_prelude_declares_select():
+    intrinsics = load_intrinsics()
+    assert "select" in intrinsics
+    assert intrinsics["select"].return_type == "int"
+    assert [param.type_name for param in intrinsics["select"].params] == [
+        "bool",
+        "int",
+        "int",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Codegen intrinsic lowering
 # ---------------------------------------------------------------------------
@@ -153,6 +164,74 @@ def test_codegen_sign_intrinsic():
     )
     ir_text = emit_llvm_ir(entities)
     assert "sign_pos" in ir_text or "sign" in ir_text
+
+
+def test_codegen_select_lowers_to_llvm_select_for_ints():
+    entities = _entities_with_pure(
+        "test_select_int",
+        [
+            {"type": "bool", "name": "cond"},
+            {"type": "int", "name": "a"},
+            {"type": "int", "name": "b"},
+        ],
+        [
+            AstReturnStmt(
+                value=AstExprCall(
+                    name="select",
+                    args=(
+                        AstExprVar(path=("cond",)),
+                        AstExprVar(path=("a",)),
+                        AstExprVar(path=("b",)),
+                    ),
+                )
+            )
+        ],
+        return_type="int",
+    )
+    ir_text = emit_llvm_ir(entities)
+    assert "= select  i1" in ir_text
+
+
+def test_codegen_select_lowers_to_llvm_select_for_structs():
+    entities = {
+        **_CODEGEN_ENTITIES_BASE,
+        "structs": [
+            {
+                "name": "Pair",
+                "fields": [
+                    {"type": "int", "name": "x"},
+                    {"type": "int", "name": "y"},
+                ],
+            }
+        ],
+        "pure_functions": [
+            {
+                "name": "pick_pair",
+                "return_type": "Pair",
+                "params": [
+                    {"type": "bool", "name": "cond"},
+                    {"type": "Pair", "name": "a"},
+                    {"type": "Pair", "name": "b"},
+                ],
+                "body_ast": [
+                    AstReturnStmt(
+                        value=AstExprCall(
+                            name="select",
+                            args=(
+                                AstExprVar(path=("cond",)),
+                                AstExprVar(path=("a",)),
+                                AstExprVar(path=("b",)),
+                            ),
+                        )
+                    )
+                ],
+                "intrinsic": False,
+            },
+            *_intrinsic_defs(),
+        ],
+    }
+    ir_text = emit_llvm_ir(entities)
+    assert '= select  i1' in ir_text
 
 
 def test_codegen_smoothstep_intrinsic():


### PR DESCRIPTION
### Motivation
- Provide a branchless ternary expression as a built-in `select` so users can express conditional selection on integers and structs without control-flow. 

### Description
- Register `select` in the prelude by adding `intrinsic int select(bool condition, int true_value, int false_value);` so it is recognized as a built-in callable via `load_intrinsics`. 
- Implement lowering in `_FunctionLowerer._lower_call` to emit LLVM's `select` instruction via `builder.select(...)` and validate that the call has three arguments, the first is a boolean (`i1`), and the true/false branch types match and are supported (integers or struct aggregates). 
- Extend semantic validation to handle `select(...)` by adding `_type_check_select_call` and integrating it into expression/type resolution so argument count, condition type, and matching branch types are diagnosed at compile time. 
- Add and update tests to assert that `select` is present in the prelude and that codegen lowers `select` to LLVM IR for integer and struct values, and to cover compiler API behavior for valid and invalid `select` usage. 

### Testing
- Ran `pytest -q tests/test_improvements.py tests/test_compiler_api.py` and the test suite completed successfully. 
- Ran `pytest -q tests/test_type_syntax.py` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b72a120be483289f13e745519f6798)