### PR TITLE
Promote stream capacities into per-arena dimension fields and drive Tick from runtime dims

### DIFF
--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -104,6 +104,8 @@ def emit_c_header(
 
     arena_fields: list[tuple[str, str, str]] = []
     for stream in entities.get("streams", []):
+        arena_fields.append(("dim", f"stream_{stream['name']}", "uint"))
+    for stream in entities.get("streams", []):
         arena_fields.append(("stream", stream["name"], stream["type"]))
     for accumulator in entities.get("accumulators", []):
         arena_fields.append(("accum", accumulator["name"], accumulator["type"]))
@@ -168,6 +170,7 @@ def emit_c_header(
         stream_capacity = (
             int(stream.get("capacity", 0)) if stream.get("capacity") is not None else 0
         )
+        lines.append(f"#define LOCKSTEP_DIM_STREAM_{stream_name} {stream_capacity}")
         lines.append(
             f"#define LOCKSTEP_CAPACITY_STREAM_{stream_name} {stream_capacity}"
         )

--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -679,17 +679,19 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
 
     arena_fields: list[tuple[str, str, ir.Type]] = []
     stream_slots: dict[str, int] = {}
-    stream_capacities: dict[str, int] = {}
+    stream_default_capacities: dict[str, int] = {}
     for stream in streams:
-        stream_slots[stream["name"]] = len(arena_fields)
+        stream_name = stream["name"]
+        arena_fields.append(("dim", f"stream_{stream_name}", ir.IntType(32)))
+        stream_slots[stream_name] = len(arena_fields)
         arena_fields.append(
             (
                 "stream",
-                stream["name"],
+                stream_name,
                 lowerer._llvm_type(stream["type"], known_structs),
             )
         )
-        stream_capacities[stream["name"]] = int(stream.get("capacity", 0))
+        stream_default_capacities[stream_name] = int(stream.get("capacity", 0))
     accum_slots: dict[str, int] = {}
     for accum in accumulators:
         accum_slots[accum["name"]] = len(arena_fields)
@@ -720,6 +722,7 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
 
     tick_arg_specs: list[tuple[str, str, ir.Type, bool]] = []
     for stream in streams:
+        tick_arg_specs.append(("dim", f"stream_{stream['name']}", ir.IntType(32), False))
         tick_arg_specs.append(
             (
                 "stream",
@@ -883,18 +886,46 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
         params = signature.get("params", []) if isinstance(signature, dict) else []
         arg_names = route.get("args") if isinstance(route.get("args"), list) else []
 
-        trip_count = 0
+        trip_count_value = ir.Constant(ir.IntType(32), 0)
+
+        def _accumulate_trip_count(stream_name: str):
+            nonlocal trip_count_value
+            default_capacity = stream_default_capacities.get(stream_name, 0)
+            dim_value = _load_tick_param("dim", f"stream_{stream_name}", ir.IntType(32))
+            dim_is_positive = tick_builder.icmp_signed(
+                ">", dim_value, ir.Constant(ir.IntType(32), 0), name="stream_dim_positive"
+            )
+            stream_count = tick_builder.select(
+                dim_is_positive,
+                dim_value,
+                ir.Constant(ir.IntType(32), default_capacity),
+                name="stream_trip_count",
+            )
+            is_larger = tick_builder.icmp_signed(
+                ">", stream_count, trip_count_value, name="stream_trip_count_gt"
+            )
+            trip_count_value = tick_builder.select(
+                is_larger, stream_count, trip_count_value, name="trip_count_max"
+            )
+
         for index, arg_name in enumerate(arg_names):
             if index >= len(params):
                 break
             modifier = params[index].get("modifier")
-            if modifier == "in" and arg_name in stream_capacities:
-                trip_count = max(trip_count, stream_capacities[arg_name])
+            if modifier == "in" and arg_name in stream_default_capacities:
+                _accumulate_trip_count(arg_name)
         target = route.get("target")
-        if isinstance(target, str) and target in stream_capacities:
-            trip_count = max(trip_count, stream_capacities[target])
-        if trip_count <= 0:
-            trip_count = 1
+        if isinstance(target, str) and target in stream_default_capacities:
+            _accumulate_trip_count(target)
+        has_trip_count = tick_builder.icmp_signed(
+            ">", trip_count_value, ir.Constant(ir.IntType(32), 0), name="has_trip_count"
+        )
+        trip_count_value = tick_builder.select(
+            has_trip_count,
+            trip_count_value,
+            ir.Constant(ir.IntType(32), 1),
+            name="trip_count_or_one",
+        )
 
         index_ptr = tick_builder.alloca(
             ir.IntType(32), name=f"{_sanitize_symbol(kernel_name)}_idx"
@@ -915,7 +946,7 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
         tick_builder.position_at_end(loop_cond)
         current = tick_builder.load(index_ptr, name="idx")
         cond = tick_builder.icmp_signed(
-            "<", current, ir.Constant(ir.IntType(32), trip_count), name="route_active"
+            "<", current, trip_count_value, name="route_active"
         )
         tick_builder.cbranch(cond, loop_body, loop_exit)
 

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -343,7 +343,7 @@ def test_emit_llvm_ir_generates_expected_declarations():
     assert 'define void @"shader_ApplyGravity"()' in llvm_ir
     assert 'define void @"filter_Cull"()' in llvm_ir
     assert (
-        'define void @"Lockstep_Tick"(%"struct.Vec3"* noalias %"stream_raw_positions", float* noalias %"accum_energy", float* %"uniform_dt")'
+        'define void @"Lockstep_Tick"(i32* %"dim_stream_raw_positions", %"struct.Vec3"* noalias %"stream_raw_positions", float* noalias %"accum_energy", float* %"uniform_dt")'
         in llvm_ir
     )
     assert "; bind: out = ApplyGravity(inp, out, energy, dt);" in llvm_ir
@@ -629,7 +629,7 @@ def test_emit_llvm_ir_accepts_ast_program_input():
     )
 
     assert "route_ApplyGravity_cond" in llvm_ir
-    assert 'icmp slt i32 %"idx", 2' in llvm_ir
+    assert 'icmp slt i32 %"idx", %"trip_count_or_one"' in llvm_ir
 
 
 def test_emit_llvm_ir_lowers_kernel_bind_routes_into_counted_loops():
@@ -669,7 +669,8 @@ def test_emit_llvm_ir_lowers_kernel_bind_routes_into_counted_loops():
     )
 
     assert "route_ApplyGravity_cond" in llvm_ir
-    assert 'icmp slt i32 %"idx", 4' in llvm_ir
+    assert 'load i32, i32* %"dim_stream_inp"' in llvm_ir
+    assert 'icmp slt i32 %"idx", %"trip_count_or_one"' in llvm_ir
     assert 'call void @"shader_ApplyGravity"(float' in llvm_ir
 
 
@@ -886,10 +887,11 @@ def test_emit_c_header_generates_structs_offsets_and_tick_signature():
     assert "#ifndef LOCKSTEP_GENERATED_H" in header
     assert "struct Lockstep_Vec3" in header
     assert "struct Lockstep_Arena" in header
-    assert "#define LOCKSTEP_ARENA_BYTES 20" in header
-    assert "#define LOCKSTEP_OFFSET_STREAM_RAW_POSITIONS 0" in header
-    assert "#define LOCKSTEP_OFFSET_ACCUM_ENERGY 12" in header
-    assert "#define LOCKSTEP_OFFSET_UNIFORM_DT 16" in header
+    assert "#define LOCKSTEP_ARENA_BYTES 24" in header
+    assert "#define LOCKSTEP_OFFSET_DIM_STREAM_RAW_POSITIONS 0" in header
+    assert "#define LOCKSTEP_OFFSET_STREAM_RAW_POSITIONS 4" in header
+    assert "#define LOCKSTEP_OFFSET_ACCUM_ENERGY 16" in header
+    assert "#define LOCKSTEP_OFFSET_UNIFORM_DT 20" in header
     assert "void Lockstep_Tick(struct Lockstep_Arena* arena);" in header
 
 
@@ -904,6 +906,7 @@ def test_emit_c_header_includes_optional_saturated_write_debug_helpers():
 
     assert "#ifdef LOCKSTEP_DEBUG_SATURATED_WRITES" in header
     assert "#include <stdio.h>" in header
+    assert "#define LOCKSTEP_DIM_STREAM_OUTPUT_STREAM 16" in header
     assert "#define LOCKSTEP_CAPACITY_STREAM_OUTPUT_STREAM 16" in header
     assert "#ifndef LOCKSTEP_SATURATED_WRITE_LOG" in header
     assert (
@@ -974,7 +977,7 @@ def test_compile_result_includes_c_header(monkeypatch):
         debug_visitor_cls=StubDebugVisitor,
     )
 
-    assert "#define LOCKSTEP_ARENA_BYTES 4" in result.c_header
+    assert "#define LOCKSTEP_ARENA_BYTES 8" in result.c_header
     assert "void Lockstep_Tick(struct Lockstep_Arena* arena);" in result.c_header
 
 


### PR DESCRIPTION
### Motivation
- Make stream capacities host-configurable per arena instance by promoting compile-time capacity constants into arena-stored dimension fields so a single compiled pipeline can be instantiated with different sizes.
- Preserve backward compatibility by still emitting the original capacity macros while adding new dimension macros for hosts to populate.
- Use runtime-provided dimensions to drive kernel loop trip counts so the compiled pipeline can operate over variable stream sizes provided by the host.

### Description
- Add per-stream arena dimension entries (`dim_stream_<name>`) to the generated C arena layout and emit `LOCKSTEP_DIM_STREAM_<NAME>` macros alongside existing `LOCKSTEP_CAPACITY_STREAM_<NAME>` macros in `lockstep_compiler/c_header.py`.
- Extend LLVM IR tick signature to accept per-stream dimension pointers and prepend `dim_stream_*` pointer parameters to `Lockstep_Tick` in `lockstep_compiler/codegen.py`.
- Lower kernel-route trip counts from loaded dimension values with a fallback to the declared capacity when the provided dimension is non-positive, and use that runtime value as the loop bound (instead of compile-time constants).
- Update tests to reflect the new arena layout, header macros, and `Lockstep_Tick` signature by adjusting `tests/test_compiler_api.py` expectations.

### Testing
- Ran `pytest -q tests/test_compiler_api.py tests/test_improvements.py` and all tests in those modules passed successfully.
- Ran focused tests asserting the new `Lockstep_Tick` signature and header macros and confirmed the generated LLVM IR and C header include the new dimension parameters and macros.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b72a0c2f8883289e123ef4050df4ec)