### PR TITLE
Add configurable frontend guardrails for source size, parse time, and nesting

### DIFF
--- a/lockstep_compiler/__init__.py
+++ b/lockstep_compiler/__init__.py
@@ -1,6 +1,6 @@
 from .c_header import emit_c_header
 from .cli import build_arg_parser, run_cli
-from .compiler import compile_lockstep, load_default_parser_classes, validate_semantics
+from .compiler import FrontendLimits, compile_lockstep, load_default_parser_classes, validate_semantics
 from .errors import LockstepCompileError, ParseErrorCollector
 from .formatter import format_lockstep_source
 from .models import LockstepCompileResult, LockstepDiagnostic, normalize_diagnostics
@@ -8,6 +8,7 @@ from .simulator import simulate_pipeline_entities, simulate_pipeline_source
 from .visitors import build_debug_visitor, build_semantic_validator
 
 __all__ = [
+    "FrontendLimits",
     "LockstepCompileError",
     "LockstepCompileResult",
     "LockstepDiagnostic",

--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -87,6 +87,24 @@ def build_arg_parser():
         "--simulate-input",
         help="Path to a JSON file containing simulation inputs with `streams` and optional `accumulators` maps.",
     )
+    parser.add_argument(
+        "--max-source-bytes",
+        type=int,
+        default=None,
+        help="Maximum UTF-8 source bytes accepted by parser (0 disables limit).",
+    )
+    parser.add_argument(
+        "--parse-timeout-ms",
+        type=int,
+        default=None,
+        help="Maximum parser runtime in milliseconds (0 disables limit).",
+    )
+    parser.add_argument(
+        "--max-expr-nesting",
+        type=int,
+        default=None,
+        help="Maximum allowed expression nesting depth (0 disables limit).",
+    )
     return parser
 
 
@@ -170,6 +188,7 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
     supports_library_sources = False
     supports_source_file = False
     supports_library_source_files = False
+    supports_frontend_limits = False
     try:
         signature = inspect.signature(compiler)
     except (TypeError, ValueError):
@@ -196,6 +215,11 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
             or parameter.name == "library_source_files"
             for parameter in signature.parameters.values()
         )
+        supports_frontend_limits = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            or parameter.name == "frontend_limits"
+            for parameter in signature.parameters.values()
+        )
 
     compile_kwargs = {}
     if supports_verbose:
@@ -206,6 +230,14 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
         compile_kwargs["source_file"] = str(source_path) if args.path else "<stdin>"
     if supports_library_source_files:
         compile_kwargs["library_source_files"] = library_source_files
+    if supports_frontend_limits:
+        from .compiler import FrontendLimits
+
+        compile_kwargs["frontend_limits"] = FrontendLimits(
+            max_source_bytes=args.max_source_bytes,
+            parse_timeout_ms=args.parse_timeout_ms,
+            max_expression_nesting=args.max_expr_nesting,
+        )
 
     try:
         if compile_kwargs:

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -1,6 +1,7 @@
 import functools
 import re
-from dataclasses import replace
+import time
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -21,10 +22,186 @@ from .visitors import validate_semantics as _validate_semantics
 
 
 DEFAULT_SOURCE_FILE = "<stdin>"
+DEFAULT_MAX_SOURCE_BYTES = 1_048_576
+DEFAULT_PARSE_TIMEOUT_MS = 2_000
+DEFAULT_MAX_EXPRESSION_NESTING = 128
 _DEPENDENCY_DECL_PATTERN = re.compile(
     r'^\s*(?:import|#include)\s+"((?:[^"\\]|\\.)+)"\s*;\s*$',
     re.MULTILINE,
 )
+
+
+@dataclass(frozen=True)
+class FrontendLimits:
+    max_source_bytes: int | None = DEFAULT_MAX_SOURCE_BYTES
+    parse_timeout_ms: int | None = DEFAULT_PARSE_TIMEOUT_MS
+    max_expression_nesting: int | None = DEFAULT_MAX_EXPRESSION_NESTING
+
+
+class FrontendLimitExceeded(RuntimeError):
+    def __init__(self, diagnostic: LockstepDiagnostic):
+        super().__init__(diagnostic.message)
+        self.diagnostic = diagnostic
+
+
+class _DeadlineTokenStream(CommonTokenStream):
+    def __init__(self, lexer, *, deadline: float | None = None, source_file: str):
+        super().__init__(lexer)
+        self._deadline = deadline
+        self._source_file = source_file
+
+    def _enforce_deadline(self) -> None:
+        if self._deadline is None:
+            return
+        if time.monotonic() > self._deadline:
+            raise FrontendLimitExceeded(
+                LockstepDiagnostic(
+                    severity="error",
+                    code="LCK004",
+                    message=(
+                        "Parsing exceeded the configured runtime limit "
+                        "(parse_timeout_ms)."
+                    ),
+                    line=1,
+                    column=0,
+                    source_file=self._source_file,
+                    hint=(
+                        "Increase --parse-timeout-ms (or parse_timeout_ms via API) "
+                        "for trusted large inputs, or set it to 0 to disable."
+                    ),
+                )
+            )
+
+    def LA(self, i: int):
+        self._enforce_deadline()
+        return super().LA(i)
+
+    def LT(self, i: int):
+        self._enforce_deadline()
+        return super().LT(i)
+
+    def consume(self):
+        self._enforce_deadline()
+        return super().consume()
+
+
+def _normalize_frontend_limits(
+    limits: FrontendLimits | None,
+) -> FrontendLimits:
+    resolved = limits or FrontendLimits()
+    return FrontendLimits(
+        max_source_bytes=(
+            resolved.max_source_bytes
+            if resolved.max_source_bytes and resolved.max_source_bytes > 0
+            else None
+        ),
+        parse_timeout_ms=(
+            resolved.parse_timeout_ms
+            if resolved.parse_timeout_ms and resolved.parse_timeout_ms > 0
+            else None
+        ),
+        max_expression_nesting=(
+            resolved.max_expression_nesting
+            if resolved.max_expression_nesting and resolved.max_expression_nesting > 0
+            else None
+        ),
+    )
+
+
+def _enforce_source_size_limit(
+    source_code: str,
+    *,
+    source_file: str,
+    limits: FrontendLimits,
+) -> None:
+    if limits.max_source_bytes is None:
+        return
+    source_size = len(source_code.encode("utf-8"))
+    if source_size <= limits.max_source_bytes:
+        return
+    diagnostic = LockstepDiagnostic(
+        severity="error",
+        code="LCK003",
+        message=(
+            "Source size exceeds the configured limit "
+            f"({source_size} bytes > {limits.max_source_bytes} bytes)."
+        ),
+        line=1,
+        column=0,
+        source_file=source_file,
+        hint=(
+            "Increase --max-source-bytes (or max_source_bytes via API) for trusted "
+            "inputs, or set it to 0 to disable."
+        ),
+    )
+    raise LockstepCompileError(
+        [diagnostic],
+        diagnostics=[diagnostic],
+        phase="parse",
+        source_file=source_file,
+    )
+
+
+def _max_expression_nesting(parse_tree: Any) -> int:
+    if not hasattr(parse_tree, "getChildCount"):
+        return 0
+
+    max_depth = 0
+
+    def _walk(node: Any, depth: int) -> None:
+        nonlocal max_depth
+        class_name = node.__class__.__name__
+        depth_increase = 0
+        if class_name == "PrimaryExprContext" and node.getChildCount() >= 3:
+            if node.getChild(0).getText() == "(" and node.getChild(2).getText() == ")":
+                depth_increase = 1
+        elif class_name == "UnaryExprContext" and node.getChildCount() >= 2:
+            if node.getChild(1).__class__.__name__ == "UnaryExprContext":
+                depth_increase = 1
+        current_depth = depth + depth_increase
+        if current_depth > max_depth:
+            max_depth = current_depth
+        for index in range(node.getChildCount()):
+            child = node.getChild(index)
+            if hasattr(child, "getChildCount"):
+                _walk(child, current_depth)
+
+    _walk(parse_tree, 0)
+    return max_depth
+
+
+def _enforce_expression_nesting_limit(
+    parse_tree: Any,
+    *,
+    source_file: str,
+    limits: FrontendLimits,
+) -> None:
+    if limits.max_expression_nesting is None:
+        return
+    depth = _max_expression_nesting(parse_tree)
+    if depth <= limits.max_expression_nesting:
+        return
+    diagnostic = LockstepDiagnostic(
+        severity="error",
+        code="LCK005",
+        message=(
+            "Expression nesting exceeds the configured limit "
+            f"({depth} > {limits.max_expression_nesting})."
+        ),
+        line=1,
+        column=0,
+        source_file=source_file,
+        hint=(
+            "Reduce nested expressions, raise --max-expr-nesting "
+            "(or max_expression_nesting via API), or set it to 0 to disable."
+        ),
+    )
+    raise LockstepCompileError(
+        [diagnostic],
+        diagnostics=[diagnostic],
+        phase="parse",
+        source_file=source_file,
+    )
 
 
 def _merge_intrinsic_pure_functions_into_ast(program: AstProgram) -> AstProgram:
@@ -237,20 +414,60 @@ def _compile_lockstep_with_dependencies(
     semantic_validator=None,
     token_stream_cls=CommonTokenStream,
     debug_visitor_cls=None,
+    frontend_limits: FrontendLimits | None = None,
 ) -> LockstepCompileResult:
     source_map = source_map or [(1, _line_count(source_code), source_file)]
+    resolved_limits = _normalize_frontend_limits(frontend_limits)
+    _enforce_source_size_limit(
+        source_code,
+        source_file=source_file,
+        limits=resolved_limits,
+    )
 
     input_stream = InputStream(source_code)
     lexer = lexer_cls(input_stream)
     error_listener = ParseErrorCollector(source_file=None)
     lexer.removeErrorListeners()
     lexer.addErrorListener(error_listener)
-    stream = token_stream_cls(lexer)
+    if resolved_limits.parse_timeout_ms is not None:
+        deadline = time.monotonic() + (resolved_limits.parse_timeout_ms / 1_000)
+
+        def _build_token_stream(inner_lexer):
+            return _DeadlineTokenStream(
+                inner_lexer,
+                deadline=deadline,
+                source_file=source_file,
+            )
+
+        stream_builder = _build_token_stream
+    else:
+        stream_builder = token_stream_cls
+
+    stream = stream_builder(lexer)
 
     parser = parser_cls(stream)
     parser.removeErrorListeners()
     parser.addErrorListener(error_listener)
-    tree = parser.program()
+    try:
+        tree = parser.program()
+    except FrontendLimitExceeded as exc:
+        diagnostic = _remap_diagnostic(
+            exc.diagnostic,
+            source_map,
+            source_file,
+        )
+        raise LockstepCompileError(
+            [diagnostic],
+            diagnostics=[diagnostic],
+            phase="parse",
+            source_file=diagnostic.source_file,
+        ) from exc
+
+    _enforce_expression_nesting_limit(
+        tree,
+        source_file=source_file,
+        limits=resolved_limits,
+    )
 
     if error_listener.errors:
         parse_errors = _remap_diagnostics(
@@ -370,6 +587,7 @@ def compile_lockstep(
     semantic_validator=None,
     token_stream_cls=CommonTokenStream,
     debug_visitor_cls=None,
+    frontend_limits: FrontendLimits | None = None,
 ) -> LockstepCompileResult:
     resolved_library_sources: list[str] = list(library_sources or [])
     resolved_library_source_files: list[str] = list(library_source_files or [])
@@ -407,6 +625,7 @@ def compile_lockstep(
         semantic_validator=semantic_validator,
         token_stream_cls=token_stream_cls,
         debug_visitor_cls=debug_visitor_cls,
+        frontend_limits=frontend_limits,
     )
 
 

--- a/tests/test_cli_libraries.py
+++ b/tests/test_cli_libraries.py
@@ -87,3 +87,40 @@ def test_run_cli_reports_stdin_file_in_diagnostics(tmp_path):
 
     assert exit_code == 1
     assert "<stdin>:1:" in stderr.getvalue()
+
+
+def test_run_cli_passes_frontend_limits_to_compiler():
+    captured = {}
+
+    def fake_compiler(source, *, frontend_limits=None):
+        captured["source"] = source
+        captured["frontend_limits"] = frontend_limits
+        return {
+            "streams": [],
+            "accumulators": [],
+            "uniforms": [],
+            "shaders": [],
+            "filters": [],
+            "bind_routes": [],
+        }
+
+    exit_code = run_cli(
+        [
+            "--simulate",
+            "--max-source-bytes",
+            "64",
+            "--parse-timeout-ms",
+            "50",
+            "--max-expr-nesting",
+            "16",
+        ],
+        stdin=io.StringIO("pipeline Main { bind { } }"),
+        stdout=io.StringIO(),
+        compiler=fake_compiler,
+    )
+
+    assert exit_code == 0
+    assert captured["source"] == "pipeline Main { bind { } }"
+    assert captured["frontend_limits"].max_source_bytes == 64
+    assert captured["frontend_limits"].parse_timeout_ms == 50
+    assert captured["frontend_limits"].max_expression_nesting == 16

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -1045,3 +1045,84 @@ def test_emit_llvm_ir_raises_on_intrinsic_type_mismatch():
                 "bind_routes": [],
             }
         )
+
+
+def test_compile_lockstep_enforces_source_size_limit():
+    with pytest.raises(lockstep_compiler.LockstepCompileError) as exc_info:
+        lockstep_compiler.compile_lockstep(
+            "pipeline P { bind { } }",
+            frontend_limits=lockstep_compiler.FrontendLimits(max_source_bytes=8),
+        )
+
+    assert exc_info.value.phase == "parse"
+    assert exc_info.value.errors[0].code == "LCK003"
+
+
+def test_compile_lockstep_enforces_expression_nesting_limit():
+    source = """
+shader S(in float v) {
+    float x = (((((((v)))))));
+}
+pipeline P {
+    stream<float,1> input;
+    bind {
+        input = S(input);
+    }
+}
+"""
+    with pytest.raises(lockstep_compiler.LockstepCompileError) as exc_info:
+        lockstep_compiler.compile_lockstep(
+            source,
+            frontend_limits=lockstep_compiler.FrontendLimits(max_expression_nesting=2),
+        )
+
+    assert exc_info.value.phase == "parse"
+    assert exc_info.value.errors[0].code == "LCK005"
+
+
+def test_compile_lockstep_enforces_parse_timeout(monkeypatch):
+    class StubLexer:
+        def __init__(self, input_stream):
+            self.input_stream = input_stream
+
+        def removeErrorListeners(self):
+            pass
+
+        def addErrorListener(self, listener):
+            pass
+
+    class StubParser:
+        def __init__(self, stream):
+            self._stream = stream
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            self._stream.LT(1)
+            return "TREE"
+
+    class StubVisitor:
+        def visit(self, _tree):
+            return None
+
+    monkeypatch.setattr(
+        compiler_module,
+        "_load_default_parser_classes",
+        lambda: (StubLexer, StubParser, StubVisitor),
+    )
+    monotonic_values = iter([0.0, 0.002])
+    monkeypatch.setattr(compiler_module.time, "monotonic", lambda: next(monotonic_values))
+
+    with pytest.raises(lockstep_compiler.LockstepCompileError) as exc_info:
+        lockstep_compiler.compile_lockstep(
+            "pipeline P { bind { } }",
+            frontend_limits=lockstep_compiler.FrontendLimits(parse_timeout_ms=1),
+        )
+
+    assert exc_info.value.phase == "parse"
+    assert exc_info.value.errors[0].code == "LCK004"


### PR DESCRIPTION
### Motivation
- Prevent pathological inputs from causing frontend DoS by bounding accepted source size, parse runtime, and expression nesting depth. 
- Provide programmable API and CLI knobs so host apps and CI can tune or disable limits as needed. 
- Surface limit violations as first-class parse diagnostics so callers can handle them consistently with existing parse/semantic errors.

### Description
- Add a `FrontendLimits` dataclass with defaults and normalization semantics and export it from the package as `FrontendLimits`. 
- Enforce limits with three new checks: `_enforce_source_size_limit` (source-size), a deadline-wrapping token stream `_DeadlineTokenStream` for parse-time budgets, and `_enforce_expression_nesting_limit` (expression nesting), with corresponding diagnostics `LCK003`, `LCK004`, and `LCK005`. 
- Wire `frontend_limits: FrontendLimits | None` through `compile_lockstep(...)` and `_compile_lockstep_with_dependencies(...)` so callers can pass limits programmatically. 
- Add CLI options `--max-source-bytes`, `--parse-timeout-ms`, and `--max-expr-nesting` and forward them as a `FrontendLimits` instance when the configured compiler callable supports the `frontend_limits` parameter. 
- Map limit violations into standard `LockstepCompileError` parse diagnostics so existing error handling and remapping logic applies.

### Testing
- Ran `pytest -q tests/test_compiler_api.py tests/test_cli_libraries.py tests/test_cli_format.py` and the test suite passed. 
- Added tests that assert `LCK003` for source-size, `LCK004` for parse-timeout, `LCK005` for expression-nesting, and a CLI test that verifies flags are forwarded as a `FrontendLimits` object.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73aa0e224832890aca21d16a07a6b)