### PR TITLE
Set default target triple and SIMD fallback in emit_llvm_ir

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -536,6 +536,18 @@ def _ast_body_for(entity: dict[str, Any], *, entity_kind: str) -> list[AstStatem
     return body_ast
 
 
+def _simd_width_for_target_triple(target_triple: str | None) -> int:
+    normalized = (target_triple or "").lower()
+    arch = normalized.split("-", maxsplit=1)[0]
+    if arch in {"x86_64", "amd64"}:
+        return 8
+    if arch in {"x86", "i386", "i486", "i586", "i686"}:
+        return 4
+    if arch in {"aarch64", "arm64", "arm", "armv7", "wasm32", "wasm64"}:
+        return 4
+    return 8
+
+
 def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
     """Generate LLVM IR using llvmlite lowering for pure/kernels."""
 
@@ -554,6 +566,10 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
     context = ir.Context()
     module = ir.Module(name="lockstep", context=context)
     module.source_filename = "lockstep"
+    target_triple = entities.get("target_triple")
+    if not isinstance(target_triple, str) or not target_triple.strip():
+        target_triple = "x86_64-unknown-linux-gnu"
+    module.triple = target_triple
     known_structs: dict[str, ir.IdentifiedStructType] = {}
     struct_fields: dict[str, list[dict[str, str]]] = {}
 
@@ -736,7 +752,7 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
 
     tick_entry = tick.append_basic_block("entry")
     tick_builder = ir.IRBuilder(tick_entry)
-    simd_width = 8
+    simd_width = _simd_width_for_target_triple(module.triple)
 
     def _zero_value(llvm_type: ir.Type) -> ir.Value:
         if isinstance(llvm_type, ir.VoidType):

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -708,6 +708,63 @@ def test_emit_llvm_ir_keeps_integer_arithmetic_in_integer_domain():
     assert "fadd float" not in llvm_ir
 
 
+def test_emit_llvm_ir_defaults_target_triple_and_simd_width_for_fold_reduce():
+    llvm_ir = emit_llvm_ir(
+        {
+            "structs": [],
+            "pure_functions": [],
+            "shaders": [],
+            "filters": [],
+            "streams": [],
+            "accumulators": [{"name": "energy", "type": "float"}],
+            "uniforms": [{"name": "total", "type": "float"}],
+            "bind_routes": ["uniform float total = fold sum(energy);"],
+            "bind_routes_ir": [
+                {
+                    "kind": "fold",
+                    "uniform_type": "float",
+                    "uniform_name": "total",
+                    "operator": "sum",
+                    "source": "energy",
+                    "route": "uniform float total = fold sum(energy);",
+                }
+            ],
+        }
+    )
+
+    assert 'target triple = "x86_64-unknown-linux-gnu"' in llvm_ir
+    assert 'call fast float @"llvm.vector.reduce.fadd.v8f32"' in llvm_ir
+
+
+def test_emit_llvm_ir_uses_default_simd_width_when_target_triple_is_unknown():
+    llvm_ir = emit_llvm_ir(
+        {
+            "target_triple": "mystery-unknown-none",
+            "structs": [],
+            "pure_functions": [],
+            "shaders": [],
+            "filters": [],
+            "streams": [],
+            "accumulators": [{"name": "energy", "type": "float"}],
+            "uniforms": [{"name": "total", "type": "float"}],
+            "bind_routes": ["uniform float total = fold sum(energy);"],
+            "bind_routes_ir": [
+                {
+                    "kind": "fold",
+                    "uniform_type": "float",
+                    "uniform_name": "total",
+                    "operator": "sum",
+                    "source": "energy",
+                    "route": "uniform float total = fold sum(energy);",
+                }
+            ],
+        }
+    )
+
+    assert 'target triple = "mystery-unknown-none"' in llvm_ir
+    assert 'call fast float @"llvm.vector.reduce.fadd.v8f32"' in llvm_ir
+
+
 def test_emit_llvm_ir_lowers_fold_routes_to_vector_reduce_intrinsics():
     llvm_ir = emit_llvm_ir(
         {


### PR DESCRIPTION
### Motivation
- Ensure folding/vector-reduce lowering picks a reasonable SIMD width when the LLVM target triple is missing or unrecognized to avoid hardcoded assumptions.
- Make the generated LLVM module carry a concrete target triple so downstream tools/IR consumers see a sensible default target.

### Description
- Added `_simd_width_for_target_triple(target_triple: str | None) -> int` to derive a SIMD lane count from the target architecture with a safe fallback of `8` lanes.
- Read `entities["target_triple"]` inside `emit_llvm_ir` and assign a default triple of `"x86_64-unknown-linux-gnu"` when missing or blank, storing it in `module.triple`.
- Replaced the hardcoded `simd_width = 8` in `Lockstep_Tick` lowering with a call to `_simd_width_for_target_triple(module.triple)` so vector reduce intrinsics are emitted using the computed width.
- Added tests to `tests/test_compiler_api.py` that verify the default triple is emitted and that fold lowering produces the `v8f32` reduce intrinsic when the triple is absent or unknown.

### Testing
- Ran `pytest -q tests/test_compiler_api.py -k "target_triple or fold_routes_to_vector_reduce_intrinsics"`, which passed (all targeted tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73b18ad3083289448c7163af12837)