### PR TITLE
Flatten nested arena bindings into SoA leaf fields for C header and Tick ABI

### DIFF
--- a/examples/minimal_host.c
+++ b/examples/minimal_host.c
@@ -10,15 +10,15 @@ int main(void) {
 
     struct Lockstep_Arena* arena = (struct Lockstep_Arena*)arena_bytes;
 
-    arena->stream_particles.pos = 10.0f;
-    arena->stream_particles.vel = 2.0f;
-    arena->uniform_dt = 0.5f;
+    arena->stream_particles_pos = 10.0f;
+    arena->stream_particles_vel = 2.0f;
+    arena->uniform_dt_value = 0.5f;
 
     Lockstep_Tick(arena);
 
     printf("After tick: pos=%.2f vel=%.2f dt=%.2f\n",
-           arena->stream_particles.pos,
-           arena->stream_particles.vel,
-           arena->uniform_dt);
+           arena->stream_particles_pos,
+           arena->stream_particles_vel,
+           arena->uniform_dt_value);
     return 0;
 }

--- a/lockstep_compiler/arena_layout.py
+++ b/lockstep_compiler/arena_layout.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+_PRIMITIVE_SIZE = {
+    "bool": 1,
+    "int": 4,
+    "uint": 4,
+    "float": 4,
+    "double": 8,
+}
+
+
+@dataclass(frozen=True)
+class ArenaLeaf:
+    kind: str
+    binding_name: str
+    path: tuple[str, ...]
+    type_name: str
+    offset: int
+    size: int
+
+
+@dataclass(frozen=True)
+class ArenaLayout:
+    normalized_structs: list[dict[str, Any]]
+    known_structs: set[str]
+    struct_sizes: dict[str, int]
+    opaque_structs: set[str]
+    leaves: list[ArenaLeaf]
+    top_level_offsets: list[tuple[str, str, int]]
+    total_size: int
+
+
+def normalize_structs(structs: list[Any]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for struct_decl in structs:
+        if isinstance(struct_decl, str):
+            normalized.append({"name": struct_decl, "fields": []})
+        elif isinstance(struct_decl, dict) and struct_decl.get("name"):
+            fields = (
+                struct_decl.get("fields")
+                if isinstance(struct_decl.get("fields"), list)
+                else []
+            )
+            normalized.append({"name": struct_decl["name"], "fields": fields})
+    return normalized
+
+
+def field_size(type_name: str, struct_sizes: dict[str, int]) -> int:
+    if type_name in _PRIMITIVE_SIZE:
+        return _PRIMITIVE_SIZE[type_name]
+    if type_name in struct_sizes:
+        return struct_sizes[type_name]
+    return 8
+
+
+def resolve_struct_layouts(
+    normalized_structs: list[dict[str, Any]],
+) -> tuple[dict[str, int], set[str]]:
+    struct_sizes: dict[str, int] = {}
+    unresolved = {struct["name"] for struct in normalized_structs}
+    struct_map = {struct["name"]: struct for struct in normalized_structs}
+    opaque_structs: set[str] = set()
+
+    while unresolved:
+        progress = False
+        for struct_name in list(unresolved):
+            fields = struct_map[struct_name].get("fields", [])
+            can_resolve = True
+            size = 0
+            for field in fields:
+                field_type_name = field.get("type", "float")
+                if field_type_name in unresolved:
+                    can_resolve = False
+                    break
+                size += field_size(field_type_name, struct_sizes)
+            if not can_resolve:
+                continue
+            struct_sizes[struct_name] = size
+            unresolved.remove(struct_name)
+            progress = True
+
+        if not progress:
+            for struct_name in unresolved:
+                struct_sizes[struct_name] = 1
+                opaque_structs.add(struct_name)
+            break
+
+    return struct_sizes, opaque_structs
+
+
+def _flatten_type_leaves(
+    type_name: str,
+    struct_map: dict[str, dict[str, Any]],
+    opaque_structs: set[str],
+    *,
+    path: tuple[str, ...] = (),
+) -> list[tuple[tuple[str, ...], str]]:
+    if type_name in _PRIMITIVE_SIZE:
+        return [(path, type_name)]
+    struct_decl = struct_map.get(type_name)
+    if struct_decl is None or type_name in opaque_structs:
+        return [(path, type_name)]
+    leaves: list[tuple[tuple[str, ...], str]] = []
+    for field in struct_decl.get("fields", []):
+        child_name = str(field.get("name", "field"))
+        child_type = str(field.get("type", "float"))
+        leaves.extend(
+            _flatten_type_leaves(
+                child_type,
+                struct_map,
+                opaque_structs,
+                path=path + (child_name,),
+            )
+        )
+    if not leaves:
+        return [(path, type_name)]
+    return leaves
+
+
+def build_arena_layout(entities: dict[str, Any]) -> ArenaLayout:
+    normalized_structs = normalize_structs(entities.get("structs", []))
+    known_structs = {struct["name"] for struct in normalized_structs}
+    struct_sizes, opaque_structs = resolve_struct_layouts(normalized_structs)
+    struct_map = {struct["name"]: struct for struct in normalized_structs}
+
+    bindings: list[tuple[str, str, str]] = []
+    for stream in entities.get("streams", []):
+        bindings.append(("stream", stream["name"], stream["type"]))
+    for accumulator in entities.get("accumulators", []):
+        bindings.append(("accum", accumulator["name"], accumulator["type"]))
+    for uniform in entities.get("uniforms", []):
+        bindings.append(("uniform", uniform["name"], uniform["type"]))
+
+    leaves: list[ArenaLeaf] = []
+    top_level_offsets: list[tuple[str, str, int]] = []
+    cursor = 0
+    for kind, binding_name, type_name in bindings:
+        top_level_offsets.append((kind, binding_name, cursor))
+        type_leaves = _flatten_type_leaves(type_name, struct_map, opaque_structs)
+        for path, leaf_type in type_leaves:
+            size = field_size(leaf_type, struct_sizes)
+            leaves.append(
+                ArenaLeaf(
+                    kind=kind,
+                    binding_name=binding_name,
+                    path=path,
+                    type_name=leaf_type,
+                    offset=cursor,
+                    size=size,
+                )
+            )
+            cursor += size
+
+    return ArenaLayout(
+        normalized_structs=normalized_structs,
+        known_structs=known_structs,
+        struct_sizes=struct_sizes,
+        opaque_structs=opaque_structs,
+        leaves=leaves,
+        top_level_offsets=top_level_offsets,
+        total_size=cursor,
+    )

--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from .ast import AstProgram, ast_to_entities
+from .arena_layout import build_arena_layout
 from .utils import sanitize_symbol as _sanitize_symbol
 
 _PRIMITIVE_C_TYPE = {
@@ -20,64 +21,6 @@ _PRIMITIVE_SIZE = {
     "float": 4,
     "double": 8,
 }
-
-
-def _normalize_structs(structs: list[Any]) -> list[dict[str, Any]]:
-    normalized: list[dict[str, Any]] = []
-    for struct_decl in structs:
-        if isinstance(struct_decl, str):
-            normalized.append({"name": struct_decl, "fields": []})
-        elif isinstance(struct_decl, dict) and struct_decl.get("name"):
-            fields = (
-                struct_decl.get("fields")
-                if isinstance(struct_decl.get("fields"), list)
-                else []
-            )
-            normalized.append({"name": struct_decl["name"], "fields": fields})
-    return normalized
-
-
-def _field_size(type_name: str, struct_sizes: dict[str, int]) -> int:
-    if type_name in _PRIMITIVE_SIZE:
-        return _PRIMITIVE_SIZE[type_name]
-    if type_name in struct_sizes:
-        return struct_sizes[type_name]
-    return 8
-
-
-def _resolve_struct_layouts(
-    normalized_structs: list[dict[str, Any]],
-) -> tuple[dict[str, int], set[str]]:
-    struct_sizes: dict[str, int] = {}
-    unresolved = {struct["name"] for struct in normalized_structs}
-    struct_map = {struct["name"]: struct for struct in normalized_structs}
-    opaque_structs: set[str] = set()
-
-    while unresolved:
-        progress = False
-        for struct_name in list(unresolved):
-            fields = struct_map[struct_name].get("fields", [])
-            can_resolve = True
-            size = 0
-            for field in fields:
-                field_type_name = field.get("type", "float")
-                if field_type_name in unresolved:
-                    can_resolve = False
-                    break
-                size += _field_size(field_type_name, struct_sizes)
-            if not can_resolve:
-                continue
-            struct_sizes[struct_name] = size
-            unresolved.remove(struct_name)
-            progress = True
-
-        if not progress:
-            for struct_name in unresolved:
-                struct_sizes[struct_name] = 1
-                opaque_structs.add(struct_name)
-            break
-
-    return struct_sizes, opaque_structs
 
 
 def _c_type(type_name: str, known_structs: set[str]) -> str:
@@ -98,23 +41,10 @@ def emit_c_header(
         else program_or_entities
     )
 
-    normalized_structs = _normalize_structs(entities.get("structs", []))
-    known_structs = {struct["name"] for struct in normalized_structs}
-    struct_sizes, opaque_structs = _resolve_struct_layouts(normalized_structs)
-
-    arena_fields: list[tuple[str, str, str]] = []
-    for stream in entities.get("streams", []):
-        arena_fields.append(("stream", stream["name"], stream["type"]))
-    for accumulator in entities.get("accumulators", []):
-        arena_fields.append(("accum", accumulator["name"], accumulator["type"]))
-    for uniform in entities.get("uniforms", []):
-        arena_fields.append(("uniform", uniform["name"], uniform["type"]))
-
-    offsets: list[tuple[str, str, int]] = []
-    cursor = 0
-    for kind, name, type_name in arena_fields:
-        offsets.append((kind, name, cursor))
-        cursor += _field_size(type_name, struct_sizes)
+    layout = build_arena_layout(entities)
+    normalized_structs = layout.normalized_structs
+    known_structs = layout.known_structs
+    opaque_structs = layout.opaque_structs
 
     lines = [
         f"#ifndef {guard}",
@@ -153,16 +83,24 @@ def emit_c_header(
         lines.append("")
 
     lines.append("LOCKSTEP_PACKED_STRUCT(struct Lockstep_Arena {")
-    for kind, name, type_name in arena_fields:
-        c_type_name = _c_type(type_name, known_structs)
-        lines.append(f"    {c_type_name} {kind}_{_sanitize_symbol(name)};")
+    for leaf in layout.leaves:
+        c_type_name = _c_type(leaf.type_name, known_structs)
+        path_suffix = "_".join(_sanitize_symbol(part) for part in leaf.path) if leaf.path else "value"
+        field_name = f"{leaf.kind}_{_sanitize_symbol(leaf.binding_name)}_{path_suffix}"
+        lines.append(f"    {c_type_name} {field_name};")
     lines.append("});")
     lines.append("")
 
-    lines.append(f"#define LOCKSTEP_ARENA_BYTES {cursor}")
-    for kind, name, offset in offsets:
+    lines.append(f"#define LOCKSTEP_ARENA_BYTES {layout.total_size}")
+    for kind, name, offset in layout.top_level_offsets:
         macro_suffix = f"{kind}_{_sanitize_symbol(name)}".upper()
         lines.append(f"#define LOCKSTEP_OFFSET_{macro_suffix} {offset}")
+    for leaf in layout.leaves:
+        if not leaf.path:
+            continue
+        leaf_suffix = "_".join(_sanitize_symbol(part) for part in leaf.path).upper()
+        macro_suffix = f"{leaf.kind}_{_sanitize_symbol(leaf.binding_name)}_{leaf_suffix}".upper()
+        lines.append(f"#define LOCKSTEP_OFFSET_{macro_suffix} {leaf.offset}")
     for stream in entities.get("streams", []):
         stream_name = _sanitize_symbol(stream["name"]).upper()
         stream_capacity = (

--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -19,6 +19,7 @@ from .ast import (
     AstVarDeclStmt,
     ast_to_entities,
 )
+from .arena_layout import build_arena_layout
 from .utils import sanitize_symbol as _sanitize_symbol
 
 
@@ -678,35 +679,25 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
             fn, _ast_body_for(flt, entity_kind="filter"), ir.VoidType()
         )
 
-    arena_fields: list[tuple[str, str, ir.Type]] = []
-    stream_slots: dict[str, int] = {}
+    layout = build_arena_layout(entities)
+
+    stream_slots: dict[str, int] = {stream["name"]: idx for idx, stream in enumerate(streams)}
     stream_capacities: dict[str, int] = {}
     for stream in streams:
-        stream_slots[stream["name"]] = len(arena_fields)
-        arena_fields.append(
-            (
-                "stream",
-                stream["name"],
-                lowerer._llvm_type(stream["type"], known_structs),
-            )
-        )
         stream_capacities[stream["name"]] = int(stream.get("capacity", 0))
-    accum_slots: dict[str, int] = {}
+    accum_slots: dict[str, int] = {accum["name"]: idx for idx, accum in enumerate(accumulators)}
+    uniform_slots: dict[str, int] = {uniform["name"]: idx for idx, uniform in enumerate(uniforms)}
+
+    leaf_offsets: dict[tuple[str, str, tuple[str, ...]], int] = {
+        (leaf.kind, leaf.binding_name, leaf.path): leaf.offset for leaf in layout.leaves
+    }
+    binding_declared_types: dict[tuple[str, str], str] = {}
+    for stream in streams:
+        binding_declared_types[("stream", stream["name"])] = stream["type"]
     for accum in accumulators:
-        accum_slots[accum["name"]] = len(arena_fields)
-        arena_fields.append(
-            ("accum", accum["name"], lowerer._llvm_type(accum["type"], known_structs))
-        )
-    uniform_slots: dict[str, int] = {}
+        binding_declared_types[("accum", accum["name"])] = accum["type"]
     for uniform in uniforms:
-        uniform_slots[uniform["name"]] = len(arena_fields)
-        arena_fields.append(
-            (
-                "uniform",
-                uniform["name"],
-                lowerer._llvm_type(uniform["type"], known_structs),
-            )
-        )
+        binding_declared_types[("uniform", uniform["name"])] = uniform["type"]
 
     kernel_signatures = {
         shader["name"]: {"kind": "shader", "params": shader.get("params", [])}
@@ -719,12 +710,10 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
         }
     )
 
-    arena_slots: dict[tuple[str, str], int] = {
-        (kind, name): index for index, (kind, name, _) in enumerate(arena_fields)
-    }
     arena_struct_ty = module.context.get_identified_type("struct.Lockstep_Arena")
-    if arena_struct_ty.is_opaque and arena_fields:
-        arena_struct_ty.set_body(*[field_type for _, _, field_type in arena_fields])
+    arena_bytes_ty = ir.ArrayType(ir.IntType(8), max(layout.total_size, 1))
+    if arena_struct_ty.is_opaque:
+        arena_struct_ty.set_body(arena_bytes_ty)
 
     tick = ir.Function(
         module,
@@ -743,27 +732,71 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
             return ir.Constant(ir.IntType(32), 0)
         return ir.Constant(llvm_type, None)
 
-    def _load_tick_param(kind: str, name: str, field_type: ir.Type) -> ir.Value:
-        field_index = arena_slots.get((kind, name))
-        if field_index is None:
-            return _zero_value(field_type)
-        field_ptr = tick_builder.gep(
+    def _leaf_ptr(kind: str, name: str, path: tuple[str, ...], leaf_type: ir.Type) -> ir.Value | None:
+        offset = leaf_offsets.get((kind, name, path))
+        if offset is None:
+            return None
+        raw_ptr = tick_builder.gep(
             arena_ptr,
-            [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), field_index)],
-            name=f"{kind}_{_sanitize_symbol(name)}_ptr",
+            [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), offset)],
+            name=f"{kind}_{_sanitize_symbol(name)}_{'_'.join(path) if path else 'value'}_raw",
         )
-        return tick_builder.load(field_ptr, name=f"{kind}_{_sanitize_symbol(name)}_val")
+        return tick_builder.bitcast(raw_ptr, leaf_type.as_pointer())
 
-    def _store_arena_slot(field_index: int, value: ir.Value):
-        if field_index < 0 or field_index >= len(arena_fields):
+    def _load_value(
+        kind: str,
+        name: str,
+        value_type: ir.Type,
+        declared_type: str,
+        path: tuple[str, ...] = (),
+    ) -> ir.Value:
+        if declared_type in struct_fields and isinstance(value_type, ir.IdentifiedStructType):
+            aggregate = ir.Constant(value_type, ir.Undefined)
+            fields = struct_fields.get(declared_type, [])
+            for index, element_type in enumerate(value_type.elements):
+                field = fields[index] if index < len(fields) else {}
+                child_name = str(field.get("name", f"field{index}"))
+                child_type = str(field.get("type", "float"))
+                field_value = _load_value(
+                    kind,
+                    name,
+                    element_type,
+                    child_type,
+                    path + (child_name,),
+                )
+                aggregate = tick_builder.insert_value(aggregate, field_value, index)
+            return aggregate
+
+        ptr = _leaf_ptr(kind, name, path, value_type)
+        if ptr is None:
+            return _zero_value(value_type)
+        return tick_builder.load(ptr, name=f"{kind}_{_sanitize_symbol(name)}_val")
+
+    def _store_value(
+        kind: str,
+        name: str,
+        value: ir.Value,
+        declared_type: str,
+        path: tuple[str, ...] = (),
+    ):
+        value_type = value.type
+        if declared_type in struct_fields and isinstance(value_type, ir.IdentifiedStructType):
+            fields = struct_fields.get(declared_type, [])
+            for index, element_type in enumerate(value_type.elements):
+                part = tick_builder.extract_value(value, index)
+                field = fields[index] if index < len(fields) else {}
+                child_name = str(field.get("name", f"field{index}"))
+                child_type = str(field.get("type", "float"))
+                _store_value(kind, name, part, child_type, path + (child_name,))
             return
-        kind, name, _ = arena_fields[field_index]
-        field_ptr = tick_builder.gep(
-            arena_ptr,
-            [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), field_index)],
-            name=f"{kind}_{_sanitize_symbol(name)}_ptr",
-        )
-        tick_builder.store(value, field_ptr)
+        ptr = _leaf_ptr(kind, name, path, value_type)
+        if ptr is None:
+            return
+        tick_builder.store(value, ptr)
+
+    def _load_tick_param(kind: str, name: str, field_type: ir.Type) -> ir.Value:
+        declared_type = binding_declared_types.get((kind, name), "float")
+        return _load_value(kind, name, field_type, declared_type)
 
     def _build_vector_splat(value: ir.Value, width: int) -> ir.Value:
         vec_ty = ir.VectorType(value.type, width)
@@ -932,16 +965,13 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
                 source_name = str(route.get("source", ""))
                 uniform_name = str(route.get("uniform_name", ""))
                 operator = str(route.get("operator", ""))
-                source_slot = accum_slots.get(source_name)
-                uniform_slot = uniform_slots.get(uniform_name)
-                if source_slot is None or uniform_slot is None:
+                if source_name not in accum_slots or uniform_name not in uniform_slots:
                     continue
                 uniform_type_name = str(route.get("uniform_type", "float"))
                 uniform_type = lowerer._llvm_type(uniform_type_name, known_structs)
-                accum_kind, accum_name, _ = arena_fields[source_slot]
-                accum_value = _load_tick_param(accum_kind, accum_name, uniform_type)
+                accum_value = _load_tick_param("accum", source_name, uniform_type)
                 reduced = _reduce_fold(operator, accum_value, uniform_type)
-                _store_arena_slot(uniform_slot, reduced)
+                _store_value("uniform", uniform_name, reduced, uniform_type_name)
                 continue
             asm_ty = ir.FunctionType(ir.VoidType(), [])
             escaped = (

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -733,8 +733,9 @@ def test_emit_llvm_ir_lowers_fold_routes_to_vector_reduce_intrinsics():
     )
 
     assert 'call fast float @"llvm.vector.reduce.fadd.v8f32"' in llvm_ir
-    assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 1' in llvm_ir
-    assert 'store float %"fold_reduce", float* %"uniform_total_ptr"' in llvm_ir
+    assert '%"struct.Lockstep_Arena" = type {[8 x i8]}' in llvm_ir
+    assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 0, i32 4' in llvm_ir
+    assert 'store float %"fold_reduce"' in llvm_ir
 
 
 def test_emit_llvm_ir_raises_on_mixed_int_float_expression():
@@ -894,6 +895,39 @@ def test_emit_c_header_generates_structs_offsets_and_tick_signature():
     assert "#define LOCKSTEP_OFFSET_ACCUM_ENERGY 12" in header
     assert "#define LOCKSTEP_OFFSET_UNIFORM_DT 16" in header
     assert "void Lockstep_Tick(struct Lockstep_Arena* arena);" in header
+
+
+def test_emit_c_header_exposes_nested_leaf_offsets_for_soa_layout():
+    header = emit_c_header(
+        {
+            "structs": [
+                {
+                    "name": "Inner",
+                    "fields": [
+                        {"type": "float", "name": "x"},
+                        {"type": "float", "name": "y"},
+                    ],
+                },
+                {
+                    "name": "Outer",
+                    "fields": [
+                        {"type": "Inner", "name": "pos"},
+                        {"type": "float", "name": "mass"},
+                    ],
+                },
+            ],
+            "streams": [{"name": "particles", "type": "Outer"}],
+            "accumulators": [],
+            "uniforms": [],
+        }
+    )
+
+    assert "float stream_particles_pos_x;" in header
+    assert "float stream_particles_pos_y;" in header
+    assert "float stream_particles_mass;" in header
+    assert "#define LOCKSTEP_OFFSET_STREAM_PARTICLES_POS_X 0" in header
+    assert "#define LOCKSTEP_OFFSET_STREAM_PARTICLES_POS_Y 4" in header
+    assert "#define LOCKSTEP_OFFSET_STREAM_PARTICLES_MASS 8" in header
 
 
 def test_emit_c_header_includes_optional_saturated_write_debug_helpers():


### PR DESCRIPTION
### Motivation
- Improve memory layout and host interoperability by decomposing nested struct types into contiguous Structure-of-Arrays (SoA) leaf fields so host code and generated LLVM IR can access individual components efficiently.
- Preserve the original struct declarations in the generated header while exposing per-leaf arena fields and offsets for single-byte-contiguous arena addressing.

### Description
- Add `lockstep_compiler/arena_layout.py` to normalize struct declarations, compute struct sizes, and flatten nested struct types into a list of leaf paths with compile-time byte offsets and top-level binding offsets.
- Update `emit_c_header` in `lockstep_compiler/c_header.py` to keep packed `struct Lockstep_<Name>` declarations but emit `struct Lockstep_Arena` as contiguous per-leaf fields and to emit both top-level `LOCKSTEP_OFFSET_*` and per-leaf `LOCKSTEP_OFFSET_*_*` macros.
- Modify the LLVM lowering in `lockstep_compiler/codegen.py` so `Lockstep_Arena` is represented as a byte array and `Lockstep_Tick` loads/stores values via leaf byte offsets, reconstructing nested struct aggregates when lowering kernel/filter/pure calls and fold routes.
- Update tests and example: add a test verifying nested leaf offsets and update `examples/minimal_host.c` to use the generated leaf arena field names.

### Testing
- Ran `pytest -q tests/test_compiler_api.py` and the entire compiler API test file passed successfully. 
- Ran the focused trio `test_emit_c_header_generates_structs_offsets_and_tick_signature`, `test_emit_c_header_exposes_nested_leaf_offsets_for_soa_layout`, and `test_emit_llvm_ir_lowers_fold_routes_to_vector_reduce_intrinsics`, and they all passed. 
- Ran the full test suite with `pytest -q` but collection failed in this environment due to missing external test dependency (`hypothesis`) and import-path issues unrelated to these changes, so full-suite execution was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73ac098088328a494a9d2e3ea064b)