### PR TITLE
Add branchless select built-in for typed conditional selection

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -344,6 +344,20 @@ class _FunctionLowerer:
         self._compiler_error(f"undefined variable '{parts[0]}'")
 
     def _lower_call(self, name: str, args: list[ir.Value]) -> ir.Value:
+        if name == "select":
+            if len(args) != 3:
+                self._compiler_error(
+                    f"built-in 'select' expects 3 argument(s), got {len(args)}"
+                )
+            condition, when_true, when_false = args
+            if not isinstance(condition.type, ir.IntType) or condition.type.width != 1:
+                self._compiler_error("built-in 'select' expects a bool condition")
+            if when_true.type != when_false.type:
+                self._compiler_error(
+                    "built-in 'select' expects matching true/false value types"
+                )
+            return self.builder.select(condition, when_true, when_false, name="select")
+
         if name in self.intrinsic_names:
             lowered_intrinsic = self._lower_intrinsic_call(name, args)
             if lowered_intrinsic is not None:

--- a/lockstep_compiler/semantic_validator.py
+++ b/lockstep_compiler/semantic_validator.py
@@ -794,6 +794,9 @@ def build_semantic_validator(base_visitor_cls):
             def _is_cast_function_name(name: str) -> bool:
                 return name in {"int", "float", "double", "uint", "bool"}
 
+            def _is_select_builtin(name: str) -> bool:
+                return name == "select"
+
             def _child_text(index: int) -> str | None:
                 if not hasattr(ctx, "getChild"):
                     return None
@@ -1081,6 +1084,58 @@ def build_semantic_validator(base_visitor_cls):
                             )
                             return None
                         return function_name
+                    if _is_select_builtin(function_name):
+                        args = ctx.exprList().expr() if ctx.exprList() is not None else []
+                        if len(args) != 3:
+                            self._add_diagnostic(
+                                severity="error",
+                                code=SEMANTIC_DIAGNOSTIC_CODES[
+                                    "pure_argument_count_mismatch"
+                                ],
+                                message=(
+                                    f"Built-in 'select(...)' expects 3 arguments, but got {len(args)}."
+                                ),
+                                ctx=ctx,
+                                hint="Use `select(condition, when_true, when_false)`.",
+                            )
+                            return None
+
+                        condition_type = self._resolve_expr_type(args[0])
+                        true_type = self._resolve_expr_type(args[1])
+                        false_type = self._resolve_expr_type(args[2])
+                        if condition_type is not None and condition_type != "bool":
+                            self._add_diagnostic(
+                                severity="error",
+                                code=SEMANTIC_DIAGNOSTIC_CODES[
+                                    "pure_argument_type_mismatch"
+                                ],
+                                message=(
+                                    "Type mismatch for built-in 'select' condition: "
+                                    f"expected bool, got {condition_type}."
+                                ),
+                                ctx=ctx,
+                                hint="Pass a boolean condition as the first argument.",
+                            )
+                            return None
+
+                        if true_type is not None and false_type is not None and true_type != false_type:
+                            self._add_diagnostic(
+                                severity="error",
+                                code=SEMANTIC_DIAGNOSTIC_CODES[
+                                    "pure_argument_type_mismatch"
+                                ],
+                                message=(
+                                    "Type mismatch for built-in 'select' value arguments: "
+                                    f"expected matching types, got {true_type} and {false_type}."
+                                ),
+                                ctx=ctx,
+                                hint="Pass true/false values with the same type.",
+                            )
+                            return None
+
+                        if true_type is not None:
+                            return true_type
+                        return false_type
                     function_signature = self.pure_functions.get(function_name)
                     if function_signature is not None:
                         return function_signature.return_type
@@ -1495,6 +1550,54 @@ def build_semantic_validator(base_visitor_cls):
                                 ctx=ctx,
                                 hint="Pass exactly one expression to a cast.",
                             )
+                    elif callee_name == "select":
+                        args = ctx.exprList().expr() if ctx.exprList() is not None else []
+                        if len(args) != 3:
+                            self._add_diagnostic(
+                                severity="error",
+                                code=SEMANTIC_DIAGNOSTIC_CODES[
+                                    "pure_argument_count_mismatch"
+                                ],
+                                message=(
+                                    f"Built-in 'select(...)' expects 3 arguments, but got {len(args)}."
+                                ),
+                                ctx=ctx,
+                                hint="Use `select(condition, when_true, when_false)`.",
+                            )
+                        else:
+                            condition_type = self._resolve_expr_type(args[0])
+                            true_type = self._resolve_expr_type(args[1])
+                            false_type = self._resolve_expr_type(args[2])
+                            if condition_type is not None and condition_type != "bool":
+                                self._add_diagnostic(
+                                    severity="error",
+                                    code=SEMANTIC_DIAGNOSTIC_CODES[
+                                        "pure_argument_type_mismatch"
+                                    ],
+                                    message=(
+                                        "Type mismatch for built-in 'select' condition: "
+                                        f"expected bool, got {condition_type}."
+                                    ),
+                                    ctx=ctx,
+                                    hint="Pass a boolean condition as the first argument.",
+                                )
+                            if (
+                                true_type is not None
+                                and false_type is not None
+                                and true_type != false_type
+                            ):
+                                self._add_diagnostic(
+                                    severity="error",
+                                    code=SEMANTIC_DIAGNOSTIC_CODES[
+                                        "pure_argument_type_mismatch"
+                                    ],
+                                    message=(
+                                        "Type mismatch for built-in 'select' value arguments: "
+                                        f"expected matching types, got {true_type} and {false_type}."
+                                    ),
+                                    ctx=ctx,
+                                    hint="Pass true/false values with the same type.",
+                                )
                     else:
                         self._type_check_pure_call(ctx)
                 return self.visitChildren(ctx)

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -708,6 +708,93 @@ def test_emit_llvm_ir_keeps_integer_arithmetic_in_integer_domain():
     assert "fadd float" not in llvm_ir
 
 
+
+
+def test_emit_llvm_ir_lowers_select_builtin_for_integers():
+    llvm_ir = emit_llvm_ir(
+        {
+            "structs": [],
+            "pure_functions": [
+                {
+                    "name": "pick",
+                    "return_type": "int",
+                    "params": [
+                        {"type": "bool", "name": "condition"},
+                        {"type": "int", "name": "a"},
+                        {"type": "int", "name": "b"},
+                    ],
+                    "body_ast": [
+                        AstReturnStmt(
+                            value=AstExprCall(
+                                name="select",
+                                args=(
+                                    AstExprVar(path=("condition",)),
+                                    AstExprVar(path=("a",)),
+                                    AstExprVar(path=("b",)),
+                                ),
+                            )
+                        )
+                    ],
+                }
+            ],
+            "shaders": [],
+            "filters": [],
+            "streams": [],
+            "accumulators": [],
+            "uniforms": [],
+            "bind_routes": [],
+        }
+    )
+
+    assert 'i1 %"condition_val", i32 %"a_val", i32 %"b_val"' in llvm_ir
+
+
+def test_emit_llvm_ir_lowers_select_builtin_for_structs():
+    llvm_ir = emit_llvm_ir(
+        {
+            "structs": [
+                {
+                    "name": "Pair",
+                    "fields": [
+                        {"type": "int", "name": "left"},
+                        {"type": "int", "name": "right"},
+                    ],
+                }
+            ],
+            "pure_functions": [
+                {
+                    "name": "pick_pair",
+                    "return_type": "Pair",
+                    "params": [
+                        {"type": "bool", "name": "condition"},
+                        {"type": "Pair", "name": "a"},
+                        {"type": "Pair", "name": "b"},
+                    ],
+                    "body_ast": [
+                        AstReturnStmt(
+                            value=AstExprCall(
+                                name="select",
+                                args=(
+                                    AstExprVar(path=("condition",)),
+                                    AstExprVar(path=("a",)),
+                                    AstExprVar(path=("b",)),
+                                ),
+                            )
+                        )
+                    ],
+                }
+            ],
+            "shaders": [],
+            "filters": [],
+            "streams": [],
+            "accumulators": [],
+            "uniforms": [],
+            "bind_routes": [],
+        }
+    )
+
+    assert 'i1 %"condition_val", %"struct.Pair" %"a_val", %"struct.Pair" %"b_val"' in llvm_ir
+
 def test_emit_llvm_ir_lowers_fold_routes_to_vector_reduce_intrinsics():
     llvm_ir = emit_llvm_ir(
         {

--- a/tests/test_debug_compiler.py
+++ b/tests/test_debug_compiler.py
@@ -1617,6 +1617,97 @@ def test_semantic_validator_accepts_intrinsic_pure_call(debug_compiler_module):
     assert validator.diagnostics == []
 
 
+
+
+def test_semantic_validator_accepts_select_builtin_for_matching_integer_values(
+    debug_compiler_module,
+):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    call_ctx = _ctx(
+        start_line=41,
+        start_col=3,
+        ID=lambda: _token("select"),
+        exprList=lambda: _ctx(
+            expr=lambda: [
+                _ctx(declared_type="bool"),
+                _ctx(declared_type="int"),
+                _ctx(declared_type="int"),
+            ]
+        ),
+    )
+
+    validator.visitPrimaryExpr(call_ctx)
+
+    assert validator.diagnostics == []
+
+
+def test_semantic_validator_reports_select_builtin_condition_type_mismatch(
+    debug_compiler_module,
+):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    call_ctx = _ctx(
+        start_line=42,
+        start_col=3,
+        ID=lambda: _token("select"),
+        exprList=lambda: _ctx(
+            expr=lambda: [
+                _ctx(declared_type="int"),
+                _ctx(declared_type="int"),
+                _ctx(declared_type="int"),
+            ]
+        ),
+    )
+
+    validator.visitPrimaryExpr(call_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK412",
+            message="Type mismatch for built-in 'select' condition: expected bool, got int.",
+            line=42,
+            column=3,
+            hint="Pass a boolean condition as the first argument.",
+        )
+    ]
+
+
+def test_semantic_validator_reports_select_builtin_value_type_mismatch(
+    debug_compiler_module,
+):
+    validator = debug_compiler_module.LockstepSemanticValidator()
+
+    call_ctx = _ctx(
+        start_line=43,
+        start_col=3,
+        ID=lambda: _token("select"),
+        exprList=lambda: _ctx(
+            expr=lambda: [
+                _ctx(declared_type="bool"),
+                _ctx(declared_type="int"),
+                _ctx(declared_type="float"),
+            ]
+        ),
+    )
+
+    validator.visitPrimaryExpr(call_ctx)
+
+    assert validator.diagnostics == [
+        debug_compiler_module.LockstepDiagnostic(
+            severity="error",
+            code="LCK412",
+            message=(
+                "Type mismatch for built-in 'select' value arguments: "
+                "expected matching types, got int and float."
+            ),
+            line=43,
+            column=3,
+            hint="Pass true/false values with the same type.",
+        )
+    ]
+
 def test_semantic_validator_accepts_struct_types_in_declarations(debug_compiler_module):
     validator = debug_compiler_module.LockstepSemanticValidator()
 


### PR DESCRIPTION
### Motivation
- Provide a branchless ternary-style primitive so callers can express conditional selection on integers and structs without introducing control-flow.
- Ensure the new builtin is validated by the semantic layer so uses are checked for arity and type safety before lowering.

### Description
- Add recognition of a `select(condition, when_true, when_false)` builtin in the semantic expression resolver and `visitPrimaryExpr`, enforcing exactly 3 arguments, a `bool` condition, and matching types for the true/false operands, and returning the selected value type for downstream checks (`lockstep_compiler/semantic_validator.py`).
- Implement LLVM lowering for `select` in the code generator using `IRBuilder.select`, validating the condition is an i1/bool and that true/false operands share the same LLVM type (`lockstep_compiler/codegen.py`).
- Add unit tests covering semantic-validator success and failure modes for `select` and codegen tests ensuring LLVM IR emits the `select` instruction for integer and struct value selections (`tests/test_debug_compiler.py`, `tests/test_compiler_api.py`).

### Testing
- Ran targeted semantic and codegen tests: `pytest -q tests/test_debug_compiler.py::test_semantic_validator_accepts_select_builtin_for_matching_integer_values tests/test_debug_compiler.py::test_semantic_validator_reports_select_builtin_condition_type_mismatch tests/test_debug_compiler.py::test_semantic_validator_reports_select_builtin_value_type_mismatch tests/test_compiler_api.py::test_emit_llvm_ir_lowers_select_builtin_for_integers tests/test_compiler_api.py::test_emit_llvm_ir_lowers_select_builtin_for_structs`, which passed after an initial assertion-string mismatch was corrected.
- Ran `pytest -q tests/test_compiler_api.py -k select -q` to validate the select-focused IR cases; all selected tests passed.
- No other automated test failures observed for the exercised test subsets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73b50a8b0832896f831af0be65ec1)