### PR TITLE
docs: replace debug_compiler API note with lockstep_compiler imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,15 @@ lockstepc path/to/program.lock --emit-header
 lockstepc --version
 ```
 
-`debug_compiler.py` exposes `compile_lockstep(source_code, verbose=True)` and returns a `LockstepCompileResult` containing:
+Programmatic frontend usage is available from `lockstep_compiler`:
+
+```python
+from lockstep_compiler import LockstepCompileResult, compile_lockstep
+
+result: LockstepCompileResult = compile_lockstep(source_code, verbose=True)
+```
+
+`compile_lockstep(...)` returns a `LockstepCompileResult` containing:
 
 * `parse_tree`: ANTLR parse tree for the source.
 * `entities`: extracted frontend entities (`structs`, `shaders`, `streams`, `accumulators`).


### PR DESCRIPTION
### Motivation
- Clarify programmatic frontend usage by replacing the old `debug_compiler.py` API note with canonical imports from the packaged `lockstep_compiler` so examples no longer imply running `debug_compiler.py` directly.

### Description
- Updated `README.md` "Compiler Frontend Usage" section to remove the `debug_compiler.py` reference and add a short Python snippet showing `from lockstep_compiler import LockstepCompileResult, compile_lockstep` and using `compile_lockstep(source_code, verbose=True)`.

### Testing
- Ran local text checks and repository commands (`rg -n "Compiler Frontend Usage|debug_compiler.py|lockstep_compiler" README.md`, `nl -ba README.md | sed -n '150,195p'`, `git status --short`, and committed the change); all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73fba53c083289673883012b63e5e)