### PR TITLE
Remove debug_compiler from setuptools py-modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-py-modules = ["debug_compiler"]
 packages = ["lockstep_compiler", "generated", "generated.parser"]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
### Motivation
- The project should be packaged via the declared packages rather than shipping `debug_compiler` as a top-level py-module, so the `py-modules` entry was removed to prevent distributing that module at the top level.

### Description
- Removed the `py-modules = ["debug_compiler"]` line from `[tool.setuptools]` in `pyproject.toml`.
- Preserved the existing `packages = ["lockstep_compiler", "generated", "generated.parser"]` and `[tool.setuptools.package-data]` entries.
- Verified there are no other packaging configuration entries that still reference `debug_compiler`.

### Testing
- Searched `pyproject.toml` for packaging keys with `rg -n "debug_compiler|py-modules|\[tool\.setuptools\]" pyproject.toml` and confirmed the `py-modules` entry is gone, which succeeded.
- Scanned optional packaging files with `for f in setup.py setup.cfg MANIFEST.in; do [ -f "$f" ] && rg -n "debug_compiler|py-modules|setuptools" "$f"; done` and confirmed no matches, which succeeded.
- Printed the updated section of `pyproject.toml` with `nl -ba pyproject.toml | sed -n '54,72p'` to visually verify the `packages` and `package-data` entries remain, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73fba3e7083289bafce78bc13ae51)