### PR TITLE
Allow `--simulate-input` when running `--report`

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -134,9 +134,9 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
     stdout = sys.stdout if stdout is None else stdout
     stderr = sys.stderr if stderr is None else stderr
 
-    if args.simulate_input and not args.simulate:
+    if args.simulate_input and not (args.simulate or args.report):
         print(
-            "usage error: --simulate-input requires --simulate.",
+            "usage error: --simulate-input requires --simulate or --report.",
             file=stderr,
         )
         return 2

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -132,7 +132,34 @@ def test_run_cli_rejects_simulate_input_without_simulate(tmp_path):
     )
 
     assert exit_code == 2
-    assert "--simulate-input requires --simulate" in stderr.getvalue()
+    assert "--simulate-input requires --simulate or --report" in stderr.getvalue()
+
+
+def test_run_cli_report_accepts_simulate_input_file(tmp_path):
+    input_file = tmp_path / "sim-input.json"
+    input_file.write_text('{"streams": {"s": [10, 20]}}', encoding="utf-8")
+
+    def fake_compiler(_source):
+        return {
+            "streams": [{"name": "s", "type": "int", "capacity": "4"}],
+            "accumulators": [],
+            "uniforms": [],
+            "shaders": [],
+            "filters": [],
+            "bind_routes": [],
+        }
+
+    stdout = io.StringIO()
+    exit_code = run_cli(
+        ["--report", "--simulate-input", str(input_file)],
+        stdin=io.StringIO("pipeline P { }"),
+        stdout=stdout,
+        compiler=fake_compiler,
+    )
+
+    assert exit_code == 0
+    payload = json.loads(stdout.getvalue())
+    assert payload["simulation"]["streams"]["s"] == [10, 20]
 
 
 def test_run_cli_report_prints_single_json_payload_with_entities_and_simulation():


### PR DESCRIPTION
### Motivation
- `--simulate-input` should be usable not only with `--simulate` but also when producing a JSON `--report` that includes simulation output.
- Update the CLI validation and user-facing message so users can pass simulation input while generating a combined report.

### Description
- Relaxed the guard in `run_cli` from `if args.simulate_input and not args.simulate:` to `if args.simulate_input and not (args.simulate or args.report):` in `lockstep_compiler/cli.py`.
- Updated the usage error text to: `"usage error: --simulate-input requires --simulate or --report."`.
- Adjusted tests in `tests/test_simulator.py` to assert the new error message and added `test_run_cli_report_accepts_simulate_input_file` to verify `--report --simulate-input <file>` loads inputs into the report payload.

### Testing
- Ran `pytest -q tests/test_simulator.py` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc38a1a1048328a11856657d8f1683)