### PR TITLE
Validate frontend limits and reject negative CLI values

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -10,6 +10,23 @@ from .simulator import parse_simulation_inputs, simulate_pipeline_entities
 from .formatter import format_lockstep_source
 
 
+def _non_negative_limit_value(flag_name: str):
+    def _parse(value: str) -> int:
+        try:
+            parsed = int(value)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                f"{flag_name} must be an integer."
+            ) from exc
+        if parsed < 0:
+            raise argparse.ArgumentTypeError(
+                f"{flag_name} must be >= 0 (0 disables the limit)."
+            )
+        return parsed
+
+    return _parse
+
+
 def _read_source_file(path: Path, *, stderr) -> str | None:
     try:
         return path.read_text(encoding="utf-8")
@@ -89,19 +106,19 @@ def build_arg_parser():
     )
     parser.add_argument(
         "--max-source-bytes",
-        type=int,
+        type=_non_negative_limit_value("--max-source-bytes"),
         default=None,
         help="Maximum UTF-8 source bytes accepted by parser (0 disables limit).",
     )
     parser.add_argument(
         "--parse-timeout-ms",
-        type=int,
+        type=_non_negative_limit_value("--parse-timeout-ms"),
         default=None,
         help="Maximum parser runtime in milliseconds (0 disables limit).",
     )
     parser.add_argument(
         "--max-expr-nesting",
-        type=int,
+        type=_non_negative_limit_value("--max-expr-nesting"),
         default=None,
         help="Maximum allowed expression nesting depth (0 disables limit).",
     )

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -25,6 +25,7 @@ DEFAULT_SOURCE_FILE = "<stdin>"
 DEFAULT_MAX_SOURCE_BYTES = 1_048_576
 DEFAULT_PARSE_TIMEOUT_MS = 2_000
 DEFAULT_MAX_EXPRESSION_NESTING = 128
+DEFAULT_INVALID_FRONTEND_LIMIT_CODE = "LCK006"
 _DEPENDENCY_DECL_PATTERN = re.compile(
     r'^\s*(?:import|#include)\s+"((?:[^"\\]|\\.)+)"\s*;\s*$',
     re.MULTILINE,
@@ -85,25 +86,62 @@ class _DeadlineTokenStream(CommonTokenStream):
         return super().consume()
 
 
+def _normalize_frontend_limit_value(
+    value: int | None,
+    *,
+    name: str,
+    source_file: str,
+) -> int | None:
+    if value is None:
+        return None
+    if value < 0:
+        diagnostic = LockstepDiagnostic(
+            severity="error",
+            code=DEFAULT_INVALID_FRONTEND_LIMIT_CODE,
+            message=(
+                f"Invalid frontend limit '{name}': {value}. "
+                "Expected a non-negative integer."
+            ),
+            line=1,
+            column=0,
+            source_file=source_file,
+            hint=(
+                f"Set {name} to 0 to disable, or provide a positive integer "
+                "to enforce the limit."
+            ),
+        )
+        raise LockstepCompileError(
+            [diagnostic],
+            diagnostics=[diagnostic],
+            phase="parse",
+            source_file=source_file,
+        )
+    if value == 0:
+        return None
+    return value
+
+
 def _normalize_frontend_limits(
     limits: FrontendLimits | None,
+    *,
+    source_file: str,
 ) -> FrontendLimits:
     resolved = limits or FrontendLimits()
     return FrontendLimits(
-        max_source_bytes=(
-            resolved.max_source_bytes
-            if resolved.max_source_bytes and resolved.max_source_bytes > 0
-            else None
+        max_source_bytes=_normalize_frontend_limit_value(
+            resolved.max_source_bytes,
+            name="max_source_bytes",
+            source_file=source_file,
         ),
-        parse_timeout_ms=(
-            resolved.parse_timeout_ms
-            if resolved.parse_timeout_ms and resolved.parse_timeout_ms > 0
-            else None
+        parse_timeout_ms=_normalize_frontend_limit_value(
+            resolved.parse_timeout_ms,
+            name="parse_timeout_ms",
+            source_file=source_file,
         ),
-        max_expression_nesting=(
-            resolved.max_expression_nesting
-            if resolved.max_expression_nesting and resolved.max_expression_nesting > 0
-            else None
+        max_expression_nesting=_normalize_frontend_limit_value(
+            resolved.max_expression_nesting,
+            name="max_expression_nesting",
+            source_file=source_file,
         ),
     )
 
@@ -417,7 +455,7 @@ def _compile_lockstep_with_dependencies(
     frontend_limits: FrontendLimits | None = None,
 ) -> LockstepCompileResult:
     source_map = source_map or [(1, _line_count(source_code), source_file)]
-    resolved_limits = _normalize_frontend_limits(frontend_limits)
+    resolved_limits = _normalize_frontend_limits(frontend_limits, source_file=source_file)
     _enforce_source_size_limit(
         source_code,
         source_file=source_file,

--- a/tests/test_improvements.py
+++ b/tests/test_improvements.py
@@ -5,6 +5,8 @@ import pathlib
 import sys
 import tempfile
 
+import pytest
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -13,6 +15,9 @@ from lockstep_compiler.cli import build_arg_parser, run_cli
 from lockstep_compiler.ast import AstExprCall, AstExprVar, AstReturnStmt
 from lockstep_compiler.codegen import emit_llvm_ir
 from lockstep_compiler.lsp import provide_hover_info
+from lockstep_compiler import compiler as compiler_module
+from lockstep_compiler.compiler import FrontendLimits, compile_lockstep
+from lockstep_compiler.errors import LockstepCompileError
 from lockstep_compiler.prelude import load_intrinsics
 
 
@@ -328,3 +333,165 @@ def test_hover_returns_none_for_empty_line():
     source = "\n\n\n"
     result = provide_hover_info(source, 0, 0)
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Frontend limits validation and CLI parsing
+# ---------------------------------------------------------------------------
+
+_LIMIT_SOURCE = "pipeline P { bind { } }"
+_NESTED_EXPR_SOURCE = """pure float nested(float v) {
+    return (((((((v)))))));
+}
+
+pipeline P {
+    bind {
+    }
+}
+"""
+
+
+
+@pytest.mark.parametrize(
+    ("limit_name", "value"),
+    [
+        ("max_source_bytes", -1),
+        ("parse_timeout_ms", -1),
+        ("max_expression_nesting", -1),
+    ],
+)
+def test_compile_lockstep_rejects_negative_frontend_limits(limit_name, value):
+    with pytest.raises(LockstepCompileError) as exc_info:
+        compile_lockstep(_LIMIT_SOURCE, frontend_limits=FrontendLimits(**{limit_name: value}))
+
+    assert exc_info.value.errors[0].code == "LCK006"
+    assert limit_name in exc_info.value.errors[0].message
+
+
+def test_compile_lockstep_zero_disables_source_size_limit():
+    compile_lockstep(
+        _LIMIT_SOURCE,
+        frontend_limits=FrontendLimits(max_source_bytes=0),
+    )
+
+
+def test_compile_lockstep_zero_disables_expression_nesting_limit():
+    compile_lockstep(
+        _NESTED_EXPR_SOURCE,
+        frontend_limits=FrontendLimits(max_expression_nesting=0),
+    )
+
+
+def test_compile_lockstep_zero_disables_parse_timeout(monkeypatch):
+    class StubLexer:
+        def __init__(self, input_stream):
+            self.input_stream = input_stream
+
+        def removeErrorListeners(self):
+            pass
+
+        def addErrorListener(self, listener):
+            pass
+
+    class StubParser:
+        def __init__(self, stream):
+            self._stream = stream
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            return "TREE"
+
+    class StubVisitor:
+        def visit(self, _tree):
+            return None
+
+    monkeypatch.setattr(
+        compiler_module,
+        "_load_default_parser_classes",
+        lambda: (StubLexer, StubParser, StubVisitor),
+    )
+
+    compile_lockstep(
+        _LIMIT_SOURCE,
+        frontend_limits=FrontendLimits(parse_timeout_ms=0),
+    )
+
+
+@pytest.mark.parametrize(
+    ("frontend_limits", "error_code"),
+    [
+        (FrontendLimits(max_source_bytes=8), "LCK003"),
+        (FrontendLimits(max_expression_nesting=2), "LCK005"),
+    ],
+)
+def test_compile_lockstep_positive_frontend_limits_are_enforced(frontend_limits, error_code):
+    source = _NESTED_EXPR_SOURCE if error_code == "LCK005" else _LIMIT_SOURCE
+    with pytest.raises(LockstepCompileError) as exc_info:
+        compile_lockstep(source, frontend_limits=frontend_limits)
+
+    assert exc_info.value.errors[0].code == error_code
+
+
+def test_compile_lockstep_positive_parse_timeout_is_enforced(monkeypatch):
+    class StubLexer:
+        def __init__(self, input_stream):
+            self.input_stream = input_stream
+
+        def removeErrorListeners(self):
+            pass
+
+        def addErrorListener(self, listener):
+            pass
+
+    class StubParser:
+        def __init__(self, stream):
+            self._stream = stream
+            self._listeners = []
+
+        def removeErrorListeners(self):
+            self._listeners = []
+
+        def addErrorListener(self, listener):
+            self._listeners.append(listener)
+
+        def program(self):
+            self._stream.LT(1)
+            return "TREE"
+
+    class StubVisitor:
+        def visit(self, _tree):
+            return None
+
+    monkeypatch.setattr(
+        compiler_module,
+        "_load_default_parser_classes",
+        lambda: (StubLexer, StubParser, StubVisitor),
+    )
+    monotonic_values = iter([0.0, 0.002])
+    monkeypatch.setattr(compiler_module.time, "monotonic", lambda: next(monotonic_values))
+
+    with pytest.raises(LockstepCompileError) as exc_info:
+        compile_lockstep(
+            _LIMIT_SOURCE,
+            frontend_limits=FrontendLimits(parse_timeout_ms=1),
+        )
+
+    assert exc_info.value.errors[0].code == "LCK004"
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["--max-source-bytes", "--parse-timeout-ms", "--max-expr-nesting"],
+)
+def test_cli_rejects_negative_limit_values(flag, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        run_cli(["--simulate", flag, "-1"], stdin=io.StringIO(_LIMIT_SOURCE))
+
+    assert exc_info.value.code == 2
+    assert "must be >= 0 (0 disables the limit)" in capsys.readouterr().err


### PR DESCRIPTION
### Motivation
- Ensure frontend limit configuration is validated so invalid negative values produce user-visible diagnostics instead of silently being treated as disabled.
- Preserve `0` as the explicit disable sentinel for limits while enforcing positive values when limits are intended to apply.
- Fail fast on bad CLI input so users get actionable messages when passing negative numbers to limit flags.

### Description
- Added a new diagnostic code `DEFAULT_INVALID_FRONTEND_LIMIT_CODE = "LCK006"` and a helper `_normalize_frontend_limit_value` in `lockstep_compiler/compiler.py` that rejects negative values (raising a parse-phase `LockstepCompileError`) and normalizes `0` to disabled (`None`).
- Updated `_normalize_frontend_limits` to accept `source_file` and use `_normalize_frontend_limit_value` for `max_source_bytes`, `parse_timeout_ms`, and `max_expression_nesting`, and wired the call site in `_compile_lockstep_with_dependencies` to pass `source_file`.
- Added a CLI argument validator `_non_negative_limit_value` in `lockstep_compiler/cli.py` and set it as the `type` for `--max-source-bytes`, `--parse-timeout-ms`, and `--max-expr-nesting` so negative inputs raise `argparse` errors with actionable messages.
- Added tests in `tests/test_improvements.py` exercising negative-value rejection (`LCK006`), zero-as-disable behavior, positive enforcement of limits (`LCK003`, `LCK004`, `LCK005`), and CLI rejection of negative flag values.

### Testing
- Ran the focused test suite with `pytest -q tests/test_improvements.py tests/test_cli_libraries.py tests/test_compiler_api.py -k 'frontend_limits or limit or timeout or source_size or expression_nesting or cli_rejects_negative_limit_values or passes_frontend_limits'` and all tests in that selection passed.
- New tests assert that negative frontend limits raise `LockstepCompileError` with `LCK006`, `0` disables the limits, positive limits are enforced, and CLI flags reject negative values with the expected parse-time message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc38a99e0483289df31d63f0156515)