### PR TITLE
Prefer compiler AST locations in LSP helpers and harden symbol lookup

### DIFF
--- a/lockstep_compiler/ast.py
+++ b/lockstep_compiler/ast.py
@@ -198,6 +198,7 @@ class AstKernelBindRoute:
     kernel: str
     args: tuple[str, ...]
     route: str
+    location: AstLocation = AstLocation()
 
 
 @dataclass(frozen=True)
@@ -207,6 +208,7 @@ class AstFoldBindRoute:
     operator: str
     source: str
     route: str
+    location: AstLocation = AstLocation()
 
     def __post_init__(self):
         object.__setattr__(self, "uniform_type", _normalize_type(self.uniform_type))
@@ -501,6 +503,7 @@ class AstBuilder(_AstBuilderMixin):
         return self.visitChildren(ctx)
 
     def visitPureDecl(self, ctx: Any):
+        name_token = getattr(self._call(ctx, "ID"), "symbol", None)
         params: list[AstKernelParam] = []
         pure_param_list = self._call(ctx, "pureParamList")
         if pure_param_list:
@@ -521,29 +524,40 @@ class AstBuilder(_AstBuilderMixin):
                 return_type=self._resolve_type(self._call(ctx, "typeName").getText()),
                 params=tuple(params),
                 body=self._parse_statement_text(ctx),
-                location=self._location(ctx),
+                location=AstLocation(
+                    line=getattr(name_token, "line", 0),
+                    column=getattr(name_token, "column", 0),
+                ),
             )
         )
         return self.visitChildren(ctx)
 
     def visitShaderDecl(self, ctx: Any):
+        name_token = getattr(self._call(ctx, "ID"), "symbol", None)
         self._shaders.append(
             AstKernelDecl(
                 name=self._call(ctx, "ID").getText(),
                 params=self._parse_params(self._call(ctx, "paramList")),
                 body=self._parse_statement_text(ctx),
-                location=self._location(ctx),
+                location=AstLocation(
+                    line=getattr(name_token, "line", 0),
+                    column=getattr(name_token, "column", 0),
+                ),
             )
         )
         return self.visitChildren(ctx)
 
     def visitFilterDecl(self, ctx: Any):
+        name_token = getattr(self._call(ctx, "ID"), "symbol", None)
         self._filters.append(
             AstKernelDecl(
                 name=self._call(ctx, "ID").getText(),
                 params=self._parse_params(self._call(ctx, "paramList")),
                 body=self._parse_statement_text(ctx),
-                location=self._location(ctx),
+                location=AstLocation(
+                    line=getattr(name_token, "line", 0),
+                    column=getattr(name_token, "column", 0),
+                ),
             )
         )
         return self.visitChildren(ctx)
@@ -620,6 +634,7 @@ class AstBuilder(_AstBuilderMixin):
                         operator=fold_operator.getText(),
                         source=id_tokens[1].getText(),
                         route=route_text,
+                        location=self._location(bind_stmt),
                     )
                 )
                 continue
@@ -631,6 +646,7 @@ class AstBuilder(_AstBuilderMixin):
                         kernel=id_tokens[1].getText(),
                         args=tuple(token.getText() for token in id_tokens[2:]),
                         route=route_text,
+                        location=self._location(bind_stmt),
                     )
                 )
         return self.visitChildren(ctx)
@@ -721,6 +737,8 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                         "kernel": route.kernel,
                         "args": list(route.args),
                         "route": route.route,
+                        "line": route.location.line,
+                        "column": route.location.column,
                     }
                 )
             else:
@@ -732,6 +750,8 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                         "operator": route.operator,
                         "source": route.source,
                         "route": route.route,
+                        "line": route.location.line,
+                        "column": route.location.column,
                     }
                 )
 
@@ -754,6 +774,8 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
         "shaders": [
             {
                 "name": shader.name,
+                "line": shader.location.line,
+                "column": shader.location.column,
                 "params": [
                     {
                         "modifier": param.modifier,
@@ -770,6 +792,8 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
         "filters": [
             {
                 "name": flt.name,
+                "line": flt.location.line,
+                "column": flt.location.column,
                 "params": [
                     {
                         "modifier": param.modifier,
@@ -786,6 +810,8 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
         "pure_functions": [
             {
                 "name": pure.name,
+                "line": pure.location.line,
+                "column": pure.location.column,
                 "return_type": _type_name(pure.return_type),
                 "params": [
                     {"type": _type_name(param.declared_type), "name": param.name}

--- a/lockstep_compiler/lsp.py
+++ b/lockstep_compiler/lsp.py
@@ -40,7 +40,6 @@ class DefinitionTarget:
 
 
 _MEMBER_ACCESS_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)")
-_BIND_BLOCK_RE = re.compile(r"\bbind\s*\{(?P<body>[\s\S]*?)\}", re.MULTILINE)
 
 
 def _diagnostics_to_dicts(diagnostics: list[Any]) -> list[dict[str, Any]]:
@@ -90,6 +89,63 @@ def _is_inside_bind_block(source: str, line: int, column: int) -> bool:
             return True
 
     return False
+
+
+def _is_identifier_char(char: str) -> bool:
+    return char.isalnum() or char == "_"
+
+
+def _identifier_at_position(source: str, line: int, column: int) -> str | None:
+    lines = source.splitlines()
+    if line < 0 or line >= len(lines):
+        return None
+
+    line_text = lines[line]
+    if column < 0:
+        return None
+    if column >= len(line_text):
+        column = max(len(line_text) - 1, 0)
+
+    in_string = False
+    escaped = False
+    for idx, char in enumerate(line_text):
+        if idx >= column:
+            break
+        if not in_string and char == "/" and idx + 1 < len(line_text) and line_text[idx + 1] == "/":
+            return None
+        if char == "\\" and in_string and not escaped:
+            escaped = True
+            continue
+        if char == '"' and not escaped:
+            in_string = not in_string
+        escaped = False
+
+    if in_string:
+        return None
+
+    comment_index = line_text.find("//")
+    if comment_index != -1 and column >= comment_index:
+        return None
+
+    if not _is_identifier_char(line_text[column]):
+        return None
+
+    start = column
+    while start > 0 and _is_identifier_char(line_text[start - 1]):
+        start -= 1
+    end = column + 1
+    while end < len(line_text) and _is_identifier_char(line_text[end]):
+        end += 1
+    return line_text[start:end]
+
+
+def _location_target_from_entity(entity: dict[str, Any], symbol: str) -> DefinitionTarget | None:
+    raw_line = entity.get("line")
+    if not isinstance(raw_line, int) or raw_line <= 0:
+        return None
+    raw_column = entity.get("column")
+    column = raw_column if isinstance(raw_column, int) and raw_column >= 0 else 0
+    return DefinitionTarget(line=raw_line - 1, column=column, symbol=symbol)
 
 
 def compile_for_lsp(source: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
@@ -246,7 +302,7 @@ def _build_callable_index(
         name = shader.get("name")
         if not name or name in callable_index:
             continue
-        target = _find_callable_definition(
+        target = _location_target_from_entity(shader, name) or _find_callable_definition(
             source,
             re.compile(rf"\bshader\s+(?P<name>{re.escape(name)})\s*\("),
             name,
@@ -258,7 +314,9 @@ def _build_callable_index(
         name = filter_decl.get("name")
         if not name or name in callable_index:
             continue
-        target = _find_callable_definition(
+        target = _location_target_from_entity(
+            filter_decl, name
+        ) or _find_callable_definition(
             source,
             re.compile(rf"\bfilter\s+(?P<name>{re.escape(name)})\s*\("),
             name,
@@ -270,7 +328,7 @@ def _build_callable_index(
         name = pure.get("name")
         if not name or pure.get("intrinsic") or name in callable_index:
             continue
-        target = _find_callable_definition(
+        target = _location_target_from_entity(pure, name) or _find_callable_definition(
             source,
             re.compile(
                 rf"\bpure\b[\s\S]*?\b(?P<name>{re.escape(name)})\s*\("
@@ -327,18 +385,11 @@ def find_definition_target(
             symbol=member.field_name,
         )
 
-    lines = source.splitlines()
-    if line < 0 or line >= len(lines):
-        return None
-
-    line_text = lines[line]
     context = analysis_context or build_analysis_context(source)
-    for match in re.finditer(r"\b([A-Za-z_][A-Za-z0-9_]*)\b", line_text):
-        start, end = match.span(1)
-        if not (start <= column < end):
-            continue
-        return context.callable_index.get(match.group(1))
-    return None
+    symbol = _identifier_at_position(source, line, column)
+    if symbol is None:
+        return None
+    return context.callable_index.get(symbol)
 
 
 def provide_bind_completion_items(
@@ -353,11 +404,17 @@ def provide_bind_completion_items(
     completion_entries: list[dict[str, Any]] = []
     seen_labels: set[str] = set()
 
-    inside_bind = (
-        line is not None
-        and column is not None
-        and _is_inside_bind_block(source, line=line, column=column)
-    )
+    inside_bind = False
+    if line is not None and column is not None:
+        bind_lines = [
+            max((route.get("line") or 1) - 1, 0)
+            for route in entities.get("bind_routes_ir", [])
+            if isinstance(route.get("line"), int)
+        ]
+        if bind_lines:
+            inside_bind = (min(bind_lines) - 1) <= line <= (max(bind_lines) + 1)
+        else:
+            inside_bind = _is_inside_bind_block(source, line=line, column=column)
 
     if inside_bind:
         for route in entities.get("bind_routes", []):
@@ -442,31 +499,24 @@ def provide_hover_info(
             return f"(field) `{struct_name}.{field_name}`"
         return None
 
-    id_pattern = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\b")
-    for match in id_pattern.finditer(line_text):
-        start, end = match.span(1)
-        if not (start <= column < end):
-            continue
-        name = match.group(1)
-        if name in context.variable_types:
-            return f"(variable) `{name}: {context.variable_types[name]}`"
-
-        entities = context.entities
-        if any(struct.get("name") == name for struct in entities.get("structs", [])):
-            return f"(struct) `struct {name}`"
-        if any(shader.get("name") == name for shader in entities.get("shaders", [])):
-            return f"(shader) `shader {name}(...)`"
-        if any(
-            filter_decl.get("name") == name
-            for filter_decl in entities.get("filters", [])
-        ):
-            return f"(filter) `filter {name}(...)`"
-        if any(
-            pure.get("name") == name and not pure.get("intrinsic")
-            for pure in entities.get("pure_functions", [])
-        ):
-            return f"(pure) `pure {name}(...)`"
+    name = _identifier_at_position(source, line, column)
+    if name is None:
         return None
+    if name in context.variable_types:
+        return f"(variable) `{name}: {context.variable_types[name]}`"
+
+    entities = context.entities
+    if any(struct.get("name") == name for struct in entities.get("structs", [])):
+        return f"(struct) `struct {name}`"
+    if any(shader.get("name") == name for shader in entities.get("shaders", [])):
+        return f"(shader) `shader {name}(...)`"
+    if any(filter_decl.get("name") == name for filter_decl in entities.get("filters", [])):
+        return f"(filter) `filter {name}(...)`"
+    if any(
+        pure.get("name") == name and not pure.get("intrinsic")
+        for pure in entities.get("pure_functions", [])
+    ):
+        return f"(pure) `pure {name}(...)`"
 
     return None
 

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -270,3 +270,83 @@ shader Wrap(in float src, out float dst) {
 
     assert blend_target is not None
     assert (blend_target.line, blend_target.column, blend_target.symbol) == (6, 0, "blend")
+
+
+def test_hover_and_definition_ignore_symbols_in_comments_and_strings():
+    source = """
+shader Integrate(in float src, out float dst) { dst = src; }
+
+shader Use(in float src, out float dst) {
+    // Integrate(src, dst);
+    string note = "Integrate should not resolve";
+    dst = src;
+}
+"""
+    lines = source.splitlines()
+    comment_line = next(i for i, text in enumerate(lines) if "Integrate(src, dst)" in text)
+    string_line = next(i for i, text in enumerate(lines) if "Integrate should not resolve" in text)
+
+    assert provide_hover_info(source, comment_line, lines[comment_line].index("Integrate") + 1) is None
+    assert find_definition_target(
+        source,
+        comment_line,
+        lines[comment_line].index("Integrate") + 1,
+    ) is None
+    assert provide_hover_info(source, string_line, lines[string_line].index("Integrate") + 1) is None
+    assert find_definition_target(
+        source,
+        string_line,
+        lines[string_line].index("Integrate") + 1,
+    ) is None
+
+
+def test_completion_and_callable_resolution_stable_with_unusual_whitespace_layout():
+    source = """
+shader
+   Integrate
+(
+    in float src,
+    out float dst
+)
+{
+    dst = src;
+}
+
+pipeline P {
+    stream<float, 8> src;
+    stream<float, 8> dst;
+
+    bind
+    {
+        dst =
+            Integrate
+            (
+                src,
+                dst
+            );
+    }
+}
+"""
+    lines = source.splitlines()
+    call_line = next(i for i, text in enumerate(lines) if "Integrate" in text and i > 10)
+    bind_line = next(i for i, text in enumerate(lines) if text.strip() == "dst =")
+
+    definition = find_definition_target(
+        source,
+        call_line,
+        lines[call_line].index("Integrate") + 1,
+    )
+    assert definition is not None
+    decl_line = next(i for i, text in enumerate(lines) if text.strip() == "Integrate")
+    assert (definition.line, definition.symbol) == (decl_line, "Integrate")
+
+    hover = provide_hover_info(
+        source,
+        call_line,
+        lines[call_line].index("Integrate") + 1,
+    )
+    assert hover == "(shader) `shader Integrate(...)`"
+
+    items = provide_bind_completion_items(source, line=bind_line, column=8)
+    labels = [item["label"] for item in items]
+    assert "dst=Integrate(src,dst);" in labels


### PR DESCRIPTION
### Motivation
- Make LSP hover/definition/completion use precise declaration locations emitted by the compiler AST instead of fragile source regex scans. 
- Avoid reporting or resolving symbols that appear inside comments or string literals and stabilize behavior for unusual whitespace/newline layouts.

### Description
- Emit `location` (`line`/`column`) for bind routes and use identifier token positions for kernel/filter/pure declaration locations in `ast_to_entities` by extending `AstKernelBindRoute`, `AstFoldBindRoute` and kernel/pure/filter AST handling in `lockstep_compiler/ast.py`.
- Add `_location_target_from_entity` and `_identifier_at_position` helpers in `lockstep_compiler/lsp.py` and refactor `_build_callable_index` to prefer entity-provided declaration locations with a regex fallback.
- Replace ad-hoc regex scanning for hover/definition with identifier extraction that ignores `//` comments and string-literal regions in `provide_hover_info` and `find_definition_target` and prefer bind-route metadata in `provide_bind_completion_items` with source fallback.
- Add tests in `tests/test_lsp.py` covering symbols in comments, string literals, and unusual whitespace/newline layouts to validate hover/definition/completion stability.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_lsp.py` and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc38b56810832897c547d39e29175f)