### PR TITLE
Expand strict mypy coverage and type-check core compiler modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: verify-parser-toolchain generate-parser check-generated-parser build test test-cov
+.PHONY: verify verify-parser-toolchain generate-parser check-generated-parser build test test-cov mypy
+
+verify: test mypy
 
 verify-parser-toolchain:
 	python scripts/generate_parser.py --verify-toolchain
@@ -20,3 +22,6 @@ test:
 
 test-cov:
 	pytest --cov=. --cov-branch --cov-report=term-missing --cov-report=xml:coverage.xml
+
+mypy:
+	python -m mypy

--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -4,13 +4,14 @@ import json
 import sys
 import traceback
 from pathlib import Path
+from typing import Any, Callable, TextIO, cast
 
 from .errors import LockstepCompileError
 from .simulator import parse_simulation_inputs, simulate_pipeline_entities
 from .formatter import format_lockstep_source
 
 
-def _read_source_file(path: Path, *, stderr) -> str | None:
+def _read_source_file(path: Path, *, stderr: TextIO) -> str | None:
     try:
         return path.read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -26,7 +27,7 @@ def _read_source_file(path: Path, *, stderr) -> str | None:
     return None
 
 
-def build_arg_parser():
+def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Debug parser for Lockstep source files."
     )
@@ -108,7 +109,9 @@ def build_arg_parser():
     return parser
 
 
-def _load_simulation_inputs(args, *, stderr):
+def _load_simulation_inputs(
+    args: argparse.Namespace, *, stderr: TextIO
+) -> tuple[dict[str, list[Any]], dict[str, list[Any]]] | None:
     input_payload = ""
     if args.simulate_input:
         input_path = Path(args.simulate_input)
@@ -126,7 +129,14 @@ def _load_simulation_inputs(args, *, stderr):
     return None
 
 
-def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
+def run_cli(
+    argv: list[str] | None = None,
+    *,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+    compiler: Callable[..., Any] | None = None,
+) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
 
@@ -221,7 +231,7 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
             for parameter in signature.parameters.values()
         )
 
-    compile_kwargs = {}
+    compile_kwargs: dict[str, Any] = {}
     if supports_verbose:
         compile_kwargs["verbose"] = False
     if supports_library_sources:
@@ -301,7 +311,11 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
         print(c_header, file=stdout)
         return 0
 
-    entities = getattr(result, "entities", result)
+    entities: dict[str, Any]
+    if hasattr(result, "entities"):
+        entities = cast(dict[str, Any], result.entities)
+    else:
+        entities = cast(dict[str, Any], result)
 
     if args.dump:
         print(json.dumps(entities, indent=2, sort_keys=True, default=str), file=stdout)
@@ -339,7 +353,7 @@ def run_cli(argv=None, *, stdin=None, stdout=None, stderr=None, compiler=None):
     return 0
 
 
-def main(argv=None):
+def main(argv: list[str] | None = None) -> None:
     from .compiler import compile_lockstep
 
     sys.exit(run_cli(argv, compiler=compile_lockstep))

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -3,7 +3,7 @@ import re
 import time
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, cast
 
 from antlr4 import CommonTokenStream, InputStream
 
@@ -44,8 +44,10 @@ class FrontendLimitExceeded(RuntimeError):
         self.diagnostic = diagnostic
 
 
-class _DeadlineTokenStream(CommonTokenStream):
-    def __init__(self, lexer, *, deadline: float | None = None, source_file: str):
+class _DeadlineTokenStream(CommonTokenStream):  # type: ignore[misc]
+    def __init__(
+        self, lexer: Any, *, deadline: float | None = None, source_file: str
+    ) -> None:
         super().__init__(lexer)
         self._deadline = deadline
         self._source_file = source_file
@@ -72,15 +74,15 @@ class _DeadlineTokenStream(CommonTokenStream):
                 )
             )
 
-    def LA(self, i: int):
+    def LA(self, i: int) -> int:
         self._enforce_deadline()
-        return super().LA(i)
+        return int(super().LA(i))
 
-    def LT(self, i: int):
+    def LT(self, i: int) -> Any:
         self._enforce_deadline()
         return super().LT(i)
 
-    def consume(self):
+    def consume(self) -> Any:
         self._enforce_deadline()
         return super().consume()
 
@@ -408,12 +410,12 @@ def _compile_lockstep_with_dependencies(
     verbose: bool = True,
     source_file: str = DEFAULT_SOURCE_FILE,
     source_map: list[tuple[int, int, str]] | None = None,
-    lexer_cls,
-    parser_cls,
-    visitor_cls,
-    semantic_validator=None,
-    token_stream_cls=CommonTokenStream,
-    debug_visitor_cls=None,
+    lexer_cls: Any,
+    parser_cls: Any,
+    visitor_cls: Any,
+    semantic_validator: Callable[..., Any] | None = None,
+    token_stream_cls: Callable[[Any], Any] = CommonTokenStream,
+    debug_visitor_cls: Any = None,
     frontend_limits: FrontendLimits | None = None,
 ) -> LockstepCompileResult:
     source_map = source_map or [(1, _line_count(source_code), source_file)]
@@ -429,10 +431,11 @@ def _compile_lockstep_with_dependencies(
     error_listener = ParseErrorCollector(source_file=None)
     lexer.removeErrorListeners()
     lexer.addErrorListener(error_listener)
+    stream_builder: Callable[[Any], Any]
     if resolved_limits.parse_timeout_ms is not None:
         deadline = time.monotonic() + (resolved_limits.parse_timeout_ms / 1_000)
 
-        def _build_token_stream(inner_lexer):
+        def _build_token_stream(inner_lexer: Any) -> _DeadlineTokenStream:
             return _DeadlineTokenStream(
                 inner_lexer,
                 deadline=deadline,
@@ -485,17 +488,20 @@ def _compile_lockstep_with_dependencies(
         build_program_ast(tree, visitor_cls)
     )
 
-    semantic_validator = semantic_validator or (
-        lambda parse_tree, *, typed_ast: validate_semantics(
+    validator: Callable[..., Any]
+    if semantic_validator is None:
+        validator = lambda parse_tree, *, typed_ast: validate_semantics(
             parse_tree, visitor_cls, typed_ast=typed_ast
         )
-    )
+    else:
+        validator = semantic_validator
     try:
         semantic_diagnostics = normalize_diagnostics(
-            semantic_validator(tree, typed_ast=typed_ast)
+            validator(tree, typed_ast=typed_ast)
         )
     except TypeError:
-        semantic_diagnostics = normalize_diagnostics(semantic_validator(tree))
+        fallback_validator = cast(Callable[[Any], Any], validator)
+        semantic_diagnostics = normalize_diagnostics(fallback_validator(tree))
     semantic_diagnostics = _remap_diagnostics(
         semantic_diagnostics,
         source_map=source_map,
@@ -568,10 +574,15 @@ def load_default_parser_classes() -> tuple[Any, Any, Any]:
     return LockstepLexer, LockstepParser, LockstepVisitor
 
 
-def validate_semantics(parse_tree: Any, visitor_cls=None, *, typed_ast=None):
+def validate_semantics(
+    parse_tree: Any, visitor_cls: Any = None, *, typed_ast: Any = None
+) -> list[LockstepDiagnostic]:
     if visitor_cls is None:
         _, _, visitor_cls = load_default_parser_classes()
-    return _validate_semantics(parse_tree, visitor_cls, typed_ast=typed_ast)
+    return cast(
+        list[LockstepDiagnostic],
+        _validate_semantics(parse_tree, visitor_cls, typed_ast=typed_ast),
+    )
 
 
 def compile_lockstep(
@@ -581,12 +592,12 @@ def compile_lockstep(
     source_file: str = DEFAULT_SOURCE_FILE,
     library_sources: list[str] | None = None,
     library_source_files: list[str] | None = None,
-    lexer_cls=None,
-    parser_cls=None,
-    visitor_cls=None,
-    semantic_validator=None,
-    token_stream_cls=CommonTokenStream,
-    debug_visitor_cls=None,
+    lexer_cls: Any = None,
+    parser_cls: Any = None,
+    visitor_cls: Any = None,
+    semantic_validator: Callable[..., Any] | None = None,
+    token_stream_cls: Callable[[Any], Any] = CommonTokenStream,
+    debug_visitor_cls: Any = None,
     frontend_limits: FrontendLimits | None = None,
 ) -> LockstepCompileResult:
     resolved_library_sources: list[str] = list(library_sources or [])

--- a/lockstep_compiler/lsp.py
+++ b/lockstep_compiler/lsp.py
@@ -505,7 +505,7 @@ def run_lsp_server() -> int:
             message=diag.get("message", ""),
         )
 
-    async def _validate(uri: str, *, debounced: bool):
+    async def _validate(uri: str, *, debounced: bool) -> None:
         if debounced:
             await asyncio.sleep(debounce_seconds)
         document = server.workspace.get_text_document(uri)
@@ -516,13 +516,13 @@ def run_lsp_server() -> int:
         )
         pending_tasks.pop(uri, None)
 
-    def _schedule_validate(uri: str, *, debounced: bool = True):
+    def _schedule_validate(uri: str, *, debounced: bool = True) -> None:
         task = pending_tasks.get(uri)
         if task is not None and not task.done():
             task.cancel()
         pending_tasks[uri] = asyncio.create_task(_validate(uri, debounced=debounced))
 
-    def _clear_document_context(uri: str):
+    def _clear_document_context(uri: str) -> None:
         task = pending_tasks.pop(uri, None)
         if task is not None and not task.done():
             task.cancel()
@@ -535,22 +535,24 @@ def run_lsp_server() -> int:
             doc_contexts[uri] = context
         return context
 
-    @server.feature(types.TEXT_DOCUMENT_DID_OPEN)
-    @server.feature(types.TEXT_DOCUMENT_DID_CHANGE)
-    def validate(params):
+    @server.feature(types.TEXT_DOCUMENT_DID_OPEN)  # type: ignore[untyped-decorator]
+    @server.feature(types.TEXT_DOCUMENT_DID_CHANGE)  # type: ignore[untyped-decorator]
+    def validate(params: Any) -> None:
         _schedule_validate(params.text_document.uri)
 
-    @server.feature(types.TEXT_DOCUMENT_DID_SAVE)
-    def validate_on_save(params):
+    @server.feature(types.TEXT_DOCUMENT_DID_SAVE)  # type: ignore[untyped-decorator]
+    def validate_on_save(params: Any) -> None:
         _schedule_validate(params.text_document.uri, debounced=False)
 
-    @server.feature(types.TEXT_DOCUMENT_DID_CLOSE)
-    def close_document(params):
+    @server.feature(types.TEXT_DOCUMENT_DID_CLOSE)  # type: ignore[untyped-decorator]
+    def close_document(params: Any) -> None:
         _clear_document_context(params.text_document.uri)
         server.publish_diagnostics(params.text_document.uri, [])
 
-    @server.feature(types.TEXT_DOCUMENT_COMPLETION)
-    def completion(params: types.CompletionParams):
+    @server.feature(types.TEXT_DOCUMENT_COMPLETION)  # type: ignore[untyped-decorator]
+    def completion(
+        params: types.CompletionParams,
+    ) -> types.CompletionList:
         document = server.workspace.get_text_document(params.text_document.uri)
         compiled = _context_for_document(document.uri, document.source)
         analysis_context = build_analysis_context(
@@ -579,8 +581,8 @@ def run_lsp_server() -> int:
             ],
         )
 
-    @server.feature(types.TEXT_DOCUMENT_HOVER)
-    def hover(params: types.HoverParams):
+    @server.feature(types.TEXT_DOCUMENT_HOVER)  # type: ignore[untyped-decorator]
+    def hover(params: types.HoverParams) -> types.Hover | None:
         document = server.workspace.get_text_document(params.text_document.uri)
         compiled = _context_for_document(document.uri, document.source)
         analysis_context = build_analysis_context(
@@ -601,8 +603,10 @@ def run_lsp_server() -> int:
             ),
         )
 
-    @server.feature(types.TEXT_DOCUMENT_DEFINITION)
-    def definition(params: types.DefinitionParams):
+    @server.feature(types.TEXT_DOCUMENT_DEFINITION)  # type: ignore[untyped-decorator]
+    def definition(
+        params: types.DefinitionParams,
+    ) -> types.Location | None:
         document = server.workspace.get_text_document(params.text_document.uri)
         compiled = _context_for_document(document.uri, document.source)
         analysis_context = build_analysis_context(

--- a/lockstep_compiler/simulator.py
+++ b/lockstep_compiler/simulator.py
@@ -348,7 +348,10 @@ def simulate_pipeline_entities(
 
 
 def simulate_pipeline_source(
-    source_code: str, *, stream_inputs=None, accumulator_inputs=None
+    source_code: str,
+    *,
+    stream_inputs: dict[str, list[Any]] | None = None,
+    accumulator_inputs: dict[str, list[Any]] | None = None,
 ) -> dict[str, Any]:
     result = compile_lockstep(source_code, verbose=False)
     return simulate_pipeline_entities(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,11 @@ show_missing = true
 [tool.mypy]
 strict = true
 files = [
+    "lockstep_compiler/cli.py",
+    "lockstep_compiler/compiler.py",
+    "lockstep_compiler/lsp.py",
     "lockstep_compiler/models.py",
+    "lockstep_compiler/simulator.py",
     "lockstep_compiler/utils.py",
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
### Motivation
- Raise static typing coverage to include high-value runtime paths (CLI, compiler, LSP, simulator) so strict `mypy` catches regressions earlier.
- Prefer fixing surfaced typing issues with targeted annotations instead of broad suppression to keep type guarantees meaningful.
- Run strict `mypy` as part of standard verification to gate type-sound changes in CI/dev workflows.

### Description
- Add the new modules to `[tool.mypy].files` in `pyproject.toml` to include `lockstep_compiler/cli.py`, `lockstep_compiler/compiler.py`, `lockstep_compiler/lsp.py`, and `lockstep_compiler/simulator.py` under strict checking.
- Add a `mypy` Makefile target and a `verify` target that runs `test` and `mypy` to make type-checking part of the normal verification flow.
- Address typing issues with focused changes: annotate CLI helper and entrypoint signatures, type `compile_kwargs`, and use narrow `cast` for `result.entities` handling in `lockstep_compiler/cli.py`.
- Add precise annotations and a small, scoped `type: ignore` for the `CommonTokenStream` subclass, tighten `_DeadlineTokenStream` return types, and introduce a typed `validator` fallback pattern in `lockstep_compiler/compiler.py`.
- Annotate LSP callbacks and apply targeted `# type: ignore[untyped-decorator]` on pygls decorators where stubs are untyped in `lockstep_compiler/lsp.py`.
- Annotate simulator entrypoint parameters in `lockstep_compiler/simulator.py` to clarify expected input shapes.

### Testing
- `python -m mypy` was run and succeeded with no issues on the configured files.
- `make mypy` was run and succeeded (invokes `python -m mypy`).
- `pytest` was attempted but test collection failed in this environment due to missing test dependencies and import setup (missing `hypothesis` and package import path), so unit tests were not successfully executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc38bb62388328a84cade8d7eccaaf)