### PR TITLE
Use compiler AST locations for robust LSP hover/definition/completion

### DIFF
--- a/lockstep_compiler/ast.py
+++ b/lockstep_compiler/ast.py
@@ -147,6 +147,7 @@ class AstPureDecl:
     body: tuple[AstStatement, ...] = ()
     intrinsic: bool = False
     location: AstLocation = AstLocation()
+    identifier_location: AstLocation = AstLocation()
 
     def __post_init__(self):
         object.__setattr__(self, "return_type", _normalize_type(self.return_type))
@@ -158,6 +159,7 @@ class AstKernelDecl:
     params: tuple[AstKernelParam, ...] = ()
     body: tuple[AstStatement, ...] = ()
     location: AstLocation = AstLocation()
+    identifier_location: AstLocation = AstLocation()
 
 
 @dataclass(frozen=True)
@@ -198,6 +200,7 @@ class AstKernelBindRoute:
     kernel: str
     args: tuple[str, ...]
     route: str
+    location: AstLocation = AstLocation()
 
 
 @dataclass(frozen=True)
@@ -207,6 +210,7 @@ class AstFoldBindRoute:
     operator: str
     source: str
     route: str
+    location: AstLocation = AstLocation()
 
     def __post_init__(self):
         object.__setattr__(self, "uniform_type", _normalize_type(self.uniform_type))
@@ -248,6 +252,13 @@ class _AstBuilderMixin:
         if callable(method):
             return method()
         return default
+
+    @staticmethod
+    def _token_location(token: Any) -> AstLocation:
+        symbol = getattr(token, "symbol", token)
+        return AstLocation(
+            line=getattr(symbol, "line", 0), column=getattr(symbol, "column", 0)
+        )
 
 
 class AstBuilder(_AstBuilderMixin):
@@ -501,6 +512,7 @@ class AstBuilder(_AstBuilderMixin):
         return self.visitChildren(ctx)
 
     def visitPureDecl(self, ctx: Any):
+        id_token = self._call(ctx, "ID")
         params: list[AstKernelParam] = []
         pure_param_list = self._call(ctx, "pureParamList")
         if pure_param_list:
@@ -517,33 +529,38 @@ class AstBuilder(_AstBuilderMixin):
                 )
         self._pure_functions.append(
             AstPureDecl(
-                name=self._call(ctx, "ID").getText(),
+                name=id_token.getText(),
                 return_type=self._resolve_type(self._call(ctx, "typeName").getText()),
                 params=tuple(params),
                 body=self._parse_statement_text(ctx),
                 location=self._location(ctx),
+                identifier_location=self._token_location(id_token),
             )
         )
         return self.visitChildren(ctx)
 
     def visitShaderDecl(self, ctx: Any):
+        id_token = self._call(ctx, "ID")
         self._shaders.append(
             AstKernelDecl(
-                name=self._call(ctx, "ID").getText(),
+                name=id_token.getText(),
                 params=self._parse_params(self._call(ctx, "paramList")),
                 body=self._parse_statement_text(ctx),
                 location=self._location(ctx),
+                identifier_location=self._token_location(id_token),
             )
         )
         return self.visitChildren(ctx)
 
     def visitFilterDecl(self, ctx: Any):
+        id_token = self._call(ctx, "ID")
         self._filters.append(
             AstKernelDecl(
-                name=self._call(ctx, "ID").getText(),
+                name=id_token.getText(),
                 params=self._parse_params(self._call(ctx, "paramList")),
                 body=self._parse_statement_text(ctx),
                 location=self._location(ctx),
+                identifier_location=self._token_location(id_token),
             )
         )
         return self.visitChildren(ctx)
@@ -620,6 +637,7 @@ class AstBuilder(_AstBuilderMixin):
                         operator=fold_operator.getText(),
                         source=id_tokens[1].getText(),
                         route=route_text,
+                        location=self._token_location(id_tokens[0]),
                     )
                 )
                 continue
@@ -631,6 +649,7 @@ class AstBuilder(_AstBuilderMixin):
                         kernel=id_tokens[1].getText(),
                         args=tuple(token.getText() for token in id_tokens[2:]),
                         route=route_text,
+                        location=self._token_location(id_tokens[0]),
                     )
                 )
         return self.visitChildren(ctx)
@@ -689,6 +708,7 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
     accumulators = []
     uniforms = []
     bind_routes = []
+    bind_routes_meta = []
     bind_routes_ir = []
     for pipeline in program.pipelines:
         streams.extend(
@@ -713,6 +733,13 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
         )
         for route in pipeline.bind_routes:
             bind_routes.append(route.route)
+            bind_routes_meta.append(
+                {
+                    "route": route.route,
+                    "line": route.location.line,
+                    "column": route.location.column,
+                }
+            )
             if isinstance(route, AstKernelBindRoute):
                 bind_routes_ir.append(
                     {
@@ -721,6 +748,8 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                         "kernel": route.kernel,
                         "args": list(route.args),
                         "route": route.route,
+                        "line": route.location.line,
+                        "column": route.location.column,
                     }
                 )
             else:
@@ -732,6 +761,8 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                         "operator": route.operator,
                         "source": route.source,
                         "route": route.route,
+                        "line": route.location.line,
+                        "column": route.location.column,
                     }
                 )
 
@@ -764,6 +795,8 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                 ],
                 "body": [_statement_to_text(statement) for statement in shader.body],
                 "body_ast": list(shader.body),
+                "line": shader.identifier_location.line,
+                "column": shader.identifier_location.column,
             }
             for shader in program.shaders
         ],
@@ -780,6 +813,8 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                 ],
                 "body": [_statement_to_text(statement) for statement in flt.body],
                 "body_ast": list(flt.body),
+                "line": flt.identifier_location.line,
+                "column": flt.identifier_location.column,
             }
             for flt in program.filters
         ],
@@ -794,6 +829,8 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
                 "body": [_statement_to_text(statement) for statement in pure.body],
                 "body_ast": list(pure.body),
                 "intrinsic": pure.intrinsic,
+                "line": pure.identifier_location.line,
+                "column": pure.identifier_location.column,
             }
             for pure in program.pure_functions
         ],
@@ -801,5 +838,6 @@ def ast_to_entities(program: AstProgram) -> dict[str, Any]:
         "accumulators": accumulators,
         "uniforms": uniforms,
         "bind_routes": bind_routes,
+        "bind_routes_meta": bind_routes_meta,
         "bind_routes_ir": bind_routes_ir,
     }

--- a/lockstep_compiler/lsp.py
+++ b/lockstep_compiler/lsp.py
@@ -223,6 +223,97 @@ def _offset_to_line_column(source: str, offset: int) -> tuple[int, int]:
     return line, clamped - line_start - 1
 
 
+def _line_column_to_offset(source: str, line: int, column: int) -> int | None:
+    if line < 0 or column < 0:
+        return None
+    lines = source.splitlines(keepends=True)
+    if line >= len(lines):
+        return None
+    return sum(len(existing) for existing in lines[:line]) + min(column, len(lines[line]))
+
+
+def _code_mask(source: str) -> list[bool]:
+    mask = [True] * len(source)
+    in_string = False
+    escaped = False
+    in_comment = False
+    for index, char in enumerate(source):
+        if in_comment:
+            mask[index] = False
+            if char == "\n":
+                in_comment = False
+            continue
+
+        if in_string:
+            mask[index] = False
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == "/" and index + 1 < len(source) and source[index + 1] == "/":
+            mask[index] = False
+            mask[index + 1] = False
+            in_comment = True
+            continue
+
+        if char == '"':
+            mask[index] = False
+            in_string = True
+            escaped = False
+    return mask
+
+
+def _identifier_at_position(source: str, line: int, column: int) -> str | None:
+    offset = _line_column_to_offset(source, line, column)
+    if offset is None or offset >= len(source):
+        return None
+
+    code_mask = _code_mask(source)
+    if not code_mask[offset]:
+        return None
+
+    index = offset
+    if not (source[index].isalnum() or source[index] == "_"):
+        if index > 0 and (source[index - 1].isalnum() or source[index - 1] == "_"):
+            index -= 1
+        else:
+            return None
+
+    start = index
+    while start > 0 and (source[start - 1].isalnum() or source[start - 1] == "_"):
+        start -= 1
+    end = index + 1
+    while end < len(source) and (source[end].isalnum() or source[end] == "_"):
+        end += 1
+
+    if any(not code_mask[pos] for pos in range(start, end)):
+        return None
+    return source[start:end]
+
+
+def _member_access_at_position(source: str, line: int, column: int) -> tuple[str, str] | None:
+    lines = source.splitlines()
+    if line < 0 or line >= len(lines):
+        return None
+    line_text = lines[line]
+    code_mask = _code_mask(source)
+    line_start = _line_column_to_offset(source, line, 0)
+    if line_start is None:
+        return None
+    for match in _MEMBER_ACCESS_RE.finditer(line_text):
+        start, end = match.span(0)
+        if not (start <= column <= end):
+            continue
+        if any(not code_mask[line_start + pos] for pos in range(start, end)):
+            continue
+        return match.group(1), match.group(2)
+    return None
+
+
 def _find_callable_definition(
     source: str,
     pattern: re.Pattern[str],
@@ -236,6 +327,17 @@ def _find_callable_definition(
     return DefinitionTarget(line=line, column=column, symbol=symbol)
 
 
+def _location_target_from_entity(entity: dict[str, Any]) -> DefinitionTarget | None:
+    name = entity.get("name")
+    line = entity.get("line")
+    column = entity.get("column")
+    if not name or not isinstance(line, int) or not isinstance(column, int):
+        return None
+    if line <= 0 or column < 0:
+        return None
+    return DefinitionTarget(line=line - 1, column=column, symbol=name)
+
+
 def _build_callable_index(
     source: str,
     entities: dict[str, Any],
@@ -246,11 +348,13 @@ def _build_callable_index(
         name = shader.get("name")
         if not name or name in callable_index:
             continue
-        target = _find_callable_definition(
-            source,
-            re.compile(rf"\bshader\s+(?P<name>{re.escape(name)})\s*\("),
-            name,
-        )
+        target = _location_target_from_entity(shader)
+        if target is None:
+            target = _find_callable_definition(
+                source,
+                re.compile(rf"\bshader\s+(?P<name>{re.escape(name)})\s*\("),
+                name,
+            )
         if target is not None:
             callable_index[name] = target
 
@@ -258,11 +362,13 @@ def _build_callable_index(
         name = filter_decl.get("name")
         if not name or name in callable_index:
             continue
-        target = _find_callable_definition(
-            source,
-            re.compile(rf"\bfilter\s+(?P<name>{re.escape(name)})\s*\("),
-            name,
-        )
+        target = _location_target_from_entity(filter_decl)
+        if target is None:
+            target = _find_callable_definition(
+                source,
+                re.compile(rf"\bfilter\s+(?P<name>{re.escape(name)})\s*\("),
+                name,
+            )
         if target is not None:
             callable_index[name] = target
 
@@ -270,13 +376,15 @@ def _build_callable_index(
         name = pure.get("name")
         if not name or pure.get("intrinsic") or name in callable_index:
             continue
-        target = _find_callable_definition(
-            source,
-            re.compile(
-                rf"\bpure\b[\s\S]*?\b(?P<name>{re.escape(name)})\s*\("
-            ),
-            name,
-        )
+        target = _location_target_from_entity(pure)
+        if target is None:
+            target = _find_callable_definition(
+                source,
+                re.compile(
+                    rf"\bpure\b[\s\S]*?\b(?P<name>{re.escape(name)})\s*\("
+                ),
+                name,
+            )
         if target is not None:
             callable_index[name] = target
 
@@ -289,23 +397,15 @@ def find_member_definition(
     column: int,
     analysis_context: AnalysisContext | None = None,
 ) -> MemberDefinition | None:
-    lines = source.splitlines()
-    if line < 0 or line >= len(lines):
-        return None
-
-    line_text = lines[line]
     context = analysis_context or build_analysis_context(source)
-
-    for match in _MEMBER_ACCESS_RE.finditer(line_text):
-        start, end = match.span(0)
-        if not (start <= column <= end):
-            continue
-        variable_name, field_name = match.groups()
-        struct_name = context.variable_types.get(variable_name)
-        if not struct_name:
-            return None
-        return context.struct_member_index.get(struct_name, {}).get(field_name)
-    return None
+    member_access = _member_access_at_position(source, line, column)
+    if member_access is None:
+        return None
+    variable_name, field_name = member_access
+    struct_name = context.variable_types.get(variable_name)
+    if not struct_name:
+        return None
+    return context.struct_member_index.get(struct_name, {}).get(field_name)
 
 
 def find_definition_target(
@@ -331,14 +431,11 @@ def find_definition_target(
     if line < 0 or line >= len(lines):
         return None
 
-    line_text = lines[line]
     context = analysis_context or build_analysis_context(source)
-    for match in re.finditer(r"\b([A-Za-z_][A-Za-z0-9_]*)\b", line_text):
-        start, end = match.span(1)
-        if not (start <= column < end):
-            continue
-        return context.callable_index.get(match.group(1))
-    return None
+    name = _identifier_at_position(source, line, column)
+    if name is None:
+        return None
+    return context.callable_index.get(name)
 
 
 def provide_bind_completion_items(
@@ -360,7 +457,15 @@ def provide_bind_completion_items(
     )
 
     if inside_bind:
-        for route in entities.get("bind_routes", []):
+        bind_route_labels = [
+            entry.get("route")
+            for entry in entities.get("bind_routes_meta", [])
+            if isinstance(entry, dict) and entry.get("route")
+        ]
+        if not bind_route_labels:
+            bind_route_labels = [route for route in entities.get("bind_routes", []) if route]
+
+        for route in bind_route_labels:
             if route in seen_labels:
                 continue
             completion_entries.append(
@@ -422,18 +527,10 @@ def provide_hover_info(
     column: int,
     analysis_context: AnalysisContext | None = None,
 ) -> str | None:
-    lines = source.splitlines()
-    if line < 0 or line >= len(lines):
-        return None
-
-    line_text = lines[line]
     context = analysis_context or build_analysis_context(source)
-
-    for match in _MEMBER_ACCESS_RE.finditer(line_text):
-        start, end = match.span(0)
-        if not (start <= column <= end):
-            continue
-        variable_name, field_name = match.groups()
+    member_access = _member_access_at_position(source, line, column)
+    if member_access is not None:
+        variable_name, field_name = member_access
         struct_name = context.variable_types.get(variable_name)
         if struct_name:
             field_type = context.struct_field_types.get(struct_name, {}).get(field_name)
@@ -442,32 +539,24 @@ def provide_hover_info(
             return f"(field) `{struct_name}.{field_name}`"
         return None
 
-    id_pattern = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\b")
-    for match in id_pattern.finditer(line_text):
-        start, end = match.span(1)
-        if not (start <= column < end):
-            continue
-        name = match.group(1)
-        if name in context.variable_types:
-            return f"(variable) `{name}: {context.variable_types[name]}`"
-
-        entities = context.entities
-        if any(struct.get("name") == name for struct in entities.get("structs", [])):
-            return f"(struct) `struct {name}`"
-        if any(shader.get("name") == name for shader in entities.get("shaders", [])):
-            return f"(shader) `shader {name}(...)`"
-        if any(
-            filter_decl.get("name") == name
-            for filter_decl in entities.get("filters", [])
-        ):
-            return f"(filter) `filter {name}(...)`"
-        if any(
-            pure.get("name") == name and not pure.get("intrinsic")
-            for pure in entities.get("pure_functions", [])
-        ):
-            return f"(pure) `pure {name}(...)`"
+    name = _identifier_at_position(source, line, column)
+    if name is None:
         return None
+    if name in context.variable_types:
+        return f"(variable) `{name}: {context.variable_types[name]}`"
 
+    entities = context.entities
+    if any(struct.get("name") == name for struct in entities.get("structs", [])):
+        return f"(struct) `struct {name}`"
+    if any(shader.get("name") == name for shader in entities.get("shaders", [])):
+        return f"(shader) `shader {name}(...)`"
+    if any(filter_decl.get("name") == name for filter_decl in entities.get("filters", [])):
+        return f"(filter) `filter {name}(...)`"
+    if any(
+        pure.get("name") == name and not pure.get("intrinsic")
+        for pure in entities.get("pure_functions", [])
+    ):
+        return f"(pure) `pure {name}(...)`"
     return None
 
 

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -270,3 +270,116 @@ shader Wrap(in float src, out float dst) {
 
     assert blend_target is not None
     assert (blend_target.line, blend_target.column, blend_target.symbol) == (6, 0, "blend")
+
+
+def test_hover_and_definition_ignore_symbols_in_comments_and_strings():
+    source = """
+shader Step(in float src, out float dst) {
+    // Step(src, dst);
+    string msg = "Step(src, dst)";
+    dst = src;
+}
+"""
+    lines = source.splitlines()
+    comment_line = next(i for i, text in enumerate(lines) if "// Step(" in text)
+    string_line = next(i for i, text in enumerate(lines) if '"Step(src, dst)"' in text)
+
+    assert provide_hover_info(source, comment_line, lines[comment_line].index("Step") + 1) is None
+    assert (
+        find_definition_target(
+            source,
+            comment_line,
+            lines[comment_line].index("Step") + 1,
+        )
+        is None
+    )
+    assert provide_hover_info(source, string_line, lines[string_line].index("Step") + 1) is None
+    assert (
+        find_definition_target(
+            source,
+            string_line,
+            lines[string_line].index("Step") + 1,
+        )
+        is None
+    )
+
+
+def test_definition_uses_identifier_locations_for_unusual_whitespace_layouts():
+    source = """
+shader
+Warp
+(
+    in float src,
+    out float dst
+) {
+    dst = src;
+}
+
+filter
+Mix
+(
+    in float src,
+    out float dst
+) {
+    dst = src;
+}
+
+pure float
+fuse
+(
+    float a,
+    float b
+) {
+    return a;
+}
+
+shader Use(in float src, out float dst) {
+    dst = fuse(src, src);
+}
+
+pipeline P {
+    stream<float, 8> src;
+    stream<float, 8> dst;
+    bind {
+        dst = Warp(src, dst);
+        dst = Mix(src, dst);
+    }
+}
+"""
+    lines = source.splitlines()
+    warp_call_line = next(i for i, text in enumerate(lines) if "Warp(src, dst)" in text)
+    mix_call_line = next(i for i, text in enumerate(lines) if "Mix(src, dst)" in text)
+    fuse_call_line = next(i for i, text in enumerate(lines) if "fuse(src, src)" in text)
+
+    warp_target = find_definition_target(source, warp_call_line, lines[warp_call_line].index("Warp") + 1)
+    mix_target = find_definition_target(source, mix_call_line, lines[mix_call_line].index("Mix") + 1)
+    fuse_target = find_definition_target(source, fuse_call_line, lines[fuse_call_line].index("fuse") + 1)
+
+    assert warp_target is not None
+    assert (warp_target.line, warp_target.column, warp_target.symbol) == (2, 0, "Warp")
+    assert mix_target is not None
+    assert (mix_target.line, mix_target.column, mix_target.symbol) == (11, 0, "Mix")
+    assert fuse_target is not None
+    assert (fuse_target.line, fuse_target.column, fuse_target.symbol) == (20, 0, "fuse")
+
+
+def test_bind_completion_prefers_bind_route_metadata_with_unusual_spacing():
+    source = """
+shader Step(in float src, out float dst) { dst = src; }
+
+pipeline P {
+    stream<float, 4> src;
+    stream<float, 4> dst;
+    bind {
+        dst
+            =
+            Step(
+                src,
+                dst
+            );
+    }
+}
+"""
+    items = provide_bind_completion_items(source, line=7, column=8)
+
+    assert items[0]["label"] == "dst=Step(src,dst);"


### PR DESCRIPTION
### Motivation
- LSP hover/definition/completion relied on fragile regex/source scans and could report symbols inside comments/strings or mis-locate declarations with unusual whitespace.
- Emit and consume exact identifier locations from the compiler AST so editor features use stable, compiler-provided coordinates.

### Description
- Emit identifier locations: added `identifier_location` to `AstKernelDecl`/`AstPureDecl` and `location` to `AstKernelBindRoute`/`AstFoldBindRoute`, and record token positions in the AST builder. (`lockstep_compiler/ast.py`).
- Emit metadata: extended `ast_to_entities` to include `line`/`column` for shaders/filters/pure functions and `bind_routes_meta` plus per-route coordinates in `bind_routes_ir`. (`lockstep_compiler/ast.py`).
- Robust LSP token extraction: added `_line_column_to_offset`, `_code_mask`, `_identifier_at_position`, and `_member_access_at_position` to ignore `//` comments and string literals and to extract identifiers safely. (`lockstep_compiler/lsp.py`).
- Prefer AST locations: added `_location_target_from_entity` and refactored `_build_callable_index`, `find_definition_target`, `provide_hover_info`, and `provide_bind_completion_items` to prefer entity-provided declaration locations with regex/source fallbacks and to prefer bind-route metadata with a legacy fallback. (`lockstep_compiler/lsp.py`).
- Tests: added LSP tests exercising comment/string ignoring, unusual whitespace/newline declaration layouts, and bind completion stability under multiline bind formatting. (`tests/test_lsp.py`).

### Testing
- Ran the LSP test module with the project on PYTHONPATH using `PYTHONPATH=. pytest -q tests/test_lsp.py`, and the test suite passed (all tests in `tests/test_lsp.py` succeeded).
- Running `pytest -q tests/test_lsp.py` without `PYTHONPATH` fails in this environment with `ModuleNotFoundError` due to import path resolution, which is environmental and not related to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df7e7eb6c48328b1add3355acd901c)