### PR TITLE
Add deterministic compiler & simulator benchmarks and `make bench` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: verify verify-parser-toolchain generate-parser check-generated-parser build test test-cov mypy lock-deps check-lock-deps
+.PHONY: verify verify-parser-toolchain generate-parser check-generated-parser build test test-cov mypy lock-deps check-lock-deps bench
 
 verify: test mypy
 
@@ -34,3 +34,6 @@ test-cov:
 
 mypy:
 	python -m mypy
+
+bench:
+	pytest tests/benchmarks -q --benchmark-only

--- a/README.md
+++ b/README.md
@@ -185,6 +185,17 @@ make lock-deps
 
 CI enforces lockfile freshness (`make check-lock-deps`) and uses `--require-hashes` during installation so builds fail if hashes do not match.
 
+### Benchmarking compiler and simulation latency
+
+Install test dependencies (includes `pytest-benchmark`) and run:
+
+```bash
+python -m pip install --require-hashes -r requirements-test.lock
+make bench
+```
+
+`make bench` executes `pytest tests/benchmarks -q --benchmark-only` and prints a benchmark summary table with per-test timing statistics (for example `min`, `max`, `mean`, and iteration counts). The benchmark suite uses fixed seeds and deterministic row counts (`1k`, `10k`, `100k`) so historical comparisons remain stable across runs.
+
 Programmatic frontend usage is available from `lockstep_compiler`:
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
 test = [
     "pytest",
     "pytest-cov",
+    "pytest-benchmark",
     "mypy",
     "hypothesis",
 ]

--- a/requirements-test.lock
+++ b/requirements-test.lock
@@ -303,6 +303,10 @@ pluggy==1.6.0 \
     # via
     #   pytest
     #   pytest-cov
+py-cpuinfo==9.0.0 \
+    --hash=sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690 \
+    --hash=sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5
+    # via pytest-benchmark
 pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
@@ -312,7 +316,12 @@ pytest==9.0.3 \
     --hash=sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
     # via
     #   Lockstep (pyproject.toml)
+    #   pytest-benchmark
     #   pytest-cov
+pytest-benchmark==5.2.3 \
+    --hash=sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803 \
+    --hash=sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779
+    # via Lockstep (pyproject.toml)
 pytest-cov==7.1.0 \
     --hash=sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2 \
     --hash=sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678

--- a/tests/benchmarks/test_benchmark_compiler.py
+++ b/tests/benchmarks/test_benchmark_compiler.py
@@ -1,0 +1,206 @@
+import random
+import pathlib
+import sys
+from typing import Any
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from lockstep_compiler.compiler import compile_lockstep
+from lockstep_compiler.simulator import simulate_pipeline_entities
+
+
+MEDIUM_LOCKSTEP_PROGRAM = """
+struct Scalar {
+    float v;
+};
+
+pure float p0(float x) {
+    return x;
+}
+
+pure float p1(float x) {
+    return x;
+}
+
+pure float p2(float x) {
+    return x;
+}
+
+pure float p3(float x) {
+    return x;
+}
+
+pure float p4(float x) {
+    return x;
+}
+
+shader Stage0() {
+}
+
+shader Stage1() {
+}
+
+shader Stage2() {
+}
+
+shader Stage3() {
+}
+
+shader Stage4() {
+}
+
+pipeline MediumBenchmark {
+    stream<Scalar, 8192> source;
+    stream<Scalar, 8192> stage_a;
+    stream<Scalar, 8192> stage_b;
+    stream<Scalar, 8192> stage_c;
+    stream<Scalar, 8192> sink;
+    accumulator<float> energy;
+    uniform float dt = 0.016;
+
+    bind {
+        uniform float total_energy = fold sum(energy);
+    }
+}
+"""
+
+
+def _stream_heavy_entities(capacity: int) -> dict[str, Any]:
+    return {
+        "streams": [
+            {"name": "source", "type": "Particle", "capacity": str(capacity)},
+            {"name": "stage1", "type": "Particle", "capacity": str(capacity)},
+            {"name": "stage2", "type": "Particle", "capacity": str(capacity)},
+            {"name": "stage3", "type": "Particle", "capacity": str(capacity)},
+            {"name": "stage4", "type": "Particle", "capacity": str(capacity)},
+            {"name": "sink", "type": "Particle", "capacity": str(capacity)},
+        ],
+        "accumulators": [],
+        "uniforms": [],
+        "shaders": [
+            {
+                "name": "StageA",
+                "params": [
+                    {"modifier": "in", "type": "Particle", "name": "src"},
+                    {"modifier": "out", "type": "Particle", "name": "dst"},
+                ],
+            },
+            {
+                "name": "StageB",
+                "params": [
+                    {"modifier": "in", "type": "Particle", "name": "src"},
+                    {"modifier": "out", "type": "Particle", "name": "dst"},
+                ],
+            },
+            {
+                "name": "StageC",
+                "params": [
+                    {"modifier": "in", "type": "Particle", "name": "src"},
+                    {"modifier": "out", "type": "Particle", "name": "dst"},
+                ],
+            },
+            {
+                "name": "StageD",
+                "params": [
+                    {"modifier": "in", "type": "Particle", "name": "src"},
+                    {"modifier": "out", "type": "Particle", "name": "dst"},
+                ],
+            },
+        ],
+        "filters": [
+            {
+                "name": "KeepAlive",
+                "params": [
+                    {"modifier": "in", "type": "Particle", "name": "src"},
+                    {"modifier": "out", "type": "Particle", "name": "dst"},
+                ],
+            }
+        ],
+        "bind_routes": [
+            "stage1 = StageA(source, stage1);",
+            "stage2 = KeepAlive(stage1, stage2);",
+            "stage3 = StageB(stage2, stage3);",
+            "stage4 = StageC(stage3, stage4);",
+            "sink = StageD(stage4, sink);",
+        ],
+        "bind_routes_ir": [
+            {
+                "kind": "kernel",
+                "target": "stage1",
+                "kernel": "StageA",
+                "args": ["source", "stage1"],
+                "route": "stage1 = StageA(source, stage1);",
+            },
+            {
+                "kind": "kernel",
+                "target": "stage2",
+                "kernel": "KeepAlive",
+                "args": ["stage1", "stage2"],
+                "route": "stage2 = KeepAlive(stage1, stage2);",
+            },
+            {
+                "kind": "kernel",
+                "target": "stage3",
+                "kernel": "StageB",
+                "args": ["stage2", "stage3"],
+                "route": "stage3 = StageB(stage2, stage3);",
+            },
+            {
+                "kind": "kernel",
+                "target": "stage4",
+                "kernel": "StageC",
+                "args": ["stage3", "stage4"],
+                "route": "stage4 = StageC(stage3, stage4);",
+            },
+            {
+                "kind": "kernel",
+                "target": "sink",
+                "kernel": "StageD",
+                "args": ["stage4", "sink"],
+                "route": "sink = StageD(stage4, sink);",
+            },
+        ],
+    }
+
+
+def _stream_rows(size: int, *, seed: int = 101) -> list[dict[str, Any]]:
+    rng = random.Random(seed)
+    rows: list[dict[str, Any]] = []
+    for idx in range(size):
+        rows.append(
+            {
+                "id": idx,
+                "x": rng.random(),
+                "y": rng.random(),
+                "vx": rng.random(),
+                "vy": rng.random(),
+                "_keep": rng.random() > 0.15,
+            }
+        )
+    return rows
+
+
+def test_benchmark_compile_medium_program(benchmark: Any):
+    benchmark.pedantic(
+        lambda: compile_lockstep(MEDIUM_LOCKSTEP_PROGRAM, verbose=False),
+        rounds=3,
+        iterations=1,
+        warmup_rounds=0,
+    )
+
+
+@pytest.mark.parametrize("row_count", [1_000, 10_000, 100_000])
+def test_benchmark_simulate_stream_heavy_bind_graph(benchmark: Any, row_count: int):
+    entities = _stream_heavy_entities(row_count)
+    source_rows = _stream_rows(row_count, seed=2024 + row_count)
+
+    benchmark.pedantic(
+        lambda: simulate_pipeline_entities(entities, stream_inputs={"source": source_rows}),
+        rounds=3,
+        iterations=1,
+        warmup_rounds=0,
+    )


### PR DESCRIPTION
### Motivation
- Provide reproducible, automated benchmarks for frontend compile latency and pipeline simulation throughput so performance regressions can be tracked over time.
- Ensure benchmarking tooling is available as an opt-in test extra so CI/contributors can run benchmarks reproducibly via locked deps.

### Description
- Add `pytest-benchmark` to the `test` optional dependency group in `pyproject.toml` and refresh `requirements-test.lock` to pin the plugin and transitive deps with hashes.
- Add a new benchmark module `tests/benchmarks/test_benchmark_compiler.py` that measures `compile_lockstep(...)` on a medium program and `simulate_pipeline_entities(...)` on a stream-heavy bind graph using fixed seeds and deterministic sizes (`1_000`, `10_000`, `100_000`).
- Ensure tests import the package by inserting repository root into `sys.path` for test collection and use deterministic random seeds for stable historical comparisons.
- Add `bench` target to the `Makefile` (`pytest tests/benchmarks -q --benchmark-only`) and document invocation and expected `pytest-benchmark` output in `README.md`.

### Testing
- Ran `make bench` which invokes `pytest tests/benchmarks -q --benchmark-only`, and all benchmark tests were collected and executed successfully, producing a `pytest-benchmark` summary table.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfce3e4d448328a2b29efa81465ff0)