### PR TITLE
Handle malformed UTF-8 dependencies as LCK002 parse diagnostics

### DIFF
--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -391,6 +391,15 @@ def _resolve_dependency_sources(
 
             try:
                 dependency_source = dependency_path.read_text(encoding="utf-8")
+            except UnicodeDecodeError as exc:
+                _dependency_parse_error(
+                    message=(
+                        f"Unable to parse dependency '{reference}' from "
+                        f"'{current_file}': invalid UTF-8 ({exc.reason})"
+                    ),
+                    source_file=current_file,
+                    line=line,
+                )
             except OSError as exc:
                 _dependency_parse_error(
                     message=(

--- a/tests/test_type_syntax.py
+++ b/tests/test_type_syntax.py
@@ -176,3 +176,22 @@ def test_circular_imports_raise_compile_error(tmp_path):
     assert exc_info.value.phase == "parse"
     assert [diag.code for diag in exc_info.value.errors] == ["LCK002"]
     assert "Circular dependency detected" in exc_info.value.errors[0].message
+
+
+def test_malformed_utf8_dependency_raises_parse_style_error(tmp_path):
+    dependency = tmp_path / "bad.lock"
+    main_file = tmp_path / "main.lock"
+    dependency.write_bytes(b"\xff\xfe\xfd")
+    main_file.write_text(f'import "{dependency.name}";\n', encoding="utf-8")
+
+    with pytest.raises(LockstepCompileError) as exc_info:
+        compile_lockstep(
+            main_file.read_text(encoding="utf-8"),
+            verbose=False,
+            source_file=str(main_file),
+        )
+
+    assert exc_info.value.phase == "parse"
+    assert [diag.code for diag in exc_info.value.errors] == ["LCK002"]
+    assert "Unable to parse dependency" in exc_info.value.errors[0].message
+    assert "invalid UTF-8" in exc_info.value.errors[0].message


### PR DESCRIPTION
### Motivation
- Decoding non-UTF-8 dependency files could raise `UnicodeDecodeError` and escape as an uncaught exception instead of being reported as a parse-style diagnostic like other dependency resolution problems.

### Description
- Add an `except UnicodeDecodeError as exc` branch around `dependency_path.read_text(encoding="utf-8")` in `_resolve_dependency_sources` that calls `_dependency_parse_error(...)` with a message including the dependency reference, parent file, and decode reason.
- Keep the existing `OSError` branch for file I/O errors unchanged.
- Add `test_malformed_utf8_dependency_raises_parse_style_error` in `tests/test_type_syntax.py` to assert malformed UTF-8 in an imported dependency raises a parse-phase `LockstepCompileError` with code `LCK002` and an "invalid UTF-8" message.

### Testing
- Ran `pytest -q tests/test_type_syntax.py -k "dependency or circular or malformed_utf8"` and the selected tests passed successfully (all tests exited with status 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e00ab3e7a083288aaf264b8cdd6ae2)