### PR TITLE
De-serialize codegen paths to AST-only compiler flow

### DIFF
--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 from .ast import AstProgram, ast_to_entities
 from .arena_layout import build_arena_layout
 from .utils import sanitize_symbol as _sanitize_symbol
@@ -32,14 +30,10 @@ def _c_type(type_name: str, known_structs: set[str]) -> str:
 
 
 def emit_c_header(
-    program_or_entities: AstProgram | dict[str, Any],
+    program: AstProgram,
     guard: str = "LOCKSTEP_GENERATED_H",
 ) -> str:
-    entities = (
-        ast_to_entities(program_or_entities)
-        if isinstance(program_or_entities, AstProgram)
-        else program_or_entities
-    )
+    entities = ast_to_entities(program)
 
     layout = build_arena_layout(entities)
     normalized_structs = layout.normalized_structs

--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -329,7 +329,20 @@ def run_cli(
         return 0
 
     entities: dict[str, Any]
-    if hasattr(result, "entities"):
+    if hasattr(result, "ast") and result.ast is not None:
+        entities = ast_to_entities(result.ast)
+        bind_optimization = optimize_bind_routes(
+            entities["bind_routes"],
+            shader_names={shader["name"] for shader in entities["shaders"]},
+            filter_names={flt["name"] for flt in entities["filters"]},
+            bind_routes_ir=entities.get("bind_routes_ir"),
+        )
+        entities = {
+            **entities,
+            "optimized_bind_routes": bind_optimization["optimized_bind_routes"],
+            "fused_bind_groups": bind_optimization["fused_groups"],
+        }
+    elif hasattr(result, "entities"):
         entities = cast(dict[str, Any], result.entities)
     else:
         entities = cast(dict[str, Any], result)

--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 from llvmlite import ir
 
 from .ast import (
@@ -533,14 +531,6 @@ class _FunctionLowerer:
                 self.builder.ret(ir.Constant(return_type, None))
 
 
-def _normalize_codegen_input(
-    program_or_entities: AstProgram | dict[str, Any],
-) -> dict[str, Any]:
-    if isinstance(program_or_entities, AstProgram):
-        return ast_to_entities(program_or_entities)
-    return program_or_entities
-
-
 def _ast_body_for(entity: dict[str, Any], *, entity_kind: str) -> list[AstStatement]:
     body_ast = entity.get("body_ast")
     if body_ast is None:
@@ -563,10 +553,10 @@ def _simd_width_for_target_triple(target_triple: str | None) -> int:
     return 8
 
 
-def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
+def emit_llvm_ir(program: AstProgram) -> str:
     """Generate LLVM IR using llvmlite lowering for pure/kernels."""
 
-    entities = _normalize_codegen_input(program_or_entities)
+    entities = ast_to_entities(program)
 
     structs = entities.get("structs", [])
     shaders = entities.get("shaders", [])

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, cast
 
 from antlr4 import CommonTokenStream, InputStream
 
-from .ast import AstKernelParam, AstProgram, AstPureDecl, AstType, ast_to_entities, build_program_ast
+from .ast import AstKernelParam, AstProgram, AstPureDecl, AstType, build_program_ast
 from .c_header import emit_c_header
 from .codegen import CodegenError, emit_llvm_ir
 from .errors import LockstepCompileError, ParseErrorCollector
@@ -563,20 +563,7 @@ def _compile_lockstep_with_dependencies(
             source_file=semantic_errors[0].source_file,
         )
 
-    entities = ast_to_entities(typed_ast)
-
     all_diagnostics = normalize_diagnostics(semantic_diagnostics)
-    bind_optimization = optimize_bind_routes(
-        entities["bind_routes"],
-        shader_names={shader["name"] for shader in entities["shaders"]},
-        filter_names={flt["name"] for flt in entities["filters"]},
-        bind_routes_ir=entities.get("bind_routes_ir"),
-    )
-    entities = {
-        **entities,
-        "optimized_bind_routes": bind_optimization["optimized_bind_routes"],
-        "fused_bind_groups": bind_optimization["fused_groups"],
-    }
 
     try:
         llvm_ir = emit_llvm_ir(typed_ast)
@@ -599,7 +586,7 @@ def _compile_lockstep_with_dependencies(
 
     return LockstepCompileResult(
         parse_tree=tree,
-        entities=entities,
+        entities={},
         ast=typed_ast,
         llvm_ir=llvm_ir,
         c_header=emit_c_header(typed_ast),

--- a/tests/test_improvements.py
+++ b/tests/test_improvements.py
@@ -12,7 +12,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from lockstep_compiler.cli import build_arg_parser, run_cli
-from lockstep_compiler.ast import AstExprCall, AstExprVar, AstReturnStmt
+from lockstep_compiler.ast import AstExprCall, AstExprVar, AstReturnStmt, AstKernelParam, AstProgram, AstPureDecl, AstType
 from lockstep_compiler.codegen import emit_llvm_ir
 from lockstep_compiler.lsp import provide_hover_info
 from lockstep_compiler import compiler as compiler_module
@@ -62,50 +62,40 @@ def test_prelude_declares_smoothstep():
 def _intrinsic_defs():
     """Return intrinsic pure function declarations needed by codegen."""
     intrinsics = load_intrinsics()
-    return [
-        {
-            "name": decl.name,
-            "return_type": decl.return_type,
-            "params": [
-                {"type": param.type_name, "name": param.name} for param in decl.params
-            ],
-            "body": [],
-            "intrinsic": True,
-        }
+    return tuple(
+        AstPureDecl(
+            name=decl.name,
+            return_type=AstType(decl.return_type),
+            params=tuple(
+                AstKernelParam(modifier="", declared_type=AstType(param.type_name), name=param.name)
+                for param in decl.params
+            ),
+            body=(),
+            intrinsic=True,
+        )
         for decl in intrinsics.values()
-    ]
+    )
 
 
-_CODEGEN_ENTITIES_BASE = {
-    "structs": [],
-    "shaders": [],
-    "filters": [],
-    "streams": [],
-    "accumulators": [],
-    "uniforms": [],
-    "bind_routes": [],
-    "bind_routes_ir": [],
-}
-
-
-def _entities_with_pure(name, params, body, return_type="float"):
-    return {
-        **_CODEGEN_ENTITIES_BASE,
-        "pure_functions": [
-            {
-                "name": name,
-                "return_type": return_type,
-                "params": params,
-                "body_ast": body,
-                "intrinsic": False,
-            },
+def _program_with_pure(name, params, body, return_type="float"):
+    return AstProgram(
+        pure_functions=(
+            AstPureDecl(
+                name=name,
+                return_type=AstType(return_type),
+                params=tuple(
+                    AstKernelParam(modifier="", declared_type=AstType(p["type"]), name=p["name"])
+                    for p in params
+                ),
+                body=tuple(body),
+            ),
             *_intrinsic_defs(),
-        ],
-    }
+        )
+    )
 
 
 def test_codegen_min_intrinsic():
-    entities = _entities_with_pure(
+    program = _program_with_pure(
         "test_min",
         [{"type": "float", "name": "a"}, {"type": "float", "name": "b"}],
         [
@@ -116,12 +106,12 @@ def test_codegen_min_intrinsic():
             )
         ],
     )
-    ir_text = emit_llvm_ir(entities)
+    ir_text = emit_llvm_ir(program)
     assert "llvm.minnum.f32" in ir_text
 
 
 def test_codegen_max_intrinsic():
-    entities = _entities_with_pure(
+    program = _program_with_pure(
         "test_max",
         [{"type": "float", "name": "a"}, {"type": "float", "name": "b"}],
         [
@@ -132,22 +122,22 @@ def test_codegen_max_intrinsic():
             )
         ],
     )
-    ir_text = emit_llvm_ir(entities)
+    ir_text = emit_llvm_ir(program)
     assert "llvm.maxnum.f32" in ir_text
 
 
 def test_codegen_abs_intrinsic():
-    entities = _entities_with_pure(
+    program = _program_with_pure(
         "test_abs",
         [{"type": "float", "name": "x"}],
         [AstReturnStmt(value=AstExprCall(name="abs", args=(AstExprVar(path=("x",)),)))],
     )
-    ir_text = emit_llvm_ir(entities)
+    ir_text = emit_llvm_ir(program)
     assert "llvm.fabs.f32" in ir_text
 
 
 def test_codegen_sign_intrinsic():
-    entities = _entities_with_pure(
+    program = _program_with_pure(
         "test_sign",
         [{"type": "float", "name": "x"}],
         [
@@ -156,12 +146,12 @@ def test_codegen_sign_intrinsic():
             )
         ],
     )
-    ir_text = emit_llvm_ir(entities)
+    ir_text = emit_llvm_ir(program)
     assert "sign_pos" in ir_text or "sign" in ir_text
 
 
 def test_codegen_smoothstep_intrinsic():
-    entities = _entities_with_pure(
+    program = _program_with_pure(
         "test_smoothstep",
         [
             {"type": "float", "name": "e0"},
@@ -181,7 +171,7 @@ def test_codegen_smoothstep_intrinsic():
             )
         ],
     )
-    ir_text = emit_llvm_ir(entities)
+    ir_text = emit_llvm_ir(program)
     assert "smoothstep" in ir_text
 
 


### PR DESCRIPTION
### Motivation
- Make the typed `AstProgram` the sole internal representation for codegen and header emission to eliminate the dual AST/entity-dict flow and simplify compiler internals.  
- Keep entity dicts as a serialization format only (for `--dump`/CLI output) rather than a hot-path input to codegen/emitters.  

### Description
- Removed the codegen normalization shim and updated `emit_llvm_ir` to accept only `AstProgram` and call `ast_to_entities(program)` internally.  
- Removed the C-header normalization and changed `emit_c_header` to accept only `AstProgram` and call `ast_to_entities(program)`.  
- Stopped constructing/optimizing the full entity dict inside the compiler core; `compile_lockstep` now returns `ast` and empty `entities`, and `c_header`/`llvm_ir` are produced from the AST.  
- Moved entity-dict materialization and bind-route optimization into the CLI runtime path where `result.ast` is available before `--dump`, `--report`, or simulation; updated tests to construct `AstProgram` fixtures instead of raw entity dicts.  

### Testing
- Ran intrinsic codegen unit tests which now build `AstProgram` fixtures: `tests/test_improvements.py::test_codegen_min_intrinsic`, `::test_codegen_max_intrinsic`, `::test_codegen_abs_intrinsic`, `::test_codegen_sign_intrinsic`, and `::test_codegen_smoothstep_intrinsic`; all passed.  
- Exercised CLI dump/report related tests `tests/test_lockstep_compiler_api.py::test_run_cli_dump_prints_compiled_entities` and `::test_run_cli_dump_falls_back_to_compiler_result`; both passed.  
- Verified `tests/test_compiler_api.py::test_compile_lockstep_wraps_codegen_errors_with_compile_error` passed; an attempted run targeting a non-existent test node was reported as not found and did not apply to the current change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149e0210dc83288c836323039648be)