### PR TITLE
Remove legacy TypeError semantic-validator fallback

### DIFF
--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -542,13 +542,9 @@ def _compile_lockstep_with_dependencies(
         )
     else:
         validator = semantic_validator
-    try:
-        semantic_diagnostics = normalize_diagnostics(
-            validator(tree, typed_ast=typed_ast)
-        )
-    except TypeError:
-        fallback_validator = cast(Callable[[Any], Any], validator)
-        semantic_diagnostics = normalize_diagnostics(fallback_validator(tree))
+    semantic_diagnostics = normalize_diagnostics(
+        validator(tree, typed_ast=typed_ast)
+    )
     semantic_diagnostics = _remap_diagnostics(
         semantic_diagnostics,
         source_map=source_map,


### PR DESCRIPTION
### Motivation
- Ensure compilation fails fast for incomplete or un-migrated AST/validator call signatures by removing the legacy fallback that masked `TypeError` during semantic validation.

### Description
- Removed the `except TypeError` compatibility fallback in `_compile_lockstep_with_dependencies` in `lockstep_compiler/compiler.py` so the validator is always invoked as `validator(tree, typed_ast=typed_ast)` and any `TypeError` now propagates.

### Testing
- Ran `pytest -q tests/test_compiler_api.py -k typed_ast_type_error_without_legacy_fallback` which passed.
- Ran the full `pytest -q tests/test_compiler_api.py` suite which passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149e16392c83289a7a89d0b60b81e5)