### PR TITLE
Add AST-dispatched expression type resolver

### DIFF
--- a/lockstep_compiler/semantic_validator.py
+++ b/lockstep_compiler/semantic_validator.py
@@ -1,6 +1,15 @@
 from difflib import get_close_matches
 from typing import Any
 
+from .ast import (
+    AstExpr,
+    AstExprBinary,
+    AstExprCall,
+    AstExprCast,
+    AstExprLiteral,
+    AstExprUnary,
+    AstExprVar,
+)
 from .prelude import load_intrinsics
 
 from .models import (
@@ -785,6 +794,8 @@ def build_semantic_validator(base_visitor_cls):
         def _resolve_expr_type(self, ctx):
             if ctx is None:
                 return None
+            if isinstance(ctx, AstExpr):
+                return self._resolve_ast_expr_type(ctx)
 
             def _as_list(value):
                 if value is None:
@@ -1158,6 +1169,90 @@ def build_semantic_validator(base_visitor_cls):
                 if child_expr is not None:
                     return self._resolve_expr_type(child_expr)
 
+            return None
+
+        def _lookup_path(self, path: tuple[str, ...]) -> str | None:
+            if not path:
+                return None
+            symbol = self._lookup(path[0])
+            if symbol is None:
+                return None
+            current_type = symbol.declared_type
+            for field_name in path[1:]:
+                fields = self.structs.get(current_type)
+                if fields is None or field_name not in fields:
+                    return None
+                current_type = fields[field_name].declared_type
+            return current_type
+
+        def _resolve_ast_expr_type(self, expr: AstExpr) -> str | None:
+            numeric_types = {"int", "uint", "float", "double"}
+
+            def _resolve_binary(expr_binary: AstExprBinary) -> str | None:
+                left_type = self._resolve_ast_expr_type(expr_binary.left)
+                right_type = self._resolve_ast_expr_type(expr_binary.right)
+                op = expr_binary.op
+
+                if left_type is None or right_type is None:
+                    return None
+                if op in {"+", "-", "*", "/"}:
+                    if left_type in numeric_types and right_type == left_type:
+                        return left_type
+                    return None
+                if op in {"&", "|", "^"}:
+                    if left_type in {"int", "uint"} and right_type == left_type:
+                        return left_type
+                    return None
+                if op in {"&&", "||"}:
+                    if left_type == "bool" and right_type == "bool":
+                        return "bool"
+                    return None
+                if op in {"==", "!=", "<", "<=", ">", ">="}:
+                    if left_type == right_type:
+                        return "bool"
+                    return None
+                if op in {"<<", ">>"}:
+                    if left_type in {"int", "uint"} and right_type in {"int", "uint"}:
+                        return left_type
+                    return None
+                return None
+
+            def _resolve_call(expr_call: AstExprCall) -> str | None:
+                if expr_call.name in {"int", "float", "double", "uint", "bool"}:
+                    return expr_call.name if len(expr_call.args) == 1 else None
+                if expr_call.name == "select":
+                    if len(expr_call.args) != 3:
+                        return None
+                    condition_type = self._resolve_ast_expr_type(expr_call.args[0])
+                    true_type = self._resolve_ast_expr_type(expr_call.args[1])
+                    false_type = self._resolve_ast_expr_type(expr_call.args[2])
+                    if condition_type == "bool" and true_type == false_type:
+                        return true_type
+                    return None
+                signature = self.pure_functions.get(expr_call.name)
+                return signature.return_type if signature is not None else None
+
+            type_dispatch = {
+                AstExprLiteral: lambda node: node.kind,
+                AstExprVar: lambda node: self._lookup_path(node.path),
+                AstExprUnary: lambda node: (
+                    "bool"
+                    if node.op == "!"
+                    else self._resolve_ast_expr_type(node.operand)
+                    if (
+                        node.op != "-"
+                        or self._resolve_ast_expr_type(node.operand) in numeric_types
+                    )
+                    else None
+                ),
+                AstExprBinary: _resolve_binary,
+                AstExprCall: _resolve_call,
+                AstExprCast: lambda node: node.target_type,
+            }
+
+            for expr_type, resolver in type_dispatch.items():
+                if isinstance(expr, expr_type):
+                    return resolver(expr)
             return None
 
         def _type_check_pure_call(self, ctx):


### PR DESCRIPTION
### Motivation
- Replace fragile parse-tree pattern-matching in expression type resolution with a clean, explicit dispatch over the AST `AstExpr` discriminated union to simplify logic and make expression type checking testable against AST nodes. 
- Provide a direct fast path for AST-based callers while preserving the existing parse-tree-based resolver for backward compatibility. 

### Description
- Import AST expression node types and add an AST fast-path in `_resolve_expr_type` so `AstExpr` instances are dispatched to `_resolve_ast_expr_type`. 
- Implement `_lookup_path` to resolve variable and member access from AST `path` tuples against scoped symbols and struct field declarations. 
- Add `_resolve_ast_expr_type` which dispatches exhaustively over `AstExprLiteral`, `AstExprVar`, `AstExprUnary`, `AstExprBinary`, `AstExprCall`, and `AstExprCast`, and includes operator-specific type rules (numeric ops, integer bitwise ops, boolean ops, comparison ops, shifts, casts and the `select` builtin). 

### Testing
- Ran `python -m pytest -q tests/test_lockstep_compiler_api.py` which exercised the validator; the suite reported 9 failing tests in bind-statement tests (failures are due to test-double shapes for `argList()` used in those tests and are unrelated to the AST type-dispatch logic). 
- Earlier attempts to run a couple of targeted tests via `python -m pytest -q` failed because the exact test node names did not match, so the full file run was used for validation. 
- No new failures related to expression type resolution were observed in the exercised tests, but the bind-statement failures remain and will be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149e266da4832893435c82c4952099)