### PR TITLE
Emit unsigned integer ops for uint arithmetic and comparisons

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -57,6 +57,8 @@ class _FunctionLowerer:
         self.intrinsic_names = intrinsic_names or set()
         self.builder: ir.IRBuilder | None = None
         self.locals: dict[str, ir.AllocaInstr] = {}
+        self.local_types: dict[str, str] = {}
+        self.function_return_types: dict[str, str] = {}
         self._string_literal_counter = 0
 
     def _compiler_error(self, message: str) -> None:
@@ -267,7 +269,9 @@ class _FunctionLowerer:
             return self.builder.sub(ir.Constant(value.type, 0), value)
         self._compiler_error(f"unary '-' is unsupported for type '{value.type}'")
 
-    def _emit_numeric_binary(self, op: str, lhs: ir.Value, rhs: ir.Value) -> ir.Value:
+    def _emit_numeric_binary(
+        self, op: str, lhs: ir.Value, rhs: ir.Value, *, type_name: str | None = None
+    ) -> ir.Value:
         if lhs.type != rhs.type:
             self._compiler_error(
                 f"operator '{op}' requires matching operand types, got '{lhs.type}' and '{rhs.type}'"
@@ -283,12 +287,13 @@ class _FunctionLowerer:
             }[op](lhs, rhs)
 
         if isinstance(lhs.type, ir.IntType):
+            is_unsigned = type_name == "uint"
             return {
                 "+": self.builder.add,
                 "-": self.builder.sub,
                 "*": self.builder.mul,
-                "/": self.builder.sdiv,
-                "%": self.builder.srem,
+                "/": self.builder.udiv if is_unsigned else self.builder.sdiv,
+                "%": self.builder.urem if is_unsigned else self.builder.srem,
             }[op](lhs, rhs)
 
         self._compiler_error(f"operator '{op}' is unsupported for type '{lhs.type}'")
@@ -318,7 +323,7 @@ class _FunctionLowerer:
         )
 
     def _emit_relational_compare(
-        self, op: str, lhs: ir.Value, rhs: ir.Value
+        self, op: str, lhs: ir.Value, rhs: ir.Value, *, type_name: str | None = None
     ) -> ir.Value:
         if lhs.type != rhs.type:
             self._compiler_error(
@@ -329,8 +334,32 @@ class _FunctionLowerer:
         if isinstance(lhs.type, (ir.FloatType, ir.DoubleType)):
             return self.builder.fcmp_ordered(rel_map[op], lhs, rhs)
         if isinstance(lhs.type, ir.IntType):
+            if type_name == "uint":
+                return self.builder.icmp_unsigned(rel_map[op], lhs, rhs)
             return self.builder.icmp_signed(rel_map[op], lhs, rhs)
         self._compiler_error(f"comparison '{op}' is unsupported for type '{lhs.type}'")
+
+    def _infer_expr_type(self, node: AstExprLiteral | AstExprVar | AstExprUnary | AstExprBinary | AstExprCall | AstExprCast) -> str | None:
+        if isinstance(node, AstExprLiteral):
+            if node.kind in {"float", "int", "bool", "double", "uint", "string"}:
+                return node.kind
+            return None
+        if isinstance(node, AstExprVar):
+            key = _sanitize_symbol(node.path[0])
+            return self.local_types.get(key)
+        if isinstance(node, AstExprCast):
+            return _type_name(node.target_type)
+        if isinstance(node, AstExprUnary):
+            return self._infer_expr_type(node.operand)
+        if isinstance(node, AstExprCall):
+            if node.name in {"int", "uint", "float", "double", "bool"}:
+                return node.name
+            return self.function_return_types.get(f"pure_{_sanitize_symbol(node.name)}")
+        if isinstance(node, AstExprBinary):
+            if node.op in {"<", "<=", ">", ">=", "==", "!=", "&&", "||"}:
+                return "bool"
+            return self._infer_expr_type(node.left)
+        return None
 
     def _load_var(self, name: str) -> ir.Value:
         parts = name.split(".")
@@ -376,9 +405,11 @@ class _FunctionLowerer:
             return self.builder.call(callee, coerced, name=f"call_{name}")
         self._compiler_error(f"unknown function '{name}'")
 
-    def _lower_binary_op(self, op: str, lhs: ir.Value, rhs: ir.Value) -> ir.Value:
+    def _lower_binary_op(
+        self, op: str, lhs: ir.Value, rhs: ir.Value, *, type_name: str | None = None
+    ) -> ir.Value:
         if op in {"+", "-", "*", "/", "%"}:
-            return self._emit_numeric_binary(op, lhs, rhs)
+            return self._emit_numeric_binary(op, lhs, rhs, type_name=type_name)
         if (
             op in {"&", "|", "^", "<<", ">>"}
             and isinstance(lhs.type, ir.IntType)
@@ -394,7 +425,7 @@ class _FunctionLowerer:
                 return self.builder.shl(lhs, rhs)
             return self.builder.ashr(lhs, rhs)
         if op in {"<", "<=", ">", ">=", "==", "!="}:
-            return self._emit_relational_compare(op, lhs, rhs)
+            return self._emit_relational_compare(op, lhs, rhs, type_name=type_name)
         if op == "&&":
             if (
                 not isinstance(lhs.type, ir.IntType)
@@ -452,7 +483,8 @@ class _FunctionLowerer:
         if not isinstance(node, AstExprBinary):
             self._compiler_error(f"unsupported expression node '{type(node).__name__}'")
         lhs, rhs = self._lower_expr(node.left), self._lower_expr(node.right)
-        return self._lower_binary_op(node.op, lhs, rhs)
+        expr_type_name = self._infer_expr_type(node.left)
+        return self._lower_binary_op(node.op, lhs, rhs, type_name=expr_type_name)
 
     def _lower_assignment(self, target_name: str, value: ir.Value):
         base_name, *field_path = target_name.split(".")
@@ -494,6 +526,7 @@ class _FunctionLowerer:
                 else "float"
             )
             llvm_type = self._llvm_type(declared_type, self.known_structs)
+            self.local_types[key] = declared_type
             if key not in self.locals:
                 slot = self.builder.alloca(llvm_type, name=key)
                 self.locals[key] = slot
@@ -509,15 +542,23 @@ class _FunctionLowerer:
         self._compiler_error(f"unsupported statement node '{type(statement).__name__}'")
 
     def lower_function(
-        self, fn: ir.Function, statements: list[AstStatement], return_type: ir.Type
+        self,
+        fn: ir.Function,
+        statements: list[AstStatement],
+        return_type: ir.Type,
+        param_type_names: list[str] | None = None,
     ):
         block = fn.append_basic_block("entry")
         self.builder = ir.IRBuilder(block)
         self.locals = {}
-        for arg in fn.args:
-            slot = self.builder.alloca(arg.type, name=_sanitize_symbol(arg.name))
+        self.local_types = {}
+        for idx, arg in enumerate(fn.args):
+            key = _sanitize_symbol(arg.name)
+            slot = self.builder.alloca(arg.type, name=key)
             self.builder.store(arg, slot)
-            self.locals[_sanitize_symbol(arg.name)] = slot
+            self.locals[key] = slot
+            if param_type_names is not None and idx < len(param_type_names):
+                self.local_types[key] = param_type_names[idx]
 
         for statement in statements:
             if self.builder.block.is_terminated:
@@ -656,6 +697,7 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
         for idx, param in enumerate(pure.get("params", [])):
             fn.args[idx].name = _sanitize_symbol(param.get("name", f"arg{idx}"))
         function_map[fn.name] = fn
+        lowerer.function_return_types[fn.name] = str(pure.get("return_type", "float"))
 
     for shader in shaders:
         params = [
@@ -695,18 +737,25 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
             fn,
             _ast_body_for(pure, entity_kind="pure function"),
             fn.function_type.return_type,
+            [str(param.get("type", "float")) for param in pure.get("params", [])],
         )
 
     for shader in shaders:
         fn = function_map[f"shader_{_sanitize_symbol(shader['name'])}"]
         lowerer.lower_function(
-            fn, _ast_body_for(shader, entity_kind="shader"), ir.VoidType()
+            fn,
+            _ast_body_for(shader, entity_kind="shader"),
+            ir.VoidType(),
+            [str(param.get("type", "float")) for param in shader.get("params", [])],
         )
 
     for flt in filters:
         fn = function_map[f"filter_{_sanitize_symbol(flt['name'])}"]
         lowerer.lower_function(
-            fn, _ast_body_for(flt, entity_kind="filter"), ir.VoidType()
+            fn,
+            _ast_body_for(flt, entity_kind="filter"),
+            ir.VoidType(),
+            [str(param.get("type", "float")) for param in flt.get("params", [])],
         )
 
     layout = build_arena_layout(entities)

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -1303,3 +1303,24 @@ def test_compile_lockstep_enforces_parse_timeout(monkeypatch):
 
     assert exc_info.value.phase == "parse"
     assert exc_info.value.errors[0].code == "LCK004"
+
+def test_codegen_uses_unsigned_ops_for_uint_math():
+    source = """
+    pure uint half(uint value) {
+        return value / uint(2);
+    }
+
+    pure uint remainder(uint value) {
+        return value % uint(3);
+    }
+
+    pure bool less_than(uint a, uint b) {
+        return a < b;
+    }
+    """
+    result = lockstep_compiler.compile_lockstep(source)
+    llvm_ir = result.llvm_ir
+
+    assert "udiv i32" in llvm_ir
+    assert "urem i32" in llvm_ir
+    assert "icmp ult i32" in llvm_ir


### PR DESCRIPTION
### Motivation
- Preserve source-level `uint` semantics during IR lowering so integer division, remainder and comparisons use unsigned semantics in generated LLVM IR.
- Ensure the backend can distinguish `int` vs `uint` intent even though both lower to `i32` at the LLVM level.

### Description
- Add per-function/local type tracking (`self.local_types`, `self.function_return_types`) and thread declared parameter types into `lower_function` so lowering knows declared source types for operands.
- Implement `_infer_expr_type` to guess an expression's source-level type and pass that info into binary op lowering so the backend can choose unsigned vs signed ops when appropriate.
- Update numeric and relational lowering: `_emit_numeric_binary` now selects `udiv`/`urem` for `uint` and `_emit_relational_compare` uses `icmp unsigned` when `type_name == "uint"` while keeping signed paths for other integers.
- Add a regression test in `tests/test_compiler_api.py` that compiles small `uint` functions and asserts the generated IR contains `udiv i32`, `urem i32`, and `icmp ult i32`.

### Testing
- Ran `pytest -q tests/test_compiler_api.py -k 'unsigned_ops_for_uint_math'` and it passed.
- Ran `pytest -q tests/test_type_syntax.py tests/test_compiler_api.py -k 'uint_double or unsigned_ops_for_uint_math'` and the selected tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149e35352c8328a9766b6e38ddbed3)