### PR TITLE
Support --target-width override for SIMD width in CLI, codegen, and header

### DIFF
--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -34,6 +34,8 @@ def _c_type(type_name: str, known_structs: set[str]) -> str:
 def emit_c_header(
     program_or_entities: AstProgram | dict[str, Any],
     guard: str = "LOCKSTEP_GENERATED_H",
+    *,
+    target_width: int = 8,
 ) -> str:
     entities = (
         ast_to_entities(program_or_entities)
@@ -92,6 +94,7 @@ def emit_c_header(
     lines.append("")
 
     lines.append(f"#define LOCKSTEP_ARENA_BYTES {layout.total_size}")
+    lines.append(f"#define LOCKSTEP_SIMD_WIDTH {int(target_width)}")
     for kind, name, offset in layout.top_level_offsets:
         macro_suffix = f"{kind}_{_sanitize_symbol(name)}".upper()
         lines.append(f"#define LOCKSTEP_OFFSET_{macro_suffix} {offset}")

--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -28,6 +28,21 @@ def _non_negative_limit_value(flag_name: str):
     return _parse
 
 
+def _positive_int_value(flag_name: str):
+    def _parse(value: str) -> int:
+        try:
+            parsed = int(value)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                f"{flag_name} must be an integer."
+            ) from exc
+        if parsed <= 0:
+            raise argparse.ArgumentTypeError(f"{flag_name} must be > 0.")
+        return parsed
+
+    return _parse
+
+
 def _read_source_file(path: Path, *, stderr) -> str | None:
     try:
         return path.read_text(encoding="utf-8")
@@ -123,6 +138,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=None,
         help="Maximum allowed expression nesting depth (0 disables limit).",
     )
+    parser.add_argument(
+        "--target-width",
+        type=_positive_int_value("--target-width"),
+        default=8,
+        help="Override SIMD vector width used by LLVM IR lowering and generated C header macros.",
+    )
     return parser
 
 
@@ -216,6 +237,7 @@ def run_cli(
     supports_source_file = False
     supports_library_source_files = False
     supports_frontend_limits = False
+    supports_target_width = False
     try:
         signature = inspect.signature(compiler)
     except (TypeError, ValueError):
@@ -247,6 +269,11 @@ def run_cli(
             or parameter.name == "frontend_limits"
             for parameter in signature.parameters.values()
         )
+        supports_target_width = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            or parameter.name == "target_width"
+            for parameter in signature.parameters.values()
+        )
 
     compile_kwargs: dict[str, Any] = {}
     if supports_verbose:
@@ -265,6 +292,8 @@ def run_cli(
             parse_timeout_ms=args.parse_timeout_ms,
             max_expression_nesting=args.max_expr_nesting,
         )
+    if supports_target_width:
+        compile_kwargs["target_width"] = args.target_width
 
     try:
         if compile_kwargs:

--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -563,7 +563,9 @@ def _simd_width_for_target_triple(target_triple: str | None) -> int:
     return 8
 
 
-def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
+def emit_llvm_ir(
+    program_or_entities: AstProgram | dict[str, Any], *, target_width: int | None = None
+) -> str:
     """Generate LLVM IR using llvmlite lowering for pure/kernels."""
 
     entities = _normalize_codegen_input(program_or_entities)
@@ -755,7 +757,11 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
 
     tick_entry = tick.append_basic_block("entry")
     tick_builder = ir.IRBuilder(tick_entry)
-    simd_width = _simd_width_for_target_triple(module.triple)
+    simd_width = (
+        int(target_width)
+        if target_width is not None and int(target_width) > 0
+        else _simd_width_for_target_triple(module.triple)
+    )
 
     def _zero_value(llvm_type: ir.Type) -> ir.Value:
         if isinstance(llvm_type, ir.VoidType):

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -464,6 +464,7 @@ def _compile_lockstep_with_dependencies(
     token_stream_cls: Callable[[Any], Any] = CommonTokenStream,
     debug_visitor_cls: Any = None,
     frontend_limits: FrontendLimits | None = None,
+    target_width: int = 8,
 ) -> LockstepCompileResult:
     source_map = source_map or [(1, _line_count(source_code), source_file)]
     resolved_limits = _normalize_frontend_limits(frontend_limits, source_file=source_file)
@@ -579,7 +580,7 @@ def _compile_lockstep_with_dependencies(
     }
 
     try:
-        llvm_ir = emit_llvm_ir(typed_ast)
+        llvm_ir = emit_llvm_ir(typed_ast, target_width=target_width)
     except CodegenError as error:
         codegen_diagnostic = LockstepDiagnostic(
             severity="error",
@@ -602,7 +603,7 @@ def _compile_lockstep_with_dependencies(
         entities=entities,
         ast=typed_ast,
         llvm_ir=llvm_ir,
-        c_header=emit_c_header(typed_ast),
+        c_header=emit_c_header(typed_ast, target_width=target_width),
         diagnostics=all_diagnostics,
     )
 
@@ -646,6 +647,7 @@ def compile_lockstep(
     token_stream_cls: Callable[[Any], Any] = CommonTokenStream,
     debug_visitor_cls: Any = None,
     frontend_limits: FrontendLimits | None = None,
+    target_width: int = 8,
 ) -> LockstepCompileResult:
     resolved_library_sources: list[str] = list(library_sources or [])
     resolved_library_source_files: list[str] = list(library_source_files or [])
@@ -684,6 +686,7 @@ def compile_lockstep(
         token_stream_cls=token_stream_cls,
         debug_visitor_cls=debug_visitor_cls,
         frontend_limits=frontend_limits,
+        target_width=target_width,
     )
 
 

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -878,6 +878,34 @@ def test_emit_llvm_ir_lowers_fold_routes_to_vector_reduce_intrinsics():
     assert 'call fast float @"llvm.vector.reduce.fadd.v8f32"' in llvm_ir
     assert '%"struct.Lockstep_Arena" = type {[8 x i8]}' in llvm_ir
     assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 0, i32 4' in llvm_ir
+
+
+def test_emit_llvm_ir_honors_explicit_target_width_override():
+    llvm_ir = emit_llvm_ir(
+        {
+            "structs": [],
+            "pure_functions": [],
+            "shaders": [],
+            "filters": [],
+            "streams": [],
+            "accumulators": [{"name": "energy", "type": "float"}],
+            "uniforms": [{"name": "total", "type": "float"}],
+            "bind_routes": ["uniform float total = fold sum(energy);"],
+            "bind_routes_ir": [
+                {
+                    "kind": "fold",
+                    "uniform_type": "float",
+                    "uniform_name": "total",
+                    "operator": "sum",
+                    "source": "energy",
+                    "route": "uniform float total = fold sum(energy);",
+                }
+            ],
+        },
+        target_width=16,
+    )
+
+    assert 'call fast float @"llvm.vector.reduce.fadd.v16f32"' in llvm_ir
     assert 'store float %"fold_reduce"' in llvm_ir
 
 
@@ -1034,10 +1062,16 @@ def test_emit_c_header_generates_structs_offsets_and_tick_signature():
     assert "struct Lockstep_Vec3" in header
     assert "struct Lockstep_Arena" in header
     assert "#define LOCKSTEP_ARENA_BYTES 20" in header
+    assert "#define LOCKSTEP_SIMD_WIDTH 8" in header
     assert "#define LOCKSTEP_OFFSET_STREAM_RAW_POSITIONS 0" in header
     assert "#define LOCKSTEP_OFFSET_ACCUM_ENERGY 12" in header
     assert "#define LOCKSTEP_OFFSET_UNIFORM_DT 16" in header
     assert "void Lockstep_Tick(struct Lockstep_Arena* arena);" in header
+
+
+def test_emit_c_header_honors_target_width_override_macro():
+    header = emit_c_header({"streams": [], "accumulators": [], "uniforms": []}, target_width=16)
+    assert "#define LOCKSTEP_SIMD_WIDTH 16" in header
 
 
 def test_emit_c_header_exposes_nested_leaf_offsets_for_soa_layout():

--- a/tests/test_improvements.py
+++ b/tests/test_improvements.py
@@ -251,6 +251,12 @@ def test_arg_parser_has_emit_header():
     assert args.emit_header is True
 
 
+def test_arg_parser_has_target_width_override():
+    parser = build_arg_parser()
+    args = parser.parse_args(["file.lock", "--target-width", "16"])
+    assert args.target_width == 16
+
+
 def test_arg_parser_has_version():
     parser = build_arg_parser()
     args = parser.parse_args(["--version"])


### PR DESCRIPTION
### Motivation
- Provide a user-facing way to override the compile-time SIMD vector width so LLVM lowering (loop boundaries, vector splats, and reduction intrinsics) and the generated C header stay consistent with a chosen target width. 
- Bubble the CLI override through the compiler entrypoints to ensure the same `target_width` drives both IR emission and header macros.

### Description
- Add a `--target-width` CLI flag (positive integer, default `8`) and runtime parsing/validation in `lockstep_compiler/cli.py`.
- Thread `target_width` through `compile_lockstep` and `_compile_lockstep_with_dependencies` so it is forwarded into codegen and header generation in `lockstep_compiler/compiler.py`.
- Extend `emit_llvm_ir` in `lockstep_compiler/codegen.py` with a `target_width` parameter and use it to set the effective `simd_width` (falling back to the target-triple-derived width when unset or invalid), which affects vector splat construction and `llvm.vector.reduce.*` intrinsic naming.
- Extend `emit_c_header` in `lockstep_compiler/c_header.py` with a `target_width` parameter and emit a `#define LOCKSTEP_SIMD_WIDTH <width>` macro in the generated header.
- Add tests: CLI parsing test (`tests/test_improvements.py`), IR reduction-width override test and header macro tests (`tests/test_compiler_api.py`).

### Testing
- Ran the focused pytest suite for the new/updated tests: `test_emit_llvm_ir_honors_explicit_target_width_override`, `test_emit_c_header_honors_target_width_override_macro`, `test_arg_parser_has_target_width_override`, and `test_emit_c_header_generates_structs_offsets_and_tick_signature`; all tests passed. 
- The changes are exercised by unit tests that assert the generated LLVM IR contains the expected `v<width>f32` reduce intrinsic and that the generated header contains `#define LOCKSTEP_SIMD_WIDTH <width>`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149e3d68048328b3864cf55992d372)