### PR TITLE
Add LCK502 overflow validation for C header arena offsets

### DIFF
--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from .ast import AstProgram, ast_to_entities
 from .arena_layout import build_arena_layout
+from .errors import LockstepCompileError
+from .models import LockstepDiagnostic
 from .utils import sanitize_symbol as _sanitize_symbol
 
 _PRIMITIVE_C_TYPE = {
@@ -21,6 +23,8 @@ _PRIMITIVE_SIZE = {
     "float": 4,
     "double": 8,
 }
+
+_MAX_U64 = (1 << 64) - 1
 
 
 def _c_type(type_name: str, known_structs: set[str]) -> str:
@@ -83,7 +87,32 @@ def emit_c_header(
         lines.append("")
 
     lines.append("LOCKSTEP_PACKED_STRUCT(struct Lockstep_Arena {")
+    cumulative_layout_total = 0
     for leaf in layout.leaves:
+        leaf_size = _PRIMITIVE_SIZE.get(leaf.type_name, 1)
+        if cumulative_layout_total > _MAX_U64 - leaf_size:
+            diagnostic = LockstepDiagnostic(
+                severity="error",
+                code="LCK502",
+                message=(
+                    "Arena structural offset generation overflowed the platform "
+                    "allocation threshold (2^64-1 bytes)."
+                ),
+                line=1,
+                column=0,
+                source_file="<c_header>",
+                hint=(
+                    "Reduce aggregate stream or uniform layout size so cumulative "
+                    "arena bytes fit within unsigned 64-bit limits."
+                ),
+            )
+            raise LockstepCompileError(
+                [diagnostic],
+                diagnostics=[diagnostic],
+                phase="codegen",
+                source_file=diagnostic.source_file,
+            )
+        cumulative_layout_total += leaf_size
         c_type_name = _c_type(leaf.type_name, known_structs)
         path_suffix = "_".join(_sanitize_symbol(part) for part in leaf.path) if leaf.path else "value"
         field_name = f"{leaf.kind}_{_sanitize_symbol(leaf.binding_name)}_{path_suffix}"

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -7,6 +7,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 import lockstep_compiler
+import lockstep_compiler.c_header as c_header_module
 import lockstep_compiler.compiler as compiler_module
 from lockstep_compiler.c_header import emit_c_header
 from lockstep_compiler.codegen import CodegenError, emit_llvm_ir
@@ -1094,6 +1095,24 @@ def test_emit_c_header_includes_optional_saturated_write_debug_helpers():
         'LOCKSTEP_SATURATED_WRITE_LOG(stream_name != NULL ? stream_name : "<unnamed>"'
         in header
     )
+
+
+def test_emit_c_header_raises_lck502_when_cumulative_offsets_overflow(monkeypatch):
+    monkeypatch.setattr(c_header_module, "_MAX_U64", 4)
+
+    with pytest.raises(lockstep_compiler.LockstepCompileError) as exc_info:
+        emit_c_header(
+            {
+                "streams": [],
+                "accumulators": [
+                    {"name": "a", "type": "float"},
+                    {"name": "b", "type": "float"},
+                ],
+                "uniforms": [],
+            }
+        )
+
+    assert [diag.code for diag in exc_info.value.errors] == ["LCK502"]
 
 
 def test_compile_result_includes_c_header(monkeypatch):


### PR DESCRIPTION
### Motivation

- Prevent generation of C header arena layouts whose cumulative byte offsets exceed the platform allocation ceiling (`2^64 - 1`) to avoid silent integer overflow and unsafe headers.

### Description

- Add imports for `LockstepCompileError` and `LockstepDiagnostic` and declare a `_MAX_U64 = (1 << 64) - 1` ceiling in `lockstep_compiler/c_header.py`.
- Track a `cumulative_layout_total` while iterating `layout.leaves` and compute each `leaf_size` from `_PRIMITIVE_SIZE` to validate the next addition will not overflow `uint64_t`.
- When an overflow would occur raise `LockstepCompileError` with diagnostic code `LCK502`, an explanatory message, and an actionable hint during the `emit_c_header` emission loop.
- Add `test_emit_c_header_raises_lck502_when_cumulative_offsets_overflow` to `tests/test_compiler_api.py` which monkeypatches `_MAX_U64` to trigger the overflow path and asserts the compiler error contains `LCK502`.

### Testing

- Executed `pytest -q tests/test_compiler_api.py -k "emit_c_header"` and the test subset passed. 
- The new regression test `test_emit_c_header_raises_lck502_when_cumulative_offsets_overflow` passed under the test run, validating the overflow error path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149e474e4083288a0758d22ad183ff)