### PR TITLE
Add compile-time LOCKSTEP_ARENA_BYTES validation guards

### DIFF
--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -92,6 +92,15 @@ def emit_c_header(
     lines.append("")
 
     lines.append(f"#define LOCKSTEP_ARENA_BYTES {layout.total_size}")
+    lines.extend(
+        [
+            "#if defined(__cplusplus) && (__cplusplus >= 201103L)",
+            'static_assert(LOCKSTEP_ARENA_BYTES <= SIZE_MAX, "LOCKSTEP_ARENA_BYTES must fit in size_t on the target architecture");',
+            "#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)",
+            '_Static_assert(LOCKSTEP_ARENA_BYTES <= SIZE_MAX, "LOCKSTEP_ARENA_BYTES must fit in size_t on the target architecture");',
+            "#endif",
+        ]
+    )
     for kind, name, offset in layout.top_level_offsets:
         macro_suffix = f"{kind}_{_sanitize_symbol(name)}".upper()
         lines.append(f"#define LOCKSTEP_OFFSET_{macro_suffix} {offset}")


### PR DESCRIPTION
### Motivation
- Ensure the generated `LOCKSTEP_ARENA_BYTES` constant is provably representable in the target platform's `size_t` to avoid allocation/truncation mismatches.
- Surface an early, clear compile-time error in C11/C++11-capable toolchains rather than allowing subtle runtime failures or undefined behavior.

### Description
- Emit a compile-time check immediately after `#define LOCKSTEP_ARENA_BYTES {layout.total_size}` in `lockstep_compiler/c_header.py`.
- Generate `static_assert(LOCKSTEP_ARENA_BYTES <= SIZE_MAX, ...)` for C++11+ (`__cplusplus >= 201103L`) and `_Static_assert(LOCKSTEP_ARENA_BYTES <= SIZE_MAX, ...)` for C11+ (`__STDC_VERSION__ >= 201112L`).
- Guard assertions with preprocessor feature checks so older language standards are unaffected.

### Testing
- Ran `pytest -q tests/test_compiler_api.py -k c_header` and the test selection passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149e4f8a008328a19c4826c62d6e01)