### PR TITLE
Use typed Lockstep_Arena struct fields for LLVM tick GEPs

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -718,9 +718,6 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
     accum_slots: dict[str, int] = {accum["name"]: idx for idx, accum in enumerate(accumulators)}
     uniform_slots: dict[str, int] = {uniform["name"]: idx for idx, uniform in enumerate(uniforms)}
 
-    leaf_offsets: dict[tuple[str, str, tuple[str, ...]], int] = {
-        (leaf.kind, leaf.binding_name, leaf.path): leaf.offset for leaf in layout.leaves
-    }
     binding_declared_types: dict[tuple[str, str], str] = {}
     for stream in streams:
         binding_declared_types[("stream", stream["name"])] = stream["type"]
@@ -741,9 +738,24 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
     )
 
     arena_struct_ty = module.context.get_identified_type("struct.Lockstep_Arena")
-    arena_bytes_ty = ir.ArrayType(ir.IntType(8), max(layout.total_size, 1))
+
+    arena_field_types: list[ir.Type] = []
+    leaf_field_indices: dict[tuple[str, str, tuple[str, ...]], int] = {}
+    for leaf in layout.leaves:
+        if leaf.type_name in _PRIMITIVE_TYPE_MAP:
+            field_ty = _PRIMITIVE_TYPE_MAP[leaf.type_name]
+        elif leaf.type_name in known_structs and leaf.type_name not in layout.opaque_structs:
+            field_ty = known_structs[leaf.type_name]
+        else:
+            field_ty = ir.ArrayType(ir.IntType(8), max(leaf.size, 1))
+        leaf_field_indices[(leaf.kind, leaf.binding_name, leaf.path)] = len(arena_field_types)
+        arena_field_types.append(field_ty)
+
+    if not arena_field_types:
+        arena_field_types = [ir.ArrayType(ir.IntType(8), 1)]
+
     if arena_struct_ty.is_opaque:
-        arena_struct_ty.set_body(arena_bytes_ty)
+        arena_struct_ty.set_body(*arena_field_types)
 
     tick = ir.Function(
         module,
@@ -763,15 +775,17 @@ def emit_llvm_ir(program_or_entities: AstProgram | dict[str, Any]) -> str:
         return ir.Constant(llvm_type, None)
 
     def _leaf_ptr(kind: str, name: str, path: tuple[str, ...], leaf_type: ir.Type) -> ir.Value | None:
-        offset = leaf_offsets.get((kind, name, path))
-        if offset is None:
+        field_index = leaf_field_indices.get((kind, name, path))
+        if field_index is None:
             return None
-        raw_ptr = tick_builder.gep(
+        typed_ptr = tick_builder.gep(
             arena_ptr,
-            [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), offset)],
-            name=f"{kind}_{_sanitize_symbol(name)}_{'_'.join(path) if path else 'value'}_raw",
+            [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), field_index)],
+            name=f"{kind}_{_sanitize_symbol(name)}_{'_'.join(path) if path else 'value'}_ptr",
         )
-        return tick_builder.bitcast(raw_ptr, leaf_type.as_pointer())
+        if typed_ptr.type.pointee != leaf_type:
+            return None
+        return typed_ptr
 
     def _load_value(
         kind: str,

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -876,8 +876,8 @@ def test_emit_llvm_ir_lowers_fold_routes_to_vector_reduce_intrinsics():
     )
 
     assert 'call fast float @"llvm.vector.reduce.fadd.v8f32"' in llvm_ir
-    assert '%"struct.Lockstep_Arena" = type {[8 x i8]}' in llvm_ir
-    assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 0, i32 4' in llvm_ir
+    assert '%"struct.Lockstep_Arena" = type {float, float}' in llvm_ir
+    assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 1' in llvm_ir
     assert 'store float %"fold_reduce"' in llvm_ir
 
 


### PR DESCRIPTION
### Motivation
- Replace fragile byte-offset + bitcast access into the arena with a concrete, strongly-typed LLVM struct so GEPs index real fields instead of raw byte ranges.
- Make lowering of `Lockstep_Tick` emit safer, type-checked pointers for each binding/path and allow the IR to reflect the actual per-leaf types.

### Description
- Materialize `struct.Lockstep_Arena` as a list of LLVM field types derived from `layout.leaves`, mapping each `(kind, binding_name, path)` leaf to a deterministic field index (`leaf_field_indices`).
- Emit typed `getelementptr` uses into `Lockstep_Tick` that index `i32 0, i32 <field_index>` for a leaf, and only return the pointer when the pointee type matches the expected leaf type (replacing the former raw byte-array + bitcast approach).
- Remove the byte-offset based `leaf_offsets` usage and back the arena with per-leaf typed fields (falling back to small byte arrays for opaque or unknown-sized leaves).
- Update compiler API unit test expectations in `tests/test_compiler_api.py` to assert on the new typed arena definition and the new field-indexed GEP pattern.

### Testing
- Ran `python -m pytest tests/test_compiler_api.py -q` which passed successfully. 
- Running `python -m pytest tests/test_compiler_api.py tests/test_lockstep_compiler_api.py -q` exhibited pre-existing semantic-validator failures in `tests/test_lockstep_compiler_api.py` (an `AttributeError: 'object' object has no attribute 'ID'` in `visitBindStmt`) that are unrelated to the arena/GEP change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149e6ddb4883288c484106b635285b)