### PR TITLE
Generate stream arena leaves as arrays in C header output

### DIFF
--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -112,7 +112,7 @@ def emit_c_header(
         c_type_name = _c_type(leaf.type_name, known_structs)
         path_suffix = "_".join(_sanitize_symbol(part) for part in leaf.path) if leaf.path else "value"
         field_name = f"{leaf.kind}_{_sanitize_symbol(leaf.binding_name)}_{path_suffix}"
-        if leaf.element_count > 1:
+        if leaf.kind == "stream" or leaf.element_count > 1:
             lines.append(f"    {c_type_name} {field_name}[{leaf.element_count}];")
         else:
             lines.append(f"    {c_type_name} {field_name};")


### PR DESCRIPTION
### Motivation
- Stream data blocks should be represented consistently as C arrays in the generated arena struct so per-stream fields use `c_type field[capacity]` semantics instead of plain scalars.

### Description
- Change the arena field emission condition in `emit_c_header` so stream leaves are always emitted as arrays by using `if leaf.kind == "stream" or leaf.element_count > 1:` in `lockstep_compiler/c_header.py`.

### Testing
- Ran `pytest -q` which failed during collection because the test environment is missing the `hypothesis` dependency (collection error).
- Ran `pytest -q tests/test_compiler_api.py -k emit_c_header` which exercised `emit_c_header` but the test run failed due to `ast_to_entities` expecting an `AstProgram` object rather than plain dict inputs in the current test harness (failures are test-harness/environmental and not changes to the header emission logic).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15a97bacf883288b37fbf0e02cf7ba)