### PR TITLE
Enforce LCK310 for uint/double source annotations

### DIFF
--- a/lockstep_compiler/semantic_validator.py
+++ b/lockstep_compiler/semantic_validator.py
@@ -54,7 +54,7 @@ def build_semantic_validator(base_visitor_cls):
                 for name, signature in load_intrinsics().items()
             }
             self.structs: dict[str, dict[str, SemanticStructField]] = {}
-            self._primitive_types = {"int", "uint", "float", "double", "bool", "string"}
+            self._primitive_types = {"int", "float", "bool", "string"}
             self._current_pure_function: SemanticPureFunctionContext | None = None
             self._pipeline_resource_stack: list[dict[str, SemanticPipelineResource]] = []
             self._pipeline_bind_usage_stack: list[set[str]] = []


### PR DESCRIPTION
### Motivation
- Remove `uint` and `double` from the validator's primitive types so source annotations using them are treated as invalid and emit `LCK310` per compiler documentation.

### Description
- Removed `uint` and `double` from `self._primitive_types` in `lockstep_compiler/semantic_validator.py`, causing the semantic validator to treat those annotations as unknown types and trigger the existing `LCK310` diagnostic path.

### Testing
- Ran `python -m pytest -q`; test collection failed with `ModuleNotFoundError` for optional dependency `hypothesis`, so automated tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15a984a5e483289054ee7f1aeda41a)