### PR TITLE
Refactor _leaf_ptr to use loop index register for element addressing

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -828,25 +828,26 @@ def emit_llvm_ir(
         name: str,
         path: tuple[str, ...],
         leaf_type: ir.Type,
-        element_index: ir.Value | None = None,
+        loop_index_reg: ir.Value | None = None,
     ) -> ir.Value | None:
         leaf_spec = leaf_specs.get((kind, name, path))
         if leaf_spec is None:
             return None
         base_offset, element_size = leaf_spec
         byte_offset: ir.Value = ir.Constant(ir.IntType(32), base_offset)
-        if kind == "stream" and element_index is not None:
+        if loop_index_reg is not None:
             stride = ir.Constant(ir.IntType(32), element_size)
             byte_offset = tick_builder.add(
                 byte_offset,
-                tick_builder.mul(element_index, stride, name="stream_elem_stride"),
-                name="stream_elem_offset",
+                tick_builder.mul(loop_index_reg, stride, name="loop_elem_stride"),
+                name="loop_elem_offset",
             )
         raw_ptr = tick_builder.gep(
             arena_ptr,
             [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), 0), byte_offset],
             name=f"{kind}_{_sanitize_symbol(name)}_{'_'.join(path) if path else 'value'}_raw",
         )
+        typed_ptr = tick_builder.bitcast(raw_ptr, leaf_type.as_pointer())
         if typed_ptr.type.pointee != leaf_type:
             return None
         return typed_ptr


### PR DESCRIPTION
### Motivation
- Support computing per-iteration element addresses using the active loop index so targets are calculated as `base_offset + (active_index * element_byte_size)`.

### Description
- Change `_leaf_ptr` signature to accept `loop_index_reg` and use it to add `loop_index_reg * element_size` to the base byte offset, and add a `bitcast` from the raw byte pointer to `leaf_type*` before returning the typed pointer.

### Testing
- Ran `python -m pytest -q tests/test_improvements.py` and observed failures due to a pre-existing `NameError: name 'program' is not defined` in `emit_llvm_ir` (at `lockstep_compiler/codegen.py:602`), which is unrelated to this targeted change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d3afdbf483288c3b5cdc6d2d99b3)