### PR TITLE
Handle sized accumulators and perform true horizontal fold reductions

### DIFF
--- a/lockstep_compiler/arena_layout.py
+++ b/lockstep_compiler/arena_layout.py
@@ -132,7 +132,14 @@ def build_arena_layout(entities: dict[str, Any]) -> ArenaLayout:
         capacity = int(stream["capacity"])
         bindings.append(("stream", stream["name"], stream["type"], capacity))
     for accumulator in entities.get("accumulators", []):
-        bindings.append(("accum", accumulator["name"], accumulator["type"], 1))
+        element_count = (
+            int(accumulator.get("size", 1))
+            if accumulator.get("size") is not None
+            else 1
+        )
+        bindings.append(
+            ("accum", accumulator["name"], accumulator["type"], max(element_count, 1))
+        )
     for uniform in entities.get("uniforms", []):
         bindings.append(("uniform", uniform["name"], uniform["type"], 1))
 

--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -763,6 +763,10 @@ def emit_llvm_ir(
         (leaf.kind, leaf.binding_name, leaf.path): (leaf.offset, leaf.size)
         for leaf in layout.leaves
     }
+    accum_sizes: dict[str, int] = {
+        accum["name"]: int(accum.get("size", 1)) if accum.get("size") is not None else 1
+        for accum in accumulators
+    }
     binding_declared_types: dict[tuple[str, str], str] = {}
     for stream in streams:
         binding_declared_types[("stream", stream["name"])] = stream["type"]
@@ -835,7 +839,7 @@ def emit_llvm_ir(
             return None
         base_offset, element_size = leaf_spec
         byte_offset: ir.Value = ir.Constant(ir.IntType(32), base_offset)
-        if kind == "stream" and element_index is not None:
+        if kind in {"stream", "accum"} and element_index is not None:
             stride = ir.Constant(ir.IntType(32), element_size)
             byte_offset = tick_builder.add(
                 byte_offset,
@@ -916,17 +920,6 @@ def emit_llvm_ir(
         declared_type = binding_declared_types.get((kind, name), "float")
         return _load_value(kind, name, field_type, declared_type, element_index=element_index)
 
-    def _build_vector_splat(value: ir.Value, width: int) -> ir.Value:
-        vec_ty = ir.VectorType(value.type, width)
-        seed = tick_builder.insert_element(
-            ir.Constant(vec_ty, ir.Undefined), value, ir.Constant(ir.IntType(32), 0)
-        )
-        mask_ty = ir.VectorType(ir.IntType(32), width)
-        mask = ir.Constant(mask_ty, [0] * width)
-        return tick_builder.shuffle_vector(
-            seed, ir.Constant(vec_ty, ir.Undefined), mask, name="fold_splat"
-        )
-
     def _get_vector_reduce_intrinsic(
         name: str, ret_ty: ir.Type, arg_tys: list[ir.Type]
     ) -> ir.Function:
@@ -936,13 +929,40 @@ def emit_llvm_ir(
             intrinsic = ir.Function(module, fn_ty, name=name)
         return intrinsic
 
-    def _reduce_fold(
-        operator: str, accum_value: ir.Value, uniform_type: ir.Type
-    ) -> ir.Value:
-        if accum_value.type != uniform_type:
+    def _reduce_fold(operator: str, source_name: str, uniform_type: ir.Type) -> ir.Value:
+        lane_count = max(accum_sizes.get(source_name, 1), 1)
+        lane_count = min(lane_count, simd_width)
+        lane_values: list[ir.Value] = []
+        for lane in range(lane_count):
+            lane_values.append(
+                _load_tick_param(
+                    "accum",
+                    source_name,
+                    uniform_type,
+                    ir.Constant(ir.IntType(32), lane),
+                )
+            )
+        if not lane_values:
             return _zero_value(uniform_type)
 
-        vector_value = _build_vector_splat(accum_value, simd_width)
+        vector_value = ir.Constant(
+            ir.VectorType(uniform_type, simd_width), ir.Undefined
+        )
+        for lane, lane_value in enumerate(lane_values):
+            vector_value = tick_builder.insert_element(
+                vector_value,
+                lane_value,
+                ir.Constant(ir.IntType(32), lane),
+                name=f"fold_lane_{lane}",
+            )
+        if lane_count < simd_width:
+            zero_value = ir.Constant(uniform_type, 0 if isinstance(uniform_type, ir.IntType) else 0.0)
+            for lane in range(lane_count, simd_width):
+                vector_value = tick_builder.insert_element(
+                    vector_value,
+                    zero_value,
+                    ir.Constant(ir.IntType(32), lane),
+                )
         vector_ty = vector_value.type
 
         # Map (is_float, operator) -> intrinsic suffix for reduction ops.
@@ -1087,8 +1107,7 @@ def emit_llvm_ir(
                     continue
                 uniform_type_name = str(route.get("uniform_type", "float"))
                 uniform_type = lowerer._llvm_type(uniform_type_name, known_structs)
-                accum_value = _load_tick_param("accum", source_name, uniform_type)
-                reduced = _reduce_fold(operator, accum_value, uniform_type)
+                reduced = _reduce_fold(operator, source_name, uniform_type)
                 _store_value("uniform", uniform_name, reduced, uniform_type_name)
                 continue
             asm_ty = ir.FunctionType(ir.VoidType(), [])


### PR DESCRIPTION
### Motivation
- Accumulators should be able to reserve multiple contiguous elements in the arena when declared with an optional `size`, so fold reductions can consume multiple lanes of stored accumulator data. 
- The fold lowering should build a SIMD vector from contiguous accumulator lanes instead of duplicating a single scalar across all lanes to enable correct horizontal reductions across accumulator elements.
- The arena addressing logic must index accumulator elements like streams so per-lane accumulator loads are possible during lowering.

### Description
- Update `build_arena_layout` to respect an optional `size` on accumulators and reserve `element_count` bytes for each accumulator binding instead of always treating accumulators as scalars (`lockstep_compiler/arena_layout.py`).
- Add `accum_sizes` tracking and extend `_leaf_ptr` indexing to treat `accum` like `stream` for element addressing, enabling element-indexed loads into accumulator storage (`lockstep_compiler/codegen.py`).
- Refactor `_reduce_fold` to accept the accumulator source name, load contiguous lanes from the accumulator into a SIMD vector (zero-fill remaining lanes), and then call the LLVM vector reduce intrinsic on the assembled vector instead of splatting a single scalar value (`lockstep_compiler/codegen.py`).
- Remove the old `_build_vector_splat` usage and update fold callsites to pass the accumulator name into the new `_reduce_fold` API (`lockstep_compiler/codegen.py`).

### Testing
- Ran `python -m compileall lockstep_compiler/arena_layout.py lockstep_compiler/codegen.py` and compilation succeeded.
- Ran `pytest -q tests/test_compiler_api.py -k fold` and the fold-related tests failed (2 failures) due to a pre-existing `NameError` in `emit_llvm_ir` where `program` is undefined when a dict of entities is passed, which appears unrelated to the accumulator/vector-lane changes.
- Basic repository lint/compile checks were performed and no syntax errors were introduced by these patches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d3b816e4832886cd9dd6fe97a70e)