### PR TITLE
Add branchless i32 vector clamp for kernel route stream indices

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -936,6 +936,39 @@ def emit_llvm_ir(
             intrinsic = ir.Function(module, fn_ty, name=name)
         return intrinsic
 
+    def _vector_i32_splat(value: ir.Value, width: int = 4) -> ir.Value:
+        vec_ty = ir.VectorType(ir.IntType(32), width)
+        seed = tick_builder.insert_element(
+            ir.Constant(vec_ty, ir.Undefined), value, ir.Constant(ir.IntType(32), 0)
+        )
+        mask_ty = ir.VectorType(ir.IntType(32), width)
+        mask = ir.Constant(mask_ty, [0] * width)
+        return tick_builder.shuffle_vector(
+            seed, ir.Constant(vec_ty, ir.Undefined), mask, name="route_i32_splat"
+        )
+
+    def _vector_i32_extract_lane0(vector: ir.Value) -> ir.Value:
+        return tick_builder.extract_element(
+            vector, ir.Constant(ir.IntType(32), 0), name="route_i32_lane0"
+        )
+
+    def _vector_i32_max(lhs: ir.Value, rhs: ir.Value, width: int = 4) -> ir.Value:
+        lhs_vec = _vector_i32_splat(lhs, width)
+        rhs_vec = _vector_i32_splat(rhs, width)
+        pred = tick_builder.icmp_signed(">", lhs_vec, rhs_vec, name="route_vec_max_cmp")
+        merged = tick_builder.select(pred, lhs_vec, rhs_vec, name="route_vec_max")
+        return _vector_i32_extract_lane0(merged)
+
+    def _vector_i32_min(lhs: ir.Value, rhs: ir.Value, width: int = 4) -> ir.Value:
+        lhs_vec = _vector_i32_splat(lhs, width)
+        rhs_vec = _vector_i32_splat(rhs, width)
+        pred = tick_builder.icmp_signed("<", lhs_vec, rhs_vec, name="route_vec_min_cmp")
+        merged = tick_builder.select(pred, lhs_vec, rhs_vec, name="route_vec_min")
+        return _vector_i32_extract_lane0(merged)
+
+    def _vector_i32_clamp(value: ir.Value, lo: ir.Value, hi: ir.Value) -> ir.Value:
+        return _vector_i32_min(_vector_i32_max(value, lo), hi)
+
     def _reduce_fold(
         operator: str, accum_value: ir.Value, uniform_type: ir.Type
     ) -> ir.Value:
@@ -1056,7 +1089,13 @@ def emit_llvm_ir(
             modifier = params[index].get("modifier") if index < len(params) else None
             value = None
             if modifier in {"in", "out"} and arg_name in stream_slots:
-                value = _load_tick_param("stream", arg_name, param.type, current)
+                raw_capacity = stream_capacities.get(arg_name, 0)
+                safe_capacity = max(int(raw_capacity), 1)
+                max_index = ir.Constant(ir.IntType(32), safe_capacity - 1)
+                clamped_index = _vector_i32_clamp(
+                    current, ir.Constant(ir.IntType(32), 0), max_index
+                )
+                value = _load_tick_param("stream", arg_name, param.type, clamped_index)
             elif modifier == "accum" and arg_name in accum_slots:
                 value = _load_tick_param("accum", arg_name, param.type)
             elif modifier == "uniform" and arg_name in uniform_slots:


### PR DESCRIPTION
### Motivation
- Ensure kernel route lowering produces IR that enforces stream index bounds inside the compiled binary rather than relying on host-side checks.
- Use branchless SIMD-style primitives so clamping does not introduce control-flow overhead in the generated LLVM IR.

### Description
- Added LLVM IR helpers: `_vector_i32_splat`, `_vector_i32_extract_lane0`, `_vector_i32_max`, `_vector_i32_min`, and `_vector_i32_clamp` to generate branchless i32 vector compare/select sequences. 
- Updated `_lower_kernel_route` to compute a safe `safe_capacity = max(int(raw_capacity), 1)`, form `max_index = safe_capacity - 1`, and replace direct `current` index loads with a clamped index via `_vector_i32_clamp(current, 0, max_index)` before calling `_load_tick_param` for `in`/`out` stream arguments.
- This change bounds each per-stream element access to `[0, capacity-1]` in IR using compare/select logic instead of branching.

### Testing
- Ran targeted optimizer tests for the bind-route behavior with `pytest -q tests/test_optimizer.py -k bind_routes`, which passed.
- Ran a broader smoke check with `pytest -q tests/test_optimizer.py tests/test_lockstep_compiler_api.py`; the bind-route subset still passes while a large set of failures appeared in semantic validator tests which are outside the modified code paths and appear to be pre-existing unrelated failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d3ce2cc08328adf094df8f19dec0)