### PR TITLE
Track declared uint field types through codegen unsigned lowering

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -337,6 +337,23 @@ class _FunctionLowerer:
             return self.builder.icmp_signed(rel_map[op], lhs, rhs)
         self._compiler_error(f"comparison '{op}' is unsupported for type '{lhs.type}'")
 
+
+    def _resolve_field_declared_type(self, base_type: str, field_path: list[str]) -> str | None:
+        current_type = base_type
+        for field_name in field_path:
+            fields = self.struct_fields.get(current_type)
+            if fields is None:
+                return None
+            field_type = None
+            for field in fields:
+                if field.get("name") == field_name:
+                    field_type = field.get("type")
+                    break
+            if field_type is None:
+                return None
+            current_type = field_type
+        return current_type
+
     def _infer_expr_type(self, node: AstExprLiteral | AstExprVar | AstExprUnary | AstExprBinary | AstExprCall | AstExprCast) -> str | None:
         if isinstance(node, AstExprLiteral):
             if node.kind in {"float", "int", "bool", "double", "uint", "string"}:
@@ -344,7 +361,12 @@ class _FunctionLowerer:
             return None
         if isinstance(node, AstExprVar):
             key = _sanitize_symbol(node.path[0])
-            return self.local_types.get(key)
+            base_type = self.local_types.get(key)
+            if base_type is None:
+                return None
+            if len(node.path) == 1:
+                return base_type
+            return self._resolve_field_declared_type(base_type, node.path[1:])
         if isinstance(node, AstExprCast):
             return _type_name(node.target_type)
         if isinstance(node, AstExprUnary):
@@ -599,7 +621,7 @@ def emit_llvm_ir(
 ) -> str:
     """Generate LLVM IR using llvmlite lowering for pure/kernels."""
 
-    entities = ast_to_entities(program)
+    entities = ast_to_entities(program_or_entities)
 
     structs = entities.get("structs", [])
     shaders = entities.get("shaders", [])

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -1402,3 +1402,27 @@ def test_codegen_uses_unsigned_ops_for_uint_math():
     assert "udiv i32" in llvm_ir
     assert "urem i32" in llvm_ir
     assert "icmp ult i32" in llvm_ir
+
+
+def test_codegen_uses_unsigned_ops_for_uint_struct_fields():
+    source = """
+    struct Pair { uint lhs; uint rhs; };
+
+    pure uint quotient(Pair p) {
+        return p.lhs / p.rhs;
+    }
+
+    pure uint remainder(Pair p) {
+        return p.lhs % p.rhs;
+    }
+
+    pure bool less_than(Pair p) {
+        return p.lhs < p.rhs;
+    }
+    """
+    result = lockstep_compiler.compile_lockstep(source)
+    llvm_ir = result.llvm_ir
+
+    assert "udiv i32" in llvm_ir
+    assert "urem i32" in llvm_ir
+    assert "icmp ult i32" in llvm_ir


### PR DESCRIPTION
### Motivation
- Ensure unsigned semantics (`udiv`, `urem`, `icmp unsigned`) are selected during codegen for numeric expressions whose declared type is `uint`, including when the `uint` comes from a struct field access like `p.lhs`.

### Description
- Add `_resolve_field_declared_type` to walk a struct field path and return the declared type for nested member accesses.
- Update `_infer_expr_type` to consult the declared base variable type and to resolve field-path types for `AstExprVar` nodes so member accesses preserve their declared type.
- Fix `emit_llvm_ir` to pass the actual input `program_or_entities` into `ast_to_entities` so IR emission normalizes its input correctly.
- Add regression test `test_codegen_uses_unsigned_ops_for_uint_struct_fields` in `tests/test_compiler_api.py` that asserts `udiv i32`, `urem i32`, and `icmp ult i32` appear in emitted IR for `uint` struct fields.

### Testing
- Ran `pytest -q tests/test_compiler_api.py -k unsigned_ops_for_uint` which initially failed due to a `NameError` in `emit_llvm_ir` and a parse-format issue that were fixed during the rollout.
- Re-ran `pytest -q tests/test_compiler_api.py -k "unsigned_ops_for_uint"` after fixes and the two relevant tests passed (final run succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f867afb08328b22abd2c7612216c)