### PR TITLE
Fix intrinsic declaration suffix for float vs double precision

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -65,7 +65,15 @@ class _FunctionLowerer:
     def _declare_llvm_intrinsic(
         self, intrinsic_name: str, arg_type: ir.Type
     ) -> ir.Function:
-        llvm_name = f"llvm.{intrinsic_name}.f32"
+        if isinstance(arg_type, ir.FloatType):
+            suffix = "f32"
+        elif isinstance(arg_type, ir.DoubleType):
+            suffix = "f64"
+        else:
+            self._compiler_error(
+                f"intrinsic '{intrinsic_name}' expects float or double arguments"
+            )
+        llvm_name = f"llvm.{intrinsic_name}.{suffix}"
         intrinsic = self.module.globals.get(llvm_name)
         if intrinsic is not None:
             return intrinsic


### PR DESCRIPTION
### Motivation
- LLVM intrinsic names are precision-specific, and always emitting `.f32` could produce LLVM validation/type-mismatch failures when double-precision values are used, so the intrinsic suffix must reflect the argument precision.

### Description
- Update `lockstep_compiler/codegen.py` in `_declare_llvm_intrinsic` to choose suffix `f32` for `ir.FloatType` and `f64` for `ir.DoubleType`, construct the intrinsic name as `llvm.{intrinsic_name}.{suffix}`, and raise a `CodegenError` for unsupported argument types.

### Testing
- Ran `pytest -q`, but test collection failed because the `hypothesis` dependency is not installed in the environment, so automated tests did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f86d12f88328a40c0c03d0bf2d83)