### PR TITLE
Add explicit arena layout cycle diagnostics (LCK503)

### DIFF
--- a/lockstep_compiler/arena_layout.py
+++ b/lockstep_compiler/arena_layout.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from .errors import LockstepCompileError
+from .models import LockstepDiagnostic
+
 _PRIMITIVE_SIZE = {
     "bool": 1,
     "int": 4,
@@ -84,10 +87,28 @@ def resolve_struct_layouts(
             progress = True
 
         if not progress:
-            for struct_name in unresolved:
-                struct_sizes[struct_name] = 1
-                opaque_structs.add(struct_name)
-            break
+            cycle_structs = sorted(unresolved)
+            diagnostic = LockstepDiagnostic(
+                severity="error",
+                code="LCK503",
+                message=(
+                    "Arena layout contains a recursive struct dependency cycle: "
+                    + " -> ".join(cycle_structs)
+                ),
+                line=1,
+                column=0,
+                source_file="<arena_layout>",
+                hint=(
+                    "Break recursive struct references in pipeline resource layouts "
+                    "so each struct can be resolved to a finite byte size."
+                ),
+            )
+            raise LockstepCompileError(
+                [diagnostic],
+                diagnostics=[diagnostic],
+                phase="codegen",
+                source_file=diagnostic.source_file,
+            )
 
     return struct_sizes, opaque_structs
 

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -10,6 +10,7 @@ import lockstep_compiler
 import lockstep_compiler.c_header as c_header_module
 import lockstep_compiler.compiler as compiler_module
 from lockstep_compiler.c_header import emit_c_header
+from lockstep_compiler.arena_layout import build_arena_layout
 from lockstep_compiler.codegen import CodegenError, emit_llvm_ir
 from lockstep_compiler.models import LockstepDiagnostic
 from lockstep_compiler.ast import (
@@ -1172,6 +1173,20 @@ def test_emit_c_header_raises_lck502_when_cumulative_offsets_overflow(monkeypatc
         )
 
     assert [diag.code for diag in exc_info.value.errors] == ["LCK502"]
+
+
+def test_build_arena_layout_raises_lck503_for_recursive_struct_layout_cycle():
+    with pytest.raises(lockstep_compiler.LockstepCompileError) as exc_info:
+        build_arena_layout(
+            {
+                "structs": [
+                    {"name": "A", "fields": [{"name": "b", "type": "B"}]},
+                    {"name": "B", "fields": [{"name": "a", "type": "A"}]},
+                ]
+            }
+        )
+
+    assert [diag.code for diag in exc_info.value.errors] == ["LCK503"]
 
 
 def test_compile_result_includes_c_header(monkeypatch):


### PR DESCRIPTION
### Motivation
- Replace the previous silent fallback that assigned unresolved structs a size of `1` with an explicit diagnostic so recursive struct dependency cycles fail fast during layout resolution.
- Make arena layout errors actionable by surfacing a distinct diagnostic code for recursive layout loops instead of producing opaque placeholders.

### Description
- Change `resolve_struct_layouts` in `lockstep_compiler/arena_layout.py` to raise `LockstepCompileError` with a `LockstepDiagnostic` code `LCK503` when struct sizes cannot be resolved due to a dependency cycle, instead of assigning size `1` to unresolved structs.
- Import `LockstepCompileError` and `LockstepDiagnostic` into `arena_layout.py` and construct a helpful error message and hint describing the recursive cycle.
- Add a regression test `test_build_arena_layout_raises_lck503_for_recursive_struct_layout_cycle` in `tests/test_compiler_api.py` that calls `build_arena_layout` with a mutually recursive `A <-> B` pair and asserts the `LCK503` error is emitted.

### Testing
- Ran `pytest -q tests/test_compiler_api.py -k 'lck503 or build_arena_layout_raises_lck503'`, and the targeted `LCK503` test passed.
- A broader run `pytest -q tests/test_compiler_api.py -k 'lck502 or lck503'` failed due to an unrelated test harness expectation where `emit_c_header` was invoked with a raw dict (not an AST-style program); this failure is orthogonal to the new cycle-detection behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f87250108328a670e85b25492a18)