### PR TITLE
Enforce dependency include root allowlisting in compiler and CLI

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -144,6 +144,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=8,
         help="Override SIMD vector width used by LLVM IR lowering and generated C header macros.",
     )
+    parser.add_argument(
+        "--unsafe-allow-external-dependencies",
+        action="store_true",
+        help=(
+            "Disable strict dependency root checks. By default, dependency includes "
+            "must resolve under the source file directory."
+        ),
+    )
     return parser
 
 
@@ -238,6 +246,7 @@ def run_cli(
     supports_library_source_files = False
     supports_frontend_limits = False
     supports_target_width = False
+    supports_dependency_root = False
     try:
         signature = inspect.signature(compiler)
     except (TypeError, ValueError):
@@ -274,6 +283,11 @@ def run_cli(
             or parameter.name == "target_width"
             for parameter in signature.parameters.values()
         )
+        supports_dependency_root = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            or parameter.name == "dependency_root"
+            for parameter in signature.parameters.values()
+        )
 
     compile_kwargs: dict[str, Any] = {}
     if supports_verbose:
@@ -294,6 +308,11 @@ def run_cli(
         )
     if supports_target_width:
         compile_kwargs["target_width"] = args.target_width
+    if supports_dependency_root:
+        dependency_root: Path | None = None
+        if args.path and not args.unsafe_allow_external_dependencies:
+            dependency_root = source_path.resolve().parent
+        compile_kwargs["dependency_root"] = dependency_root
 
     try:
         if compile_kwargs:

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -26,6 +26,7 @@ DEFAULT_MAX_SOURCE_BYTES = 1_048_576
 DEFAULT_PARSE_TIMEOUT_MS = 2_000
 DEFAULT_MAX_EXPRESSION_NESTING = 128
 DEFAULT_INVALID_FRONTEND_LIMIT_CODE = "LCK006"
+DEFAULT_DEPENDENCY_ROOT_VIOLATION_CODE = "LCK007"
 _DEPENDENCY_DECL_PATTERN = re.compile(
     r'^\s*(?:import|#include)\s+"((?:[^"\\]|\\.)+)"\s*;\s*$',
     re.MULTILINE,
@@ -352,28 +353,61 @@ def _resolve_dependency_sources(
     source_code: str,
     *,
     source_file: str,
+    dependency_root: Path | None = None,
 ) -> tuple[list[str], list[str]]:
     if source_file.startswith("<") and source_file.endswith(">"):
-        base_directory = Path.cwd()
+        base_directory = Path.cwd().resolve()
     else:
         base_directory = Path(source_file).resolve().parent
+    canonical_dependency_root = (
+        dependency_root.resolve() if dependency_root is not None else None
+    )
 
     visited: set[Path] = set()
     in_stack: list[Path] = []
     ordered_sources: list[str] = []
     ordered_source_files: list[str] = []
 
-    def _resolve_reference(reference: str, parent_file: str) -> Path:
+    def _resolve_reference(reference: str, parent_file: str, line: int) -> Path:
         candidate = Path(reference)
         if candidate.is_absolute():
-            return candidate.resolve()
-        if parent_file.startswith("<") and parent_file.endswith(">"):
-            return (base_directory / candidate).resolve()
-        return (Path(parent_file).resolve().parent / candidate).resolve()
+            resolved_candidate = candidate.resolve()
+        elif parent_file.startswith("<") and parent_file.endswith(">"):
+            resolved_candidate = (base_directory / candidate).resolve()
+        else:
+            resolved_candidate = (Path(parent_file).resolve().parent / candidate).resolve()
+
+        if canonical_dependency_root is not None:
+            try:
+                resolved_candidate.relative_to(canonical_dependency_root)
+            except ValueError:
+                diagnostic = LockstepDiagnostic(
+                    severity="error",
+                    code=DEFAULT_DEPENDENCY_ROOT_VIOLATION_CODE,
+                    message=(
+                        f"Dependency '{reference}' resolves outside allowlisted root "
+                        f"'{canonical_dependency_root}'."
+                    ),
+                    line=line,
+                    column=0,
+                    source_file=parent_file,
+                    hint=(
+                        "Keep dependency references under the configured dependency root, "
+                        "or disable strict dependency root checks only for trusted internal usage."
+                    ),
+                )
+                raise LockstepCompileError(
+                    [diagnostic],
+                    diagnostics=[diagnostic],
+                    phase="parse",
+                    source_file=parent_file,
+                )
+
+        return resolved_candidate
 
     def _walk(current_source: str, current_file: str) -> None:
         for reference, line in _extract_dependency_references(current_source):
-            dependency_path = _resolve_reference(reference, current_file)
+            dependency_path = _resolve_reference(reference, current_file, line)
             if dependency_path in in_stack:
                 cycle_chain = [*in_stack, dependency_path]
                 cycle_text = " -> ".join(str(path) for path in cycle_chain)
@@ -624,6 +658,7 @@ def compile_lockstep(
     source_file: str = DEFAULT_SOURCE_FILE,
     library_sources: list[str] | None = None,
     library_source_files: list[str] | None = None,
+    dependency_root: Path | None = None,
     lexer_cls: Any = None,
     parser_cls: Any = None,
     visitor_cls: Any = None,
@@ -639,6 +674,7 @@ def compile_lockstep(
     dependency_sources, dependency_source_files = _resolve_dependency_sources(
         source_code,
         source_file=source_file,
+        dependency_root=dependency_root,
     )
     resolved_library_sources.extend(dependency_sources)
     resolved_library_source_files.extend(dependency_source_files)

--- a/tests/test_cli_libraries.py
+++ b/tests/test_cli_libraries.py
@@ -124,3 +124,35 @@ def test_run_cli_passes_frontend_limits_to_compiler():
     assert captured["frontend_limits"].max_source_bytes == 64
     assert captured["frontend_limits"].parse_timeout_ms == 50
     assert captured["frontend_limits"].max_expression_nesting == 16
+
+
+def test_run_cli_defaults_dependency_root_to_source_directory(tmp_path):
+    source_path = tmp_path / "main.lock"
+    source_path.write_text("pipeline Main { bind { } }", encoding="utf-8")
+    captured = {}
+
+    def fake_compiler(source, *, dependency_root=None):
+        captured["dependency_root"] = dependency_root
+        return {"streams": [], "accumulators": [], "uniforms": [], "shaders": [], "filters": [], "bind_routes": []}
+
+    exit_code = run_cli([str(source_path), "--simulate"], stdout=io.StringIO(), compiler=fake_compiler)
+    assert exit_code == 0
+    assert captured["dependency_root"] == source_path.resolve().parent
+
+
+def test_run_cli_can_disable_dependency_root_with_unsafe_flag(tmp_path):
+    source_path = tmp_path / "main.lock"
+    source_path.write_text("pipeline Main { bind { } }", encoding="utf-8")
+    captured = {}
+
+    def fake_compiler(source, *, dependency_root=None):
+        captured["dependency_root"] = dependency_root
+        return {"streams": [], "accumulators": [], "uniforms": [], "shaders": [], "filters": [], "bind_routes": []}
+
+    exit_code = run_cli(
+        [str(source_path), "--simulate", "--unsafe-allow-external-dependencies"],
+        stdout=io.StringIO(),
+        compiler=fake_compiler,
+    )
+    assert exit_code == 0
+    assert captured["dependency_root"] is None

--- a/tests/test_type_syntax.py
+++ b/tests/test_type_syntax.py
@@ -164,6 +164,71 @@ pipeline Main {{
     assert any(struct["name"] == "Particle" for struct in result.entities["structs"])
 
 
+def test_dependency_root_allows_relative_include_within_root(tmp_path, monkeypatch):
+    monkeypatch.setattr("lockstep_compiler.compiler.emit_llvm_ir", lambda *_args, **_kwargs: "")
+    monkeypatch.setattr("lockstep_compiler.compiler.emit_c_header", lambda *_args, **_kwargs: "")
+    root = tmp_path / "project"
+    deps = root / "deps"
+    deps.mkdir(parents=True)
+    (deps / "types.lock").write_text("struct Allowed { float x; };\n", encoding="utf-8")
+    main_file = root / "main.lock"
+    main_file.write_text(
+        'import "deps/types.lock";\n\npipeline Main { uniform Allowed item; bind { } }\n',
+        encoding="utf-8",
+    )
+
+    result = compile_lockstep(
+        main_file.read_text(encoding="utf-8"),
+        verbose=False,
+        source_file=str(main_file),
+        dependency_root=root,
+    )
+
+    assert all(diag.severity != "error" for diag in result.diagnostics)
+
+
+def test_dependency_root_rejects_parent_traversal(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    outside = tmp_path / "outside.lock"
+    outside.write_text("struct Hidden { float x; };\n", encoding="utf-8")
+    main_file = root / "main.lock"
+    main_file.write_text('import "../outside.lock";\n', encoding="utf-8")
+
+    with pytest.raises(LockstepCompileError) as exc_info:
+        compile_lockstep(
+            main_file.read_text(encoding="utf-8"),
+            verbose=False,
+            source_file=str(main_file),
+            dependency_root=root,
+        )
+
+    assert [diag.code for diag in exc_info.value.errors] == ["LCK007"]
+    assert exc_info.value.errors[0].source_file == str(main_file)
+    assert exc_info.value.errors[0].line == 1
+
+
+def test_dependency_root_rejects_absolute_include_outside_root(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    outside = tmp_path / "outside.lock"
+    outside.write_text("struct Hidden { float x; };\n", encoding="utf-8")
+    main_file = root / "main.lock"
+    main_file.write_text(f'import "{outside}";\n', encoding="utf-8")
+
+    with pytest.raises(LockstepCompileError) as exc_info:
+        compile_lockstep(
+            main_file.read_text(encoding="utf-8"),
+            verbose=False,
+            source_file=str(main_file),
+            dependency_root=root,
+        )
+
+    assert [diag.code for diag in exc_info.value.errors] == ["LCK007"]
+    assert exc_info.value.errors[0].source_file == str(main_file)
+    assert exc_info.value.errors[0].line == 1
+
+
 def test_circular_imports_raise_compile_error(tmp_path):
     file_a = tmp_path / "a.lock"
     file_b = tmp_path / "b.lock"


### PR DESCRIPTION
### Motivation
- Prevent dependencies from including files outside an allowlisted root to reduce accidental or malicious filesystem traversal during compilation.
- Provide a strict default for CLI builds (source file directory) while allowing an explicit opt-out for trusted internal usage.

### Description
- Add a new compile option `dependency_root: Path | None` and thread it through `compile_lockstep` into dependency resolution (`_resolve_dependency_sources`).
- Canonicalize both the base directory and candidate dependency paths using `.resolve()` and validate containment via `Path.relative_to(...)`.
- Reject any dependency that resolves outside the canonical allowlisted root with a deterministic parse diagnostic `LCK007` that includes the referencing source file and line and a usage hint.
- Make CLI builds strict by default when a path is supplied (sets `dependency_root` to the source file directory) and add `--unsafe-allow-external-dependencies` to opt out; add tests exercising CLI behavior.

### Testing
- Ran targeted dependency-root unit tests in `tests/test_type_syntax.py` covering allowed relative includes, `..` traversal rejection, absolute includes outside root, and cycle detection, all of which passed.
- Ran CLI tests in `tests/test_cli_libraries.py` that verify default `dependency_root` behavior and the `--unsafe-allow-external-dependencies` opt-out, which passed.
- A broader run of `pytest -q tests/test_type_syntax.py tests/test_cli_libraries.py` surfaced an unrelated pre-existing `NameError` in `lockstep_compiler/codegen.py` that caused failures not introduced by these changes; dependency-root related tests were executed separately and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f8d9a71883288e7a1dca691dfacd)