### PR TITLE
Add dependency-resolution frontend limits and expose via CLI

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -139,6 +139,24 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Maximum allowed expression nesting depth (0 disables limit).",
     )
     parser.add_argument(
+        "--max-dependency-files",
+        type=_non_negative_limit_value("--max-dependency-files"),
+        default=None,
+        help="Maximum number of resolved dependency files (0 disables limit).",
+    )
+    parser.add_argument(
+        "--max-dependency-total-bytes",
+        type=_non_negative_limit_value("--max-dependency-total-bytes"),
+        default=None,
+        help="Maximum total UTF-8 bytes across all resolved dependencies (0 disables limit).",
+    )
+    parser.add_argument(
+        "--max-dependency-depth",
+        type=_non_negative_limit_value("--max-dependency-depth"),
+        default=None,
+        help="Maximum import/include nesting depth while resolving dependencies (0 disables limit).",
+    )
+    parser.add_argument(
         "--target-width",
         type=_positive_int_value("--target-width"),
         default=8,
@@ -291,6 +309,9 @@ def run_cli(
             max_source_bytes=args.max_source_bytes,
             parse_timeout_ms=args.parse_timeout_ms,
             max_expression_nesting=args.max_expr_nesting,
+            max_dependency_files=args.max_dependency_files,
+            max_dependency_total_bytes=args.max_dependency_total_bytes,
+            max_dependency_depth=args.max_dependency_depth,
         )
     if supports_target_width:
         compile_kwargs["target_width"] = args.target_width

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -37,6 +37,9 @@ class FrontendLimits:
     max_source_bytes: int | None = DEFAULT_MAX_SOURCE_BYTES
     parse_timeout_ms: int | None = DEFAULT_PARSE_TIMEOUT_MS
     max_expression_nesting: int | None = DEFAULT_MAX_EXPRESSION_NESTING
+    max_dependency_files: int | None = DEFAULT_MAX_SOURCE_BYTES
+    max_dependency_total_bytes: int | None = DEFAULT_MAX_SOURCE_BYTES
+    max_dependency_depth: int | None = DEFAULT_MAX_EXPRESSION_NESTING
 
 
 class FrontendLimitExceeded(RuntimeError):
@@ -143,6 +146,21 @@ def _normalize_frontend_limits(
         max_expression_nesting=_normalize_frontend_limit_value(
             resolved.max_expression_nesting,
             name="max_expression_nesting",
+            source_file=source_file,
+        ),
+        max_dependency_files=_normalize_frontend_limit_value(
+            resolved.max_dependency_files,
+            name="max_dependency_files",
+            source_file=source_file,
+        ),
+        max_dependency_total_bytes=_normalize_frontend_limit_value(
+            resolved.max_dependency_total_bytes,
+            name="max_dependency_total_bytes",
+            source_file=source_file,
+        ),
+        max_dependency_depth=_normalize_frontend_limit_value(
+            resolved.max_dependency_depth,
+            name="max_dependency_depth",
             source_file=source_file,
         ),
     )
@@ -352,7 +370,9 @@ def _resolve_dependency_sources(
     source_code: str,
     *,
     source_file: str,
+    limits: FrontendLimits | None = None,
 ) -> tuple[list[str], list[str]]:
+    resolved_limits = limits or FrontendLimits()
     if source_file.startswith("<") and source_file.endswith(">"):
         base_directory = Path.cwd()
     else:
@@ -362,6 +382,31 @@ def _resolve_dependency_sources(
     in_stack: list[Path] = []
     ordered_sources: list[str] = []
     ordered_source_files: list[str] = []
+    dependency_file_count = 0
+    dependency_total_bytes = 0
+
+    def _dependency_limit_error(
+        *,
+        line: int,
+        current_file: str,
+        message: str,
+        hint: str,
+    ) -> None:
+        diagnostic = LockstepDiagnostic(
+            severity="error",
+            code="LCK007",
+            message=message,
+            line=line,
+            column=0,
+            source_file=current_file,
+            hint=hint,
+        )
+        raise LockstepCompileError(
+            [diagnostic],
+            diagnostics=[diagnostic],
+            phase="parse",
+            source_file=current_file,
+        )
 
     def _resolve_reference(reference: str, parent_file: str) -> Path:
         candidate = Path(reference)
@@ -371,8 +416,26 @@ def _resolve_dependency_sources(
             return (base_directory / candidate).resolve()
         return (Path(parent_file).resolve().parent / candidate).resolve()
 
-    def _walk(current_source: str, current_file: str) -> None:
+    def _walk(current_source: str, current_file: str, depth: int) -> None:
+        nonlocal dependency_file_count, dependency_total_bytes
         for reference, line in _extract_dependency_references(current_source):
+            next_depth = depth + 1
+            if (
+                resolved_limits.max_dependency_depth is not None
+                and next_depth > resolved_limits.max_dependency_depth
+            ):
+                _dependency_limit_error(
+                    line=line,
+                    current_file=current_file,
+                    message=(
+                        "Dependency include depth exceeds the configured limit "
+                        f"({next_depth} > {resolved_limits.max_dependency_depth})."
+                    ),
+                    hint=(
+                        "Reduce nested imports, raise --max-dependency-depth "
+                        "(or max_dependency_depth via API), or set it to 0 to disable."
+                    ),
+                )
             dependency_path = _resolve_reference(reference, current_file)
             if dependency_path in in_stack:
                 cycle_chain = [*in_stack, dependency_path]
@@ -411,14 +474,53 @@ def _resolve_dependency_sources(
                 )
 
             in_stack.append(dependency_path)
-            _walk(dependency_source, str(dependency_path))
+            _walk(dependency_source, str(dependency_path), next_depth)
             in_stack.pop()
 
+            dependency_bytes = len(dependency_source.encode("utf-8"))
+            dependency_file_count += 1
+            dependency_total_bytes += dependency_bytes
+            if (
+                resolved_limits.max_dependency_files is not None
+                and dependency_file_count > resolved_limits.max_dependency_files
+            ):
+                _dependency_limit_error(
+                    line=line,
+                    current_file=current_file,
+                    message=(
+                        "Dependency file count exceeds the configured limit "
+                        f"({dependency_file_count} > "
+                        f"{resolved_limits.max_dependency_files})."
+                    ),
+                    hint=(
+                        "Reduce imported files, raise --max-dependency-files "
+                        "(or max_dependency_files via API), or set it to 0 to disable."
+                    ),
+                )
+            if (
+                resolved_limits.max_dependency_total_bytes is not None
+                and dependency_total_bytes > resolved_limits.max_dependency_total_bytes
+            ):
+                _dependency_limit_error(
+                    line=line,
+                    current_file=current_file,
+                    message=(
+                        "Total dependency source size exceeds the configured limit "
+                        f"({dependency_total_bytes} bytes > "
+                        f"{resolved_limits.max_dependency_total_bytes} bytes)."
+                    ),
+                    hint=(
+                        "Reduce imported source size, raise "
+                        "--max-dependency-total-bytes "
+                        "(or max_dependency_total_bytes via API), or set it to 0 "
+                        "to disable."
+                    ),
+                )
             visited.add(dependency_path)
             ordered_sources.append(dependency_source)
             ordered_source_files.append(str(dependency_path))
 
-    _walk(source_code, source_file)
+    _walk(source_code, source_file, 0)
     return ordered_sources, ordered_source_files
 
 
@@ -635,10 +737,12 @@ def compile_lockstep(
 ) -> LockstepCompileResult:
     resolved_library_sources: list[str] = list(library_sources or [])
     resolved_library_source_files: list[str] = list(library_source_files or [])
+    resolved_limits = _normalize_frontend_limits(frontend_limits, source_file=source_file)
 
     dependency_sources, dependency_source_files = _resolve_dependency_sources(
         source_code,
         source_file=source_file,
+        limits=resolved_limits,
     )
     resolved_library_sources.extend(dependency_sources)
     resolved_library_source_files.extend(dependency_source_files)
@@ -669,7 +773,7 @@ def compile_lockstep(
         semantic_validator=semantic_validator,
         token_stream_cls=token_stream_cls,
         debug_visitor_cls=debug_visitor_cls,
-        frontend_limits=frontend_limits,
+        frontend_limits=resolved_limits,
         target_width=target_width,
     )
 

--- a/tests/test_cli_libraries.py
+++ b/tests/test_cli_libraries.py
@@ -113,6 +113,12 @@ def test_run_cli_passes_frontend_limits_to_compiler():
             "50",
             "--max-expr-nesting",
             "16",
+            "--max-dependency-files",
+            "4",
+            "--max-dependency-total-bytes",
+            "512",
+            "--max-dependency-depth",
+            "2",
         ],
         stdin=io.StringIO("pipeline Main { bind { } }"),
         stdout=io.StringIO(),
@@ -124,3 +130,6 @@ def test_run_cli_passes_frontend_limits_to_compiler():
     assert captured["frontend_limits"].max_source_bytes == 64
     assert captured["frontend_limits"].parse_timeout_ms == 50
     assert captured["frontend_limits"].max_expression_nesting == 16
+    assert captured["frontend_limits"].max_dependency_files == 4
+    assert captured["frontend_limits"].max_dependency_total_bytes == 512
+    assert captured["frontend_limits"].max_dependency_depth == 2

--- a/tests/test_improvements.py
+++ b/tests/test_improvements.py
@@ -354,6 +354,9 @@ pipeline P {
         ("max_source_bytes", -1),
         ("parse_timeout_ms", -1),
         ("max_expression_nesting", -1),
+        ("max_dependency_files", -1),
+        ("max_dependency_total_bytes", -1),
+        ("max_dependency_depth", -1),
     ],
 )
 def test_compile_lockstep_rejects_negative_frontend_limits(limit_name, value):
@@ -416,6 +419,25 @@ def test_compile_lockstep_zero_disables_parse_timeout(monkeypatch):
     compile_lockstep(
         _LIMIT_SOURCE,
         frontend_limits=FrontendLimits(parse_timeout_ms=0),
+    )
+
+
+def test_compile_lockstep_zero_disables_dependency_limits(tmp_path, monkeypatch):
+    dep = tmp_path / "dep.lock"
+    main = tmp_path / "main.lock"
+    dep.write_text("pipeline Dep { bind { } }\n", encoding="utf-8")
+    main.write_text(f'import "{dep.name}";\npipeline Main {{ bind {{ }} }}\n', encoding="utf-8")
+    monkeypatch.setattr(compiler_module, "emit_llvm_ir", lambda *_args, **_kwargs: "")
+    monkeypatch.setattr(compiler_module, "emit_c_header", lambda *_args, **_kwargs: "")
+
+    compile_lockstep(
+        main.read_text(encoding="utf-8"),
+        source_file=str(main),
+        frontend_limits=FrontendLimits(
+            max_dependency_files=0,
+            max_dependency_total_bytes=0,
+            max_dependency_depth=0,
+        ),
     )
 
 
@@ -483,7 +505,14 @@ def test_compile_lockstep_positive_parse_timeout_is_enforced(monkeypatch):
 
 @pytest.mark.parametrize(
     "flag",
-    ["--max-source-bytes", "--parse-timeout-ms", "--max-expr-nesting"],
+    [
+        "--max-source-bytes",
+        "--parse-timeout-ms",
+        "--max-expr-nesting",
+        "--max-dependency-files",
+        "--max-dependency-total-bytes",
+        "--max-dependency-depth",
+    ],
 )
 def test_cli_rejects_negative_limit_values(flag, capsys):
     with pytest.raises(SystemExit) as exc_info:

--- a/tests/test_type_syntax.py
+++ b/tests/test_type_syntax.py
@@ -8,7 +8,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from lockstep_compiler import compile_lockstep
+from lockstep_compiler import FrontendLimits, compile_lockstep
 from lockstep_compiler.errors import LockstepCompileError
 
 
@@ -195,3 +195,67 @@ def test_malformed_utf8_dependency_raises_parse_style_error(tmp_path):
     assert [diag.code for diag in exc_info.value.errors] == ["LCK002"]
     assert "Unable to parse dependency" in exc_info.value.errors[0].message
     assert "invalid UTF-8" in exc_info.value.errors[0].message
+
+
+def test_dependency_file_count_limit_is_enforced(tmp_path):
+    dep_a = tmp_path / "a.lock"
+    dep_b = tmp_path / "b.lock"
+    main = tmp_path / "main.lock"
+    dep_a.write_text("pipeline A { bind { } }\n", encoding="utf-8")
+    dep_b.write_text("pipeline B { bind { } }\n", encoding="utf-8")
+    main.write_text(f'import "{dep_a.name}";\nimport "{dep_b.name}";\n', encoding="utf-8")
+
+    with pytest.raises(LockstepCompileError) as exc_info:
+        compile_lockstep(
+            main.read_text(encoding="utf-8"),
+            verbose=False,
+            source_file=str(main),
+            frontend_limits=FrontendLimits(max_dependency_files=1),
+        )
+
+    diagnostic = exc_info.value.errors[0]
+    assert diagnostic.code == "LCK007"
+    assert "(2 > 1)" in diagnostic.message
+    assert diagnostic.line == 2
+
+
+def test_dependency_total_bytes_limit_is_enforced(tmp_path):
+    dep = tmp_path / "dep.lock"
+    main = tmp_path / "main.lock"
+    dep.write_text("pipeline Dependency { bind { } }\n", encoding="utf-8")
+    main.write_text(f'import "{dep.name}";\n', encoding="utf-8")
+
+    with pytest.raises(LockstepCompileError) as exc_info:
+        compile_lockstep(
+            main.read_text(encoding="utf-8"),
+            verbose=False,
+            source_file=str(main),
+            frontend_limits=FrontendLimits(max_dependency_total_bytes=8),
+        )
+
+    diagnostic = exc_info.value.errors[0]
+    assert diagnostic.code == "LCK007"
+    assert "bytes > 8 bytes" in diagnostic.message
+    assert diagnostic.line == 1
+
+
+def test_dependency_depth_limit_is_enforced(tmp_path):
+    dep2 = tmp_path / "dep2.lock"
+    dep1 = tmp_path / "dep1.lock"
+    main = tmp_path / "main.lock"
+    dep2.write_text("pipeline Deep { bind { } }\n", encoding="utf-8")
+    dep1.write_text(f'import "{dep2.name}";\n', encoding="utf-8")
+    main.write_text(f'import "{dep1.name}";\n', encoding="utf-8")
+
+    with pytest.raises(LockstepCompileError) as exc_info:
+        compile_lockstep(
+            main.read_text(encoding="utf-8"),
+            verbose=False,
+            source_file=str(main),
+            frontend_limits=FrontendLimits(max_dependency_depth=1),
+        )
+
+    diagnostic = exc_info.value.errors[0]
+    assert diagnostic.code == "LCK007"
+    assert "(2 > 1)" in diagnostic.message
+    assert diagnostic.line == 1


### PR DESCRIPTION
### Motivation

- Limit dependency traversal resource usage (file count, total bytes, nesting depth) during parsing to protect the frontend from large or malicious dependency graphs.
- Surface these controls to callers and CLI users so the same `0 => disable` and negative-value rejection conventions apply to dependency limits.

### Description

- Extended `FrontendLimits` with `max_dependency_files`, `max_dependency_total_bytes`, and `max_dependency_depth` and normalized them via `_normalize_frontend_limits` so `0` disables and negative values raise `LCK006`.
- Enforced limits inside `_resolve_dependency_sources` while traversing includes, tracking file count, aggregated UTF-8 bytes, and current depth, and emitting parse-phase diagnostics (`LCK007`) with file/line and current-vs-limit counters when a limit is exceeded.
- Threaded normalized limits into `compile_lockstep` and into the dependency resolution call so the same resolved limits are used downstream.
- Added CLI flags `--max-dependency-files`, `--max-dependency-total-bytes`, and `--max-dependency-depth` in `build_arg_parser()` and passed them into `FrontendLimits` in `run_cli` to mirror existing limit flags.
- Added unit tests and small test adjustments to cover negative-value rejection, `0 => disable` behavior, CLI passthrough, and each dependency-limit breach (file count, total bytes, depth).

### Testing

- Ran targeted tests that exercise the new behavior and CLI passthrough: `tests/test_type_syntax.py` (dependency-limit tests), `tests/test_cli_libraries.py` (frontend limits passthrough), and `tests/test_improvements.py` (frontend limits validation). These targeted groups passed in this environment.
- A broader combined test run initially surfaced unrelated pre-existing failures in `lockstep_compiler/codegen.py` (`NameError` in `emit_llvm_ir`), so full-suite validation was not possible here; the dependency-limit changes themselves are covered by the added/updated unit tests which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f8dad4f08328b137460c36be4a1a)