### PR TITLE
Refactor simulator numeric reductions to deterministic Python default

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ lockstepc path/to/program.lock --simulate --simulate-input path/to/input.json
 
 Simulation output includes per-route `input_count`/`output_count`, updated stream snapshots, accumulator contents, and folded uniform values.
 
+By default, fold reductions (`sum` / `avg`) run in deterministic pure-Python mode, including mixed numeric accumulators (`int`, `float`, `bool`) with stable coercion behavior. Optional LLVM-backed reduction remains available as an opt-in for experimentation/perf checks by setting `LOCKSTEP_SIM_USE_LLVM=1` (or passing `use_llvm_runtime=True` in API calls). If opt-in LLVM execution fails (for example missing `clang`/`lli`), simulation reports an explicit runtime error instead of silently falling back.
+
 Generated C headers include `Lockstep_SaturatedWriteIndex(...)` plus per-stream `LOCKSTEP_CAPACITY_STREAM_<NAME>` macros. Define `LOCKSTEP_DEBUG_SATURATED_WRITES` before including the header to log whenever a saturated write falls back to the final index. Override `LOCKSTEP_SATURATED_WRITE_LOG(...)` to integrate with custom telemetry.
 
 ### Diagnostic Shape

--- a/lockstep_compiler/simulator.py
+++ b/lockstep_compiler/simulator.py
@@ -1,4 +1,5 @@
 import json
+import os
 from dataclasses import dataclass
 from functools import lru_cache
 import shutil
@@ -20,14 +21,14 @@ class RouteSimulation:
     notes: str | None = None
 
 
-def _fold_values(operator: str, values: list[Any]) -> Any:
+def _fold_values(operator: str, values: list[Any], *, use_llvm_runtime: bool = False) -> Any:
     numeric = [value for value in values if isinstance(value, (int, float))]
     if not numeric:
         return None
     if operator == "sum":
-        return _jit_numeric_reduce("sum", numeric)
+        return _jit_numeric_reduce("sum", numeric, use_llvm_runtime=use_llvm_runtime)
     if operator == "avg":
-        return _jit_numeric_reduce("avg", numeric)
+        return _jit_numeric_reduce("avg", numeric, use_llvm_runtime=use_llvm_runtime)
     if operator == "min":
         return min(numeric)
     if operator == "max":
@@ -155,15 +156,44 @@ def _run_reduce_subprocess(values: list[float]) -> float:
     return float(completed.stdout.strip())
 
 
-def _jit_numeric_reduce(operator: str, values: list[Any]) -> Any:
+class SimulatorRuntimeError(RuntimeError):
+    """Raised when optional LLVM-backed simulation fails."""
+
+
+def _python_numeric_reduce(operator: str, values: list[Any]) -> Any:
+    numeric_values = [float(value) for value in values]
+    if not numeric_values:
+        return None
+
+    reduced = float(sum(numeric_values))
+    if operator == "avg":
+        reduced /= len(numeric_values)
+
+    if all(isinstance(value, int) and not isinstance(value, bool) for value in values):
+        return int(reduced)
+    return reduced
+
+
+def _jit_numeric_reduce(
+    operator: str,
+    values: list[Any],
+    *,
+    use_llvm_runtime: bool = False,
+) -> Any:
+    reduced_python = _python_numeric_reduce(operator, values)
+    if not use_llvm_runtime:
+        return reduced_python
+
     numeric_values = [float(value) for value in values]
     if not numeric_values:
         return None
 
     try:
         reduced = _run_reduce_subprocess(numeric_values)
-    except Exception:
-        reduced = float(sum(numeric_values))
+    except Exception as exc:
+        raise SimulatorRuntimeError(
+            "LLVM simulation runtime failed; disable llvm runtime or install clang/lli"
+        ) from exc
 
     if operator == "avg":
         reduced /= len(numeric_values)
@@ -195,7 +225,11 @@ def simulate_pipeline_entities(
     *,
     stream_inputs: dict[str, list[Any]] | None = None,
     accumulator_inputs: dict[str, list[Any]] | None = None,
+    use_llvm_runtime: bool | None = None,
 ) -> dict[str, Any]:
+    if use_llvm_runtime is None:
+        use_llvm_runtime = os.getenv("LOCKSTEP_SIM_USE_LLVM", "").lower() in {"1", "true", "yes", "on"}
+
     streams = {
         stream["name"]: {
             "type": stream["type"],
@@ -236,7 +270,9 @@ def simulate_pipeline_entities(
             uniform_name = route_ir.get("uniform_name")
             if isinstance(uniform_name, str) and uniform_name:
                 uniforms[uniform_name] = _fold_values(
-                    str(route_ir.get("operator", "")), source_values
+                    str(route_ir.get("operator", "")),
+                    source_values,
+                    use_llvm_runtime=use_llvm_runtime,
                 )
             routes.append(
                 RouteSimulation(

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -305,7 +305,7 @@ def test_run_cli_simulate_reports_invalid_simulation_shape(tmp_path):
 def test_fold_values_uses_jit_reduce_for_sum_and_avg(monkeypatch):
     calls = []
 
-    def fake_reduce(operator, values):
+    def fake_reduce(operator, values, **_kwargs):
         calls.append((operator, list(values)))
         return 42.5 if operator == "sum" else 10.625
 
@@ -357,11 +357,39 @@ def test_fold_values_uses_jit_reduce_for_sum_and_avg(monkeypatch):
     ]
 
 
-def test_jit_numeric_reduce_falls_back_to_python_sum_on_error(monkeypatch):
+def test_jit_numeric_reduce_has_deterministic_python_behavior_for_mixed_numeric_values():
+    from lockstep_compiler.simulator import _jit_numeric_reduce
+
+    values = [1, 2.5, True, False, 4]
+    assert _jit_numeric_reduce("sum", values) == 8.5
+    assert _jit_numeric_reduce("avg", values) == 1.7
+
+
+def test_jit_numeric_reduce_preserves_int_result_for_non_bool_int_inputs():
+    from lockstep_compiler.simulator import _jit_numeric_reduce
+
+    assert _jit_numeric_reduce("sum", [1, 2, 3]) == 6
+    assert isinstance(_jit_numeric_reduce("sum", [1, 2, 3]), int)
+
+
+def test_jit_numeric_reduce_raises_mode_specific_error_when_llvm_runtime_fails(monkeypatch):
+    from lockstep_compiler.simulator import SimulatorRuntimeError, _jit_numeric_reduce
+
     monkeypatch.setattr(
         "lockstep_compiler.simulator._run_reduce_subprocess",
         lambda _values: (_ for _ in ()).throw(RuntimeError("boom")),
     )
+
+    try:
+        _jit_numeric_reduce("sum", [1.25, 2.75], use_llvm_runtime=True)
+    except SimulatorRuntimeError as err:
+        assert "LLVM simulation runtime failed" in str(err)
+    else:
+        raise AssertionError("Expected SimulatorRuntimeError when LLVM runtime fails")
+
+
+def test_simulate_pipeline_entities_defaults_to_python_mode_without_runtime_binaries(monkeypatch):
+    monkeypatch.setattr("lockstep_compiler.simulator._simulator_runtime_command", lambda: None)
 
     assert (
         simulate_pipeline_entities(
@@ -383,7 +411,7 @@ def test_jit_numeric_reduce_falls_back_to_python_sum_on_error(monkeypatch):
                     }
                 ],
             },
-            accumulator_inputs={"energy": [1.25, 2.75]},
+            accumulator_inputs={"energy": [1.25, 2.75, True]},
         )["uniforms"]["total"]
-        == 4.0
+        == 5.0
     )


### PR DESCRIPTION
### Motivation
- Avoid shelling out to `clang`/`lli` for common numeric reductions and provide a predictable, deterministic default reducer for `sum`/`avg` that handles mixed `int`/`float`/`bool` inputs explicitly. 
- Make LLVM-backed simulation an explicit opt-in to prevent silent fallbacks and surface mode-specific diagnostics when it fails. 
- Ensure the simulator behaves stably even when external runtime binaries are not installed and add tests documenting the guarantees.

### Description
- Added a pure-Python reducer `_python_numeric_reduce` that coerces numerics to `float`, computes `sum`/`avg`, and preserves `int` return type when all inputs are non-`bool` ints. 
- Reworked `_jit_numeric_reduce` to accept `use_llvm_runtime: bool` and return the Python result by default, while only invoking `_run_reduce_subprocess` when `use_llvm_runtime=True`. 
- Introduced `SimulatorRuntimeError` and removed the previous silent exception-swallowing fallback so opt-in LLVM runtime failures raise an explicit error with guidance. 
- Plumbed the opt-in through the API via `simulate_pipeline_entities(..., use_llvm_runtime=...)` and via the environment variable `LOCKSTEP_SIM_USE_LLVM`, and updated `_fold_values` to pass the flag through. 
- Updated `README.md` to document deterministic default behavior and the optional accelerated LLVM mode. 
- Added and adjusted tests in `tests/test_simulator.py` covering deterministic mixed numeric behavior, int-preserving semantics, explicit error reporting for failing LLVM runtime, and stable default behavior when runtime binaries are absent.

### Testing
- Ran `pytest -q tests/test_simulator.py` which passed successfully. 
- New/updated tests exercise: deterministic mixed `int`/`float`/`bool` reductions, `int`-preserving outputs for all-int (non-bool) inputs, raised `SimulatorRuntimeError` when opt-in LLVM runtime fails, and default Python-mode behavior when runtime binaries are missing. 
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f8dd09548328ab9061cd026a2172)