### PR TITLE
Fix _leaf_ptr parameter lookup index guard

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -898,7 +898,7 @@ def emit_llvm_ir(
             return None
         base_offset, element_size = leaf_spec
         byte_offset: ir.Value = ir.Constant(ir.IntType(32), base_offset)
-        if kind in {"stream", "accum"} and element_index is not None:
+        if kind in {"stream", "accum"} and loop_index_reg is not None:
             stride = ir.Constant(ir.IntType(32), element_size)
             byte_offset = tick_builder.add(
                 byte_offset,


### PR DESCRIPTION
### Motivation
- Fix an incorrect guard in `_leaf_ptr` that checked `element_index` instead of the intended `loop_index_reg`, which could skip stream/accum offset computation when the loop index register is available.

### Description
- In `lockstep_compiler/codegen.py` replace `and element_index is not None` with `and loop_index_reg is not None` inside the `_leaf_ptr` function so the `kind in {"stream","accum"}` offset is computed when `loop_index_reg` is present.

### Testing
- No automated tests were run for this targeted single-line change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17018c8810832883c103c1f9f78aa1)