### PR TITLE
Fix malformed GEP indexing for arena leaves in `_leaf_ptr`

### DIFF
--- a/lockstep_compiler/arena_layout.py
+++ b/lockstep_compiler/arena_layout.py
@@ -257,8 +257,8 @@ def build_arena_layout(entities: dict[str, Any]) -> ArenaLayout:
 
     bindings: list[tuple[str, str, str, int]] = []
     for stream in entities.get("streams", []):
-        capacity = int(stream["capacity"])
-        bindings.append(("stream", stream["name"], stream["type"], capacity))
+        capacity = int(stream.get("capacity", 1))
+        bindings.append(("stream", stream["name"], stream["type"], max(capacity, 1)))
     for accumulator in entities.get("accumulators", []):
         element_count = (
             int(accumulator.get("size", 1))

--- a/lockstep_compiler/ast.py
+++ b/lockstep_compiler/ast.py
@@ -679,7 +679,10 @@ def build_program_ast(parse_tree: Any, visitor_cls: type) -> AstProgram:
     return visitor.build()
 
 
-def ast_to_entities(program: AstProgram) -> dict[str, Any]:
+def ast_to_entities(program: AstProgram | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(program, dict):
+        return program
+
     def _expr_to_text(expr: AstExpr) -> str:
         if isinstance(expr, AstExprLiteral):
             return expr.value

--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -112,7 +112,7 @@ def emit_c_header(
         c_type_name = _c_type(leaf.type_name, known_structs)
         path_suffix = "_".join(_sanitize_symbol(part) for part in leaf.path) if leaf.path else "value"
         field_name = f"{leaf.kind}_{_sanitize_symbol(leaf.binding_name)}_{path_suffix}"
-        if leaf.kind == "stream" or leaf.element_count > 1:
+        if leaf.element_count > 1:
             lines.append(f"    {c_type_name} {field_name}[{leaf.element_count}];")
         else:
             lines.append(f"    {c_type_name} {field_name};")

--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -849,6 +849,7 @@ def emit_llvm_ir(
 
     arena_field_types: list[ir.Type] = []
     leaf_field_indices: dict[tuple[str, str, tuple[str, ...]], int] = {}
+    leaf_field_is_array: dict[tuple[str, str, tuple[str, ...]], bool] = {}
     for leaf in layout.leaves:
         if leaf.type_name in _PRIMITIVE_TYPE_MAP:
             field_ty = _PRIMITIVE_TYPE_MAP[leaf.type_name]
@@ -856,8 +857,15 @@ def emit_llvm_ir(
             field_ty = known_structs[leaf.type_name]
         else:
             field_ty = ir.ArrayType(ir.IntType(8), max(leaf.size, 1))
-        leaf_field_indices[(leaf.kind, leaf.binding_name, leaf.path)] = len(arena_field_types)
-        arena_field_types.append(field_ty)
+
+        leaf_key = (leaf.kind, leaf.binding_name, leaf.path)
+        leaf_field_indices[leaf_key] = len(arena_field_types)
+        if leaf.element_count > 1:
+            arena_field_types.append(ir.ArrayType(field_ty, max(leaf.element_count, 1)))
+            leaf_field_is_array[leaf_key] = True
+        else:
+            arena_field_types.append(field_ty)
+            leaf_field_is_array[leaf_key] = False
 
     if not arena_field_types:
         arena_field_types = [ir.ArrayType(ir.IntType(8), 1)]
@@ -893,23 +901,32 @@ def emit_llvm_ir(
         leaf_type: ir.Type,
         loop_index_reg: ir.Value | None = None,
     ) -> ir.Value | None:
-        leaf_spec = leaf_specs.get((kind, name, path))
-        if leaf_spec is None:
+        leaf_key = (kind, name, path)
+        if leaf_key not in leaf_specs:
             return None
-        base_offset, element_size = leaf_spec
-        byte_offset: ir.Value = ir.Constant(ir.IntType(32), base_offset)
-        if kind in {"stream", "accum"} and loop_index_reg is not None:
-            stride = ir.Constant(ir.IntType(32), element_size)
-            byte_offset = tick_builder.add(
-                byte_offset,
-                tick_builder.mul(loop_index_reg, stride, name="loop_elem_stride"),
-                name="loop_elem_offset",
+        field_index = leaf_field_indices.get(leaf_key)
+        if field_index is None:
+            return None
+
+        gep_indices = [
+            ir.Constant(ir.IntType(32), 0),
+            ir.Constant(ir.IntType(32), field_index),
+        ]
+        if leaf_field_is_array.get(leaf_key, False):
+            element_index = (
+                loop_index_reg
+                if kind in {"stream", "accum"} and loop_index_reg is not None
+                else ir.Constant(ir.IntType(32), 0)
             )
+            gep_indices.append(element_index)
+
         raw_ptr = tick_builder.gep(
             arena_ptr,
-            [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), 0), byte_offset],
-            name=f"{kind}_{_sanitize_symbol(name)}_{'_'.join(path) if path else 'value'}_raw",
+            gep_indices,
+            name=f"{kind}_{_sanitize_symbol(name)}_{'_'.join(path) if path else 'value'}_ptr",
         )
+        if raw_ptr.type.pointee == leaf_type:
+            return raw_ptr
         typed_ptr = tick_builder.bitcast(raw_ptr, leaf_type.as_pointer())
         if typed_ptr.type.pointee != leaf_type:
             return None

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -675,6 +675,9 @@ def test_emit_llvm_ir_lowers_kernel_bind_routes_into_counted_loops():
     assert "route_ApplyGravity_cond" in llvm_ir
     assert 'icmp slt i32 %"idx", 4' in llvm_ir
     assert 'call void @"shader_ApplyGravity"(float' in llvm_ir
+    assert '%"struct.Lockstep_Arena" = type {[4 x float], [4 x float], float}' in llvm_ir
+    assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 0, i32 %"route_i32_lane0.1"' in llvm_ir
+    assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 1, i32 %"route_i32_lane0.3"' in llvm_ir
 
 
 def test_emit_llvm_ir_keeps_integer_arithmetic_in_integer_domain():
@@ -878,8 +881,9 @@ def test_emit_llvm_ir_lowers_fold_routes_to_vector_reduce_intrinsics():
     )
 
     assert 'call fast float @"llvm.vector.reduce.fadd.v8f32"' in llvm_ir
-    assert '%"struct.Lockstep_Arena" = type {[8 x i8]}' in llvm_ir
-    assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 0, i32 4' in llvm_ir
+    assert '%"struct.Lockstep_Arena" = type {float, float}' in llvm_ir
+    assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 1' in llvm_ir
+    assert 'i32 0, i32 0, i32 4' not in llvm_ir
 
 
 def test_emit_llvm_ir_honors_explicit_target_width_override():


### PR DESCRIPTION
### Motivation
- The arena layout was represented as a flattened byte offset and `_leaf_ptr` injected that byte offset as a GEP index into the 0-th struct field, producing incorrect pointer arithmetic and unsafe memory accesses. 
- The intent is to map each layout leaf to its own typed struct field and apply loop indices as element array indices for stream/accum leaves to produce correct, well-typed GEPs.

### Description
- Build the `struct.Lockstep_Arena` fields per leaf and only make a field an array when `leaf.element_count > 1`, tracking positions with `leaf_field_indices` and `leaf_field_is_array` in `emit_llvm_ir` (`lockstep_compiler/codegen.py`).
- Replace the old byte-offset GEP logic in `_leaf_ptr` with a typed GEP that uses the field index followed by an optional array element index derived from the loop register for stream/accum leaves, and then `bitcast` to the desired typed pointer (`_leaf_ptr` in `lockstep_compiler/codegen.py`).
- Align C header emission with the typed arena model by emitting arrays only for leaves with `element_count > 1` (`lockstep_compiler/c_header.py`).
- Allow `ast_to_entities` to accept a dict directly and default stream capacity handling to a minimum of one element in `build_arena_layout` (`lockstep_compiler/ast.py` and `lockstep_compiler/arena_layout.py`).
- Update IR tests to assert typed field GEPs and to disallow the previous malformed byte-offset GEP pattern (`tests/test_compiler_api.py`).

### Testing
- Ran `python -m compileall lockstep_compiler tests/test_compiler_api.py` which succeeded for the modified modules.
- Ran the targeted pytest cases `test_emit_llvm_ir_lowers_kernel_bind_routes_into_counted_loops`, `test_emit_llvm_ir_lowers_fold_routes_to_vector_reduce_intrinsics`, `test_emit_c_header_exposes_nested_leaf_offsets_for_soa_layout`, and `test_emit_c_header_uses_parallel_soa_blocks_for_stream_capacity`, all of which passed against the patched code.
- A full `pytest -q` run is affected by an environment missing the `hypothesis` dependency (collection error), so broader suite execution was not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1db13e23f4832890bf9604ac4f3caa)