### PR TITLE
Reject undeclared assignment targets in codegen

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -520,8 +520,7 @@ class _FunctionLowerer:
         base_name, *field_path = target_name.split(".")
         key = _sanitize_symbol(base_name)
         if key not in self.locals:
-            slot = self.builder.alloca(value.type, name=key)
-            self.locals[key] = slot
+            self._compiler_error(f"undefined variable '{base_name}' in assignment")
         if not field_path:
             if self.local_indirections.get(key):
                 ref_ptr = self.builder.load(self.locals[key], name=f"{key}_ptr")

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -15,6 +15,8 @@ from lockstep_compiler.codegen import CodegenError, emit_llvm_ir
 from lockstep_compiler.models import LockstepDiagnostic
 from lockstep_compiler.ast import (
     AstAssignStmt,
+    AstProgram,
+    AstPureDecl,
     AstExprBinary,
     AstExprCall,
     AstExprCast,
@@ -355,6 +357,34 @@ def test_emit_llvm_ir_generates_expected_declarations():
     assert 'call float @"llvm.maxnum.f32"' in llvm_ir
     assert 'call float @"llvm.minnum.f32"' in llvm_ir
     assert "uitofp i1" in llvm_ir
+
+
+def test_emit_llvm_ir_rejects_assignment_to_undeclared_local():
+    program = AstProgram(
+        pure_functions=(
+            AstPureDecl(
+                name="typo_assignment",
+                return_type="float",
+                body=(
+                    AstVarDeclStmt(
+                        declared_type="float",
+                        name="position",
+                        initializer=AstExprLiteral(kind="float", value="1.0"),
+                    ),
+                    AstAssignStmt(
+                        target=("positiom",),
+                        value=AstExprLiteral(kind="float", value="2.0"),
+                    ),
+                    AstReturnStmt(value=AstExprVar(path=("position",))),
+                ),
+            ),
+        ),
+    )
+
+    with pytest.raises(
+        CodegenError, match="undefined variable 'positiom' in assignment"
+    ):
+        emit_llvm_ir(program)
 
 
 def test_emit_llvm_ir_lowers_struct_member_extract_and_insert():


### PR DESCRIPTION
### Motivation
- Prevent silent creation of local variables during lowering so typos or accidental assignments (e.g. `positiom = 2.0`) surface as errors rather than implicitly allocating new storage.

### Description
- Remove the implicit `alloca` creation in `_FunctionLowerer._lower_assignment` and replace it with `self._compiler_error(f"undefined variable '{base_name}' in assignment")`, and add a regression test `test_emit_llvm_ir_rejects_assignment_to_undeclared_local` to assert the new behavior.

### Testing
- Ran `pytest tests/test_compiler_api.py -q`, which failed for many unrelated tests in the full suite but did not indicate a regression for this targeted change.
- Ran the focused test `pytest tests/test_compiler_api.py::test_emit_llvm_ir_rejects_assignment_to_undeclared_local -q`, which passed.
- Ran `python -m compileall -q lockstep_compiler/codegen.py tests/test_compiler_api.py` and `git diff --check`, both of which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1db1ad67a88328b5d8162abe5752e9)