### PR TITLE
Fix unsigned inference for asymmetric binary ops

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -363,6 +363,27 @@ class _FunctionLowerer:
             current_type = field_type
         return current_type
 
+    @staticmethod
+    def _promote_scalar_type_names(
+        left_type: str | None, right_type: str | None
+    ) -> str | None:
+        if left_type is None or right_type is None:
+            return left_type or right_type
+        if left_type == right_type:
+            return left_type
+        if left_type in {"int", "uint"} and right_type in {"int", "uint"}:
+            return "uint" if "uint" in {left_type, right_type} else "int"
+        return None
+
+    def _infer_binary_operand_type(self, node: AstExprBinary) -> str | None:
+        left_type = self._infer_expr_type(node.left)
+        right_type = self._infer_expr_type(node.right)
+        if node.op in {"&&", "||"}:
+            return "bool" if left_type == "bool" and right_type == "bool" else None
+        if node.op in {"<<", ">>"}:
+            return left_type
+        return self._promote_scalar_type_names(left_type, right_type)
+
     def _infer_expr_type(self, node: AstExprLiteral | AstExprVar | AstExprUnary | AstExprBinary | AstExprCall | AstExprCast) -> str | None:
         if isinstance(node, AstExprLiteral):
             if node.kind in {"float", "int", "bool", "double", "uint", "string"}:
@@ -385,9 +406,11 @@ class _FunctionLowerer:
                 return node.name
             return self.function_return_types.get(f"pure_{_sanitize_symbol(node.name)}")
         if isinstance(node, AstExprBinary):
-            if node.op in {"<", "<=", ">", ">=", "==", "!=", "&&", "||"}:
+            if node.op in {"&&", "||"}:
                 return "bool"
-            return self._infer_expr_type(node.left)
+            if node.op in {"<", "<=", ">", ">=", "==", "!="}:
+                return "bool"
+            return self._infer_binary_operand_type(node)
         return None
 
     def _load_var(self, name: str) -> ir.Value:
@@ -489,7 +512,9 @@ class _FunctionLowerer:
         if isinstance(node, AstExprLiteral):
             if node.kind == "float":
                 return ir.Constant(ir.FloatType(), float(node.value))
-            if node.kind == "int":
+            if node.kind == "double":
+                return ir.Constant(ir.DoubleType(), float(node.value))
+            if node.kind in {"int", "uint"}:
                 return ir.Constant(ir.IntType(32), int(node.value))
             if node.kind == "string":
                 return self._lower_string_literal(node.value)
@@ -513,7 +538,11 @@ class _FunctionLowerer:
         if not isinstance(node, AstExprBinary):
             self._compiler_error(f"unsupported expression node '{type(node).__name__}'")
         lhs, rhs = self._lower_expr(node.left), self._lower_expr(node.right)
-        expr_type_name = self._infer_expr_type(node.left)
+        expr_type_name = self._infer_binary_operand_type(node)
+        if expr_type_name in _PRIMITIVE_TYPE_MAP:
+            operand_type = self._llvm_type(expr_type_name, self.known_structs)
+            lhs = self._coerce_value_to_type(lhs, operand_type)
+            rhs = self._coerce_value_to_type(rhs, operand_type)
         return self._lower_binary_op(node.op, lhs, rhs, type_name=expr_type_name)
 
     def _lower_assignment(self, target_name: str, value: ir.Value):

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -1419,6 +1419,43 @@ def test_codegen_uses_unsigned_ops_for_uint_math():
     assert "icmp ult i32" in llvm_ir
 
 
+def test_codegen_promotes_asymmetric_uint_binary_operands():
+    source = """
+    pure uint literal_divided_by_uint(uint value) {
+        return 5 / value;
+    }
+
+    pure uint literal_remainder_uint(uint value) {
+        return 5 % value;
+    }
+
+    pure bool literal_less_than_uint(uint value) {
+        return 5 < value;
+    }
+
+    pure uint signed_divided_by_uint(int lhs, uint rhs) {
+        return lhs / rhs;
+    }
+
+    pure bool signed_less_than_uint(int lhs, uint rhs) {
+        return lhs < rhs;
+    }
+
+    pure bool nested_uint_expr_compares_unsigned(uint value) {
+        return (5 / value) < 10;
+    }
+    """
+    result = lockstep_compiler.compile_lockstep(source)
+    llvm_ir = result.llvm_ir
+
+    assert llvm_ir.count("udiv i32") == 3
+    assert "urem i32" in llvm_ir
+    assert llvm_ir.count("icmp ult i32") == 3
+    assert "sdiv i32" not in llvm_ir
+    assert "srem i32" not in llvm_ir
+    assert "icmp slt i32" not in llvm_ir
+
+
 def test_codegen_uses_unsigned_ops_for_uint_struct_fields():
     source = """
     struct Pair { uint lhs; uint rhs; };


### PR DESCRIPTION
### Motivation
- Binary operator lowering selected signed vs unsigned semantics based solely on the left-hand operand, causing expressions like `5 / uint_var` or `int_var / uint_var` to use signed LLVM ops incorrectly.
- The intent is to apply unified scalar promotion/coercion so that if either operand is `uint` the unsigned backend operators are used.

### Description
- Add `_promote_scalar_type_names` to implement simple scalar promotion rules that promote mixed `{int,uint}` pairs to `uint` and otherwise preserve matching types or return `None` for incompatible pairs.
- Add `_infer_binary_operand_type` to infer a binary expression type from both operands with special handling for boolean operators and shifts, and wire it into `_infer_expr_type` for binary nodes.
- During lowering of binary expressions, infer the promoted operand type from both sides, coerce both lowered `lhs` and `rhs` to the promoted LLVM type when the type is a known primitive, and pass that type to the backend so it selects `udiv`/`urem`/`icmp ult` when appropriate.
- Improve literal lowering to produce `double` for `double` literals and treat `uint` literals as 32-bit integers so literal operands participate properly in promotion/coercion.
- Add a regression test `test_codegen_promotes_asymmetric_uint_binary_operands` covering literal-left and signed-left vs `uint`-right cases and a nested comparison scenario.

### Testing
- Ran the new targeted regression test with `pytest tests/test_compiler_api.py::test_codegen_promotes_asymmetric_uint_binary_operands -q`, which passed.
- Ran a bytecode compile check with `python -m compileall lockstep_compiler`, which succeeded.
- A full run of `pytest tests/test_compiler_api.py -q` was attempted earlier and surfaced unrelated failures in other areas; the focused changes in this PR are covered by the added regression test above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1db1b97db48328ac76e28216315f5f)