### PR TITLE
Support structural array/generic type suffixes in codegen

### DIFF
--- a/lockstep_compiler/ast.py
+++ b/lockstep_compiler/ast.py
@@ -5,17 +5,67 @@ from typing import Any
 
 
 @dataclass(frozen=True)
+class AstTypeArraySuffix:
+    size: int
+
+    def __str__(self) -> str:
+        return f"[{self.size}]"
+
+
+@dataclass(frozen=True)
+class AstTypeGenericSuffix:
+    type_name: "AstType"
+    arity: int | None = None
+
+    def __str__(self) -> str:
+        if self.arity is None:
+            return f"<{self.type_name}>"
+        return f"<{self.type_name},{self.arity}>"
+
+
+AstTypeSuffix = AstTypeArraySuffix | AstTypeGenericSuffix
+
+
+@dataclass(frozen=True)
 class AstType:
     name: str
     kind: str = "named"
+    suffixes: tuple[AstTypeSuffix, ...] = ()
 
     def __str__(self) -> str:
-        return self.name
+        return self.name + "".join(str(suffix) for suffix in self.suffixes)
+
+
+def _ast_type_from_parsed(parsed_type: Any) -> AstType:
+    from .models import ParsedTypeArraySuffix, ParsedTypeGenericSuffix
+
+    suffixes: list[AstTypeSuffix] = []
+    for suffix in parsed_type.inner:
+        if isinstance(suffix, ParsedTypeArraySuffix):
+            suffixes.append(AstTypeArraySuffix(size=suffix.size))
+        elif isinstance(suffix, ParsedTypeGenericSuffix):
+            suffixes.append(
+                AstTypeGenericSuffix(
+                    type_name=_ast_type_from_parsed(suffix.type_name),
+                    arity=suffix.arity,
+                )
+            )
+    kind = (
+        "primitive"
+        if parsed_type.base in {"int", "float", "bool", "uint", "double", "string"}
+        else "named"
+    )
+    return AstType(name=parsed_type.base, kind=kind, suffixes=tuple(suffixes))
 
 
 def _normalize_type(value: AstType | str) -> AstType:
     if isinstance(value, AstType):
         return value
+    from .type_analysis import parse_type_name
+
+    parsed_type, index = parse_type_name(value)
+    if parsed_type is not None and index == len(value):
+        return _ast_type_from_parsed(parsed_type)
     kind = (
         "primitive"
         if value in {"int", "float", "bool", "uint", "double", "string"}
@@ -27,7 +77,7 @@ def _normalize_type(value: AstType | str) -> AstType:
 def _type_name(value: AstType | str | None) -> str | None:
     if value is None:
         return None
-    return value.name if isinstance(value, AstType) else value
+    return str(value) if isinstance(value, AstType) else value
 
 
 @dataclass(frozen=True)
@@ -282,10 +332,49 @@ class AstBuilder(_AstBuilderMixin):
         self._active_bind_routes: list[AstBindRoute] = []
         self._types: dict[str, AstType] = {}
 
-    def _resolve_type(self, type_name: str) -> AstType:
-        if type_name not in self._types:
-            self._types[type_name] = _normalize_type(type_name)
-        return self._types[type_name]
+    def _resolve_type(self, type_name: AstType | str) -> AstType:
+        normalized = _normalize_type(type_name)
+        key = str(normalized)
+        if key not in self._types:
+            self._types[key] = normalized
+        return self._types[key]
+
+    def _parse_type_ctx(self, type_ctx: Any) -> AstType:
+        id_token = self._call(type_ctx, "ID")
+        if id_token is None:
+            return self._resolve_type(type_ctx.getText())
+
+        suffixes: list[AstTypeSuffix] = []
+        for suffix_ctx in self._call(type_ctx, "typeSuffix", []) or []:
+            text = suffix_ctx.getText()
+            if text.startswith("[") and text.endswith("]"):
+                suffixes.append(AstTypeArraySuffix(size=int(text[1:-1])))
+                continue
+
+            inner_type_ctx = self._call(suffix_ctx, "typeName")
+            if inner_type_ctx is not None:
+                int_token = self._call(suffix_ctx, "INT")
+                suffixes.append(
+                    AstTypeGenericSuffix(
+                        type_name=self._parse_type_ctx(inner_type_ctx),
+                        arity=(
+                            int(int_token.getText()) if int_token is not None else None
+                        ),
+                    )
+                )
+                continue
+
+            return self._resolve_type(type_ctx.getText())
+
+        base_name = id_token.getText()
+        kind = (
+            "primitive"
+            if base_name in {"int", "float", "bool", "uint", "double", "string"}
+            else "named"
+        )
+        return self._resolve_type(
+            AstType(name=base_name, kind=kind, suffixes=tuple(suffixes))
+        )
 
     def _parse_params(self, param_list_ctx: Any) -> tuple[AstKernelParam, ...]:
         if param_list_ctx is None:
@@ -294,7 +383,7 @@ class AstBuilder(_AstBuilderMixin):
         params: list[AstKernelParam] = []
         for param in params_ctx:
             modifier = param.getChild(0).getText()
-            declared_type = self._resolve_type(self._call(param, "typeName").getText())
+            declared_type = self._parse_type_ctx(self._call(param, "typeName"))
             name = self._call(param, "ID").getText()
             params.append(
                 AstKernelParam(
@@ -375,9 +464,7 @@ class AstBuilder(_AstBuilderMixin):
                 and ctx.getChild(2).getText() == ")"
             ):
                 return AstExprCast(
-                    target_type=self._resolve_type(
-                        self._call(ctx, "typeName").getText()
-                    ),
+                    target_type=self._parse_type_ctx(self._call(ctx, "typeName")),
                     value=self.visit(nested),
                 )
             return AstExprUnary(
@@ -447,7 +534,7 @@ class AstBuilder(_AstBuilderMixin):
                 parsed.append(
                     AstVarDeclStmt(
                         declared_type=(
-                            self._resolve_type(declared_type.getText())
+                            self._parse_type_ctx(declared_type)
                             if declared_type
                             else None
                         ),
@@ -487,9 +574,7 @@ class AstBuilder(_AstBuilderMixin):
         members = self._call(ctx, "structMember", []) or []
         fields = tuple(
             AstStructField(
-                declared_type=self._resolve_type(
-                    self._call(member, "typeName").getText()
-                ),
+                declared_type=self._parse_type_ctx(self._call(member, "typeName")),
                 name=self._call(member, "ID").getText(),
                 location=AstLocation(
                     line=getattr(
@@ -523,14 +608,14 @@ class AstBuilder(_AstBuilderMixin):
                 params.append(
                     AstKernelParam(
                         modifier="in",
-                        declared_type=self._resolve_type(declared_type.getText()),
+                        declared_type=self._parse_type_ctx(declared_type),
                         name=name.getText(),
                     )
                 )
         self._pure_functions.append(
             AstPureDecl(
                 name=id_token.getText(),
-                return_type=self._resolve_type(self._call(ctx, "typeName").getText()),
+                return_type=self._parse_type_ctx(self._call(ctx, "typeName")),
                 params=tuple(params),
                 body=self._parse_statement_text(ctx),
                 location=self._location(ctx),
@@ -589,7 +674,7 @@ class AstBuilder(_AstBuilderMixin):
         self._active_streams.append(
             AstStreamDecl(
                 name=self._call(ctx, "ID").getText(),
-                declared_type=self._resolve_type(self._call(ctx, "typeName").getText()),
+                declared_type=self._parse_type_ctx(self._call(ctx, "typeName")),
                 capacity=self._call(ctx, "INT").getText(),
                 location=self._location(ctx),
             )
@@ -600,7 +685,7 @@ class AstBuilder(_AstBuilderMixin):
         self._active_accumulators.append(
             AstAccumulatorDecl(
                 name=self._call(ctx, "ID").getText(),
-                declared_type=self._resolve_type(self._call(ctx, "typeName").getText()),
+                declared_type=self._parse_type_ctx(self._call(ctx, "typeName")),
                 location=self._location(ctx),
             )
         )
@@ -611,7 +696,7 @@ class AstBuilder(_AstBuilderMixin):
         self._active_uniforms.append(
             AstUniformDecl(
                 name=self._call(ctx, "ID").getText(),
-                declared_type=self._resolve_type(self._call(ctx, "typeName").getText()),
+                declared_type=self._parse_type_ctx(self._call(ctx, "typeName")),
                 initializer=expr_ctx.getText() if expr_ctx else None,
                 location=self._location(ctx),
             )
@@ -627,9 +712,7 @@ class AstBuilder(_AstBuilderMixin):
                 self._active_bind_routes.append(
                     AstFoldBindRoute(
                         uniform_type=(
-                            self._resolve_type(
-                                self._call(bind_stmt, "typeName").getText()
-                            )
+                            self._parse_type_ctx(self._call(bind_stmt, "typeName"))
                             if self._call(bind_stmt, "typeName")
                             else self._resolve_type("float")
                         ),
@@ -643,7 +726,9 @@ class AstBuilder(_AstBuilderMixin):
                 continue
 
             if len(id_tokens) >= 2:
-                arg_tokens = self._call(self._call(bind_stmt, "argList"), "ID", []) or []
+                arg_tokens = (
+                    self._call(self._call(bind_stmt, "argList"), "ID", []) or []
+                )
                 if not isinstance(arg_tokens, list):
                     arg_tokens = [arg_tokens]
                 self._active_bind_routes.append(

--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -14,12 +14,13 @@ from .ast import (
     AstReturnStmt,
     AstStatement,
     AstType,
+    AstTypeArraySuffix,
+    AstTypeGenericSuffix,
     AstVarDeclStmt,
     ast_to_entities,
 )
 from .arena_layout import build_arena_layout
 from .utils import sanitize_symbol as _sanitize_symbol
-
 
 _PRIMITIVE_TYPE_MAP: dict[str, ir.Type] = {
     "bool": ir.IntType(1),
@@ -36,7 +37,7 @@ class CodegenError(RuntimeError):
 
 
 def _type_name(value: AstType | str) -> str:
-    return value.name if isinstance(value, AstType) else value
+    return str(value) if isinstance(value, AstType) else value
 
 
 class _FunctionLowerer:
@@ -207,10 +208,14 @@ class _FunctionLowerer:
             if value.type.width > target_type.width:
                 return self.builder.trunc(value, target_type)
 
-        if isinstance(target_type, (ir.FloatType, ir.DoubleType)) and isinstance(value.type, ir.IntType):
+        if isinstance(target_type, (ir.FloatType, ir.DoubleType)) and isinstance(
+            value.type, ir.IntType
+        ):
             return self.builder.sitofp(value, target_type)
 
-        if isinstance(target_type, ir.IntType) and isinstance(value.type, (ir.FloatType, ir.DoubleType)):
+        if isinstance(target_type, ir.IntType) and isinstance(
+            value.type, (ir.FloatType, ir.DoubleType)
+        ):
             return self.builder.fptosi(value, target_type)
 
         if isinstance(target_type, ir.FloatType) and isinstance(
@@ -261,13 +266,57 @@ class _FunctionLowerer:
         )
 
     def _llvm_type(
-        self, type_name: str, known_structs: dict[str, ir.IdentifiedStructType]
+        self,
+        type_name: AstType | str,
+        known_structs: dict[str, ir.IdentifiedStructType],
     ) -> ir.Type:
-        if type_name in _PRIMITIVE_TYPE_MAP:
-            return _PRIMITIVE_TYPE_MAP[type_name]
-        if type_name in known_structs:
-            return known_structs[type_name]
-        return ir.IntType(8).as_pointer()
+        normalized_type = (
+            type_name if isinstance(type_name, AstType) else AstType(type_name)
+        )
+        if not isinstance(type_name, AstType):
+            from .ast import _normalize_type
+
+            normalized_type = _normalize_type(type_name)
+
+        rendered_name = str(normalized_type)
+        if rendered_name in known_structs:
+            return known_structs[rendered_name]
+
+        base_type: ir.Type
+        if normalized_type.name in _PRIMITIVE_TYPE_MAP:
+            base_type = _PRIMITIVE_TYPE_MAP[normalized_type.name]
+        elif normalized_type.name in known_structs:
+            base_type = known_structs[normalized_type.name]
+        else:
+            base_type = ir.IntType(8).as_pointer()
+
+        return self._apply_type_suffixes(
+            base_type, normalized_type.suffixes, known_structs
+        )
+
+    def _apply_type_suffixes(
+        self,
+        base_type: ir.Type,
+        suffixes: tuple[AstTypeArraySuffix | AstTypeGenericSuffix, ...],
+        known_structs: dict[str, ir.IdentifiedStructType],
+    ) -> ir.Type:
+        lowered = base_type
+        for suffix in reversed(suffixes):
+            if isinstance(suffix, AstTypeArraySuffix):
+                lowered = ir.ArrayType(lowered, suffix.size)
+                continue
+
+            if (
+                isinstance(suffix, AstTypeGenericSuffix)
+                and suffix.arity is not None
+                and suffix.arity >= 0
+                and isinstance(lowered, ir.PointerType)
+            ):
+                lowered = ir.ArrayType(
+                    self._llvm_type(suffix.type_name, known_structs), suffix.arity
+                )
+
+        return lowered
 
     def _emit_numeric_unary_minus(self, value: ir.Value) -> ir.Value:
         if isinstance(value.type, (ir.FloatType, ir.DoubleType)):
@@ -346,8 +395,9 @@ class _FunctionLowerer:
             return self.builder.icmp_signed(rel_map[op], lhs, rhs)
         self._compiler_error(f"comparison '{op}' is unsupported for type '{lhs.type}'")
 
-
-    def _resolve_field_declared_type(self, base_type: str, field_path: list[str]) -> str | None:
+    def _resolve_field_declared_type(
+        self, base_type: str, field_path: list[str]
+    ) -> str | None:
         current_type = base_type
         for field_name in field_path:
             fields = self.struct_fields.get(current_type)
@@ -363,7 +413,17 @@ class _FunctionLowerer:
             current_type = field_type
         return current_type
 
-    def _infer_expr_type(self, node: AstExprLiteral | AstExprVar | AstExprUnary | AstExprBinary | AstExprCall | AstExprCast) -> str | None:
+    def _infer_expr_type(
+        self,
+        node: (
+            AstExprLiteral
+            | AstExprVar
+            | AstExprUnary
+            | AstExprBinary
+            | AstExprCall
+            | AstExprCast
+        ),
+    ) -> str | None:
         if isinstance(node, AstExprLiteral):
             if node.kind in {"float", "int", "bool", "double", "uint", "string"}:
                 return node.kind
@@ -506,9 +566,7 @@ class _FunctionLowerer:
                 node.name, [self._lower_expr(arg) for arg in node.args]
             )
         if isinstance(node, AstExprCast):
-            target_type = self._llvm_type(
-                _type_name(node.target_type), self.known_structs
-            )
+            target_type = self._llvm_type(node.target_type, self.known_structs)
             return self._coerce_value_to_type(self._lower_expr(node.value), target_type)
         if not isinstance(node, AstExprBinary):
             self._compiler_error(f"unsupported expression node '{type(node).__name__}'")
@@ -526,7 +584,9 @@ class _FunctionLowerer:
             if self.local_indirections.get(key):
                 ref_ptr = self.builder.load(self.locals[key], name=f"{key}_ptr")
                 slot_type = ref_ptr.type.pointee
-                self.builder.store(self._coerce_value_to_type(value, slot_type), ref_ptr)
+                self.builder.store(
+                    self._coerce_value_to_type(value, slot_type), ref_ptr
+                )
             else:
                 slot_type = self.locals[key].type.pointee
                 self.builder.store(
@@ -564,12 +624,10 @@ class _FunctionLowerer:
         if isinstance(statement, AstVarDeclStmt):
             key = _sanitize_symbol(statement.name)
             declared_type = (
-                _type_name(statement.declared_type)
-                if statement.declared_type
-                else "float"
+                statement.declared_type if statement.declared_type else AstType("float")
             )
             llvm_type = self._llvm_type(declared_type, self.known_structs)
-            self.local_types[key] = declared_type
+            self.local_types[key] = str(declared_type)
             if key not in self.locals:
                 slot = self.builder.alloca(llvm_type, name=key)
                 self.locals[key] = slot
@@ -602,7 +660,11 @@ class _FunctionLowerer:
             slot = self.builder.alloca(arg.type, name=key)
             self.builder.store(arg, slot)
             self.locals[key] = slot
-            is_by_ref = bool(param_by_ref[idx]) if param_by_ref is not None and idx < len(param_by_ref) else False
+            is_by_ref = (
+                bool(param_by_ref[idx])
+                if param_by_ref is not None and idx < len(param_by_ref)
+                else False
+            )
             self.local_indirections[key] = is_by_ref
             if param_type_names is not None and idx < len(param_type_names):
                 self.local_types[key] = param_type_names[idx]
@@ -743,7 +805,9 @@ def emit_llvm_ir(
     for shader in shaders:
         params = [
             (
-                lowerer._llvm_type(param.get("type", "float"), known_structs).as_pointer()
+                lowerer._llvm_type(
+                    param.get("type", "float"), known_structs
+                ).as_pointer()
                 if param.get("modifier") in {"out", "accum"}
                 else lowerer._llvm_type(param.get("type", "float"), known_structs)
             )
@@ -761,7 +825,9 @@ def emit_llvm_ir(
     for flt in filters:
         params = [
             (
-                lowerer._llvm_type(param.get("type", "float"), known_structs).as_pointer()
+                lowerer._llvm_type(
+                    param.get("type", "float"), known_structs
+                ).as_pointer()
                 if param.get("modifier") in {"out", "accum"}
                 else lowerer._llvm_type(param.get("type", "float"), known_structs)
             )
@@ -796,7 +862,10 @@ def emit_llvm_ir(
             _ast_body_for(shader, entity_kind="shader"),
             ir.VoidType(),
             [str(param.get("type", "float")) for param in shader.get("params", [])],
-            [param.get("modifier") in {"out", "accum"} for param in shader.get("params", [])],
+            [
+                param.get("modifier") in {"out", "accum"}
+                for param in shader.get("params", [])
+            ],
         )
 
     for flt in filters:
@@ -806,17 +875,26 @@ def emit_llvm_ir(
             _ast_body_for(flt, entity_kind="filter"),
             ir.VoidType(),
             [str(param.get("type", "float")) for param in flt.get("params", [])],
-            [param.get("modifier") in {"out", "accum"} for param in flt.get("params", [])],
+            [
+                param.get("modifier") in {"out", "accum"}
+                for param in flt.get("params", [])
+            ],
         )
 
     layout = build_arena_layout(entities)
 
-    stream_slots: dict[str, int] = {stream["name"]: idx for idx, stream in enumerate(streams)}
+    stream_slots: dict[str, int] = {
+        stream["name"]: idx for idx, stream in enumerate(streams)
+    }
     stream_capacities: dict[str, int] = {}
     for stream in streams:
         stream_capacities[stream["name"]] = int(stream.get("capacity", 0))
-    accum_slots: dict[str, int] = {accum["name"]: idx for idx, accum in enumerate(accumulators)}
-    uniform_slots: dict[str, int] = {uniform["name"]: idx for idx, uniform in enumerate(uniforms)}
+    accum_slots: dict[str, int] = {
+        accum["name"]: idx for idx, accum in enumerate(accumulators)
+    }
+    uniform_slots: dict[str, int] = {
+        uniform["name"]: idx for idx, uniform in enumerate(uniforms)
+    }
 
     leaf_specs: dict[tuple[str, str, tuple[str, ...]], tuple[int, int]] = {
         (leaf.kind, leaf.binding_name, leaf.path): (leaf.offset, leaf.size)
@@ -852,11 +930,16 @@ def emit_llvm_ir(
     for leaf in layout.leaves:
         if leaf.type_name in _PRIMITIVE_TYPE_MAP:
             field_ty = _PRIMITIVE_TYPE_MAP[leaf.type_name]
-        elif leaf.type_name in known_structs and leaf.type_name not in layout.opaque_structs:
+        elif (
+            leaf.type_name in known_structs
+            and leaf.type_name not in layout.opaque_structs
+        ):
             field_ty = known_structs[leaf.type_name]
         else:
             field_ty = ir.ArrayType(ir.IntType(8), max(leaf.size, 1))
-        leaf_field_indices[(leaf.kind, leaf.binding_name, leaf.path)] = len(arena_field_types)
+        leaf_field_indices[(leaf.kind, leaf.binding_name, leaf.path)] = len(
+            arena_field_types
+        )
         arena_field_types.append(field_ty)
 
     if not arena_field_types:
@@ -907,7 +990,11 @@ def emit_llvm_ir(
             )
         raw_ptr = tick_builder.gep(
             arena_ptr,
-            [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), 0), byte_offset],
+            [
+                ir.Constant(ir.IntType(32), 0),
+                ir.Constant(ir.IntType(32), 0),
+                byte_offset,
+            ],
             name=f"{kind}_{_sanitize_symbol(name)}_{'_'.join(path) if path else 'value'}_raw",
         )
         typed_ptr = tick_builder.bitcast(raw_ptr, leaf_type.as_pointer())
@@ -923,7 +1010,9 @@ def emit_llvm_ir(
         path: tuple[str, ...] = (),
         element_index: ir.Value | None = None,
     ) -> ir.Value:
-        if declared_type in struct_fields and isinstance(value_type, ir.IdentifiedStructType):
+        if declared_type in struct_fields and isinstance(
+            value_type, ir.IdentifiedStructType
+        ):
             aggregate = ir.Constant(value_type, ir.Undefined)
             fields = struct_fields.get(declared_type, [])
             for index, element_type in enumerate(value_type.elements):
@@ -955,7 +1044,9 @@ def emit_llvm_ir(
         element_index: ir.Value | None = None,
     ):
         value_type = value.type
-        if declared_type in struct_fields and isinstance(value_type, ir.IdentifiedStructType):
+        if declared_type in struct_fields and isinstance(
+            value_type, ir.IdentifiedStructType
+        ):
             fields = struct_fields.get(declared_type, [])
             for index, element_type in enumerate(value_type.elements):
                 part = tick_builder.extract_value(value, index)
@@ -978,7 +1069,9 @@ def emit_llvm_ir(
         element_index: ir.Value | None = None,
     ) -> ir.Value:
         declared_type = binding_declared_types.get((kind, name), "float")
-        return _load_value(kind, name, field_type, declared_type, element_index=element_index)
+        return _load_value(
+            kind, name, field_type, declared_type, element_index=element_index
+        )
 
     def _load_tick_param_ptr(
         kind: str,
@@ -1053,7 +1146,9 @@ def emit_llvm_ir(
                 name=f"fold_lane_{lane}",
             )
         if populated_lanes < simd_width:
-            zero_value = ir.Constant(uniform_type, 0 if isinstance(uniform_type, ir.IntType) else 0.0)
+            zero_value = ir.Constant(
+                uniform_type, 0 if isinstance(uniform_type, ir.IntType) else 0.0
+            )
             for lane in range(populated_lanes, simd_width):
                 vector_value = tick_builder.insert_element(
                     vector_value,
@@ -1184,7 +1279,9 @@ def emit_llvm_ir(
                         "stream", arg_name, param.type.pointee, clamped_index
                     )
                 else:
-                    value = _load_tick_param("stream", arg_name, param.type, clamped_index)
+                    value = _load_tick_param(
+                        "stream", arg_name, param.type, clamped_index
+                    )
             elif modifier == "accum" and arg_name in accum_slots:
                 value = _load_tick_param_ptr("accum", arg_name, param.type.pointee)
             elif modifier == "uniform" and arg_name in uniform_slots:

--- a/lockstep_compiler/semantic_validator.py
+++ b/lockstep_compiler/semantic_validator.py
@@ -60,9 +60,11 @@ def build_semantic_validator(base_visitor_cls):
                 for name, signature in load_intrinsics().items()
             }
             self.structs: dict[str, dict[str, SemanticStructField]] = {}
-            self._primitive_types = {"int", "float", "bool", "string"}
+            self._primitive_types = {"int", "uint", "float", "double", "bool", "string"}
             self._current_pure_function: SemanticPureFunctionContext | None = None
-            self._pipeline_resource_stack: list[dict[str, SemanticPipelineResource]] = []
+            self._pipeline_resource_stack: list[dict[str, SemanticPipelineResource]] = (
+                []
+            )
             self._pipeline_bind_usage_stack: list[set[str]] = []
 
         def _line_col(self, ctx) -> tuple[int, int]:
@@ -551,7 +553,9 @@ def build_semantic_validator(base_visitor_cls):
                         if field.name in seen_field_names:
                             self._add_diagnostic(
                                 severity="error",
-                                code=SEMANTIC_DIAGNOSTIC_CODES["duplicate_struct_field"],
+                                code=SEMANTIC_DIAGNOSTIC_CODES[
+                                    "duplicate_struct_field"
+                                ],
                                 message=(
                                     f"Struct '{struct.name}' has duplicate field declaration "
                                     f"'{field.name}'."
@@ -562,7 +566,7 @@ def build_semantic_validator(base_visitor_cls):
                             continue
                         seen_field_names.add(field.name)
                         fields[field.name] = SemanticStructField(
-                            name=field.name, declared_type=field.declared_type.name
+                            name=field.name, declared_type=str(field.declared_type)
                         )
                     self.structs[struct.name] = fields
 
@@ -571,7 +575,7 @@ def build_semantic_validator(base_visitor_cls):
                     params = [
                         SemanticKernelParam(
                             name=param.name,
-                            declared_type=param.declared_type.name,
+                            declared_type=str(param.declared_type),
                             modifier=param.modifier,
                         )
                         for param in shader.params
@@ -579,7 +583,9 @@ def build_semantic_validator(base_visitor_cls):
                     if shader.name in self.shaders:
                         self._add_diagnostic(
                             severity="error",
-                            code=SEMANTIC_DIAGNOSTIC_CODES["duplicate_kernel_declaration"],
+                            code=SEMANTIC_DIAGNOSTIC_CODES[
+                                "duplicate_kernel_declaration"
+                            ],
                             message=f"Duplicate shader/filter declaration for '{shader.name}'.",
                             ctx=shader_ctx,
                             hint="Rename one declaration to avoid symbol collisions.",
@@ -592,7 +598,7 @@ def build_semantic_validator(base_visitor_cls):
                     params = [
                         SemanticKernelParam(
                             name=param.name,
-                            declared_type=param.declared_type.name,
+                            declared_type=str(param.declared_type),
                             modifier=param.modifier,
                         )
                         for param in filter_decl.params
@@ -600,7 +606,9 @@ def build_semantic_validator(base_visitor_cls):
                     if filter_decl.name in self.filters:
                         self._add_diagnostic(
                             severity="error",
-                            code=SEMANTIC_DIAGNOSTIC_CODES["duplicate_kernel_declaration"],
+                            code=SEMANTIC_DIAGNOSTIC_CODES[
+                                "duplicate_kernel_declaration"
+                            ],
                             message=f"Duplicate shader/filter declaration for '{filter_decl.name}'.",
                             ctx=filter_ctx,
                             hint="Rename one declaration to avoid symbol collisions.",
@@ -886,12 +894,15 @@ def build_semantic_validator(base_visitor_cls):
                 AstExprUnary: lambda node: (
                     "bool"
                     if node.op == "!"
-                    else self._resolve_ast_expr_type(node.operand)
-                    if (
-                        node.op != "-"
-                        or self._resolve_ast_expr_type(node.operand) in numeric_types
+                    else (
+                        self._resolve_ast_expr_type(node.operand)
+                        if (
+                            node.op != "-"
+                            or self._resolve_ast_expr_type(node.operand)
+                            in numeric_types
+                        )
+                        else None
                     )
-                    else None
                 ),
                 AstExprBinary: _resolve_binary,
                 AstExprCall: _resolve_call,
@@ -1135,9 +1146,11 @@ def build_semantic_validator(base_visitor_cls):
                 kind="stream",
             )
             if self._pipeline_resource_stack:
-                self._pipeline_resource_stack[-1][ctx.ID().getText()] = SemanticPipelineResource(
-                    kind="stream",
-                    declaration_ctx=ctx,
+                self._pipeline_resource_stack[-1][ctx.ID().getText()] = (
+                    SemanticPipelineResource(
+                        kind="stream",
+                        declaration_ctx=ctx,
+                    )
                 )
             return self.visitChildren(ctx)
 
@@ -1153,9 +1166,11 @@ def build_semantic_validator(base_visitor_cls):
                 kind="accumulator",
             )
             if self._pipeline_resource_stack:
-                self._pipeline_resource_stack[-1][ctx.ID().getText()] = SemanticPipelineResource(
-                    kind="accumulator",
-                    declaration_ctx=ctx,
+                self._pipeline_resource_stack[-1][ctx.ID().getText()] = (
+                    SemanticPipelineResource(
+                        kind="accumulator",
+                        declaration_ctx=ctx,
+                    )
                 )
             return self.visitChildren(ctx)
 
@@ -1189,9 +1204,11 @@ def build_semantic_validator(base_visitor_cls):
                         hint="Use an initializer expression with the same type as the declared uniform.",
                     )
             if self._pipeline_resource_stack:
-                self._pipeline_resource_stack[-1][ctx.ID().getText()] = SemanticPipelineResource(
-                    kind="uniform",
-                    declaration_ctx=ctx,
+                self._pipeline_resource_stack[-1][ctx.ID().getText()] = (
+                    SemanticPipelineResource(
+                        kind="uniform",
+                        declaration_ctx=ctx,
+                    )
                 )
             return self.visitChildren(ctx)
 
@@ -1302,7 +1319,9 @@ def build_semantic_validator(base_visitor_cls):
                                 hint="Pass exactly one expression to a cast.",
                             )
                     elif callee_name == "select":
-                        args = ctx.exprList().expr() if ctx.exprList() is not None else []
+                        args = (
+                            ctx.exprList().expr() if ctx.exprList() is not None else []
+                        )
                         if len(args) != 3:
                             self._add_diagnostic(
                                 severity="error",
@@ -1382,7 +1401,9 @@ def build_semantic_validator(base_visitor_cls):
                     return
                 if isinstance(expr, AstExprCast):
                     cast_ctx = self._ctx_from_location(getattr(expr, "location", None))
-                    self._validate_declared_type(expr.target_type.name, cast_ctx, "LCK310")
+                    self._validate_declared_type(
+                        str(expr.target_type), cast_ctx, "LCK310"
+                    )
                     _validate_ast_expr(expr.value)
 
             def _validate_ast_statement(statement: AstStatement):
@@ -1390,12 +1411,14 @@ def build_semantic_validator(base_visitor_cls):
                 if isinstance(statement, AstVarDeclStmt):
                     if statement.declared_type is not None:
                         self._validate_declared_type(
-                            statement.declared_type.name, stmt_ctx, "LCK310"
+                            str(statement.declared_type), stmt_ctx, "LCK310"
                         )
                     if statement.initializer is not None:
                         _validate_ast_expr(statement.initializer)
                     declared_type_name = (
-                        statement.declared_type.name if statement.declared_type else "unknown"
+                        str(statement.declared_type)
+                        if statement.declared_type
+                        else "unknown"
                     )
                     self._declare(
                         statement.name,
@@ -1409,7 +1432,9 @@ def build_semantic_validator(base_visitor_cls):
                 if isinstance(statement, AstAssignStmt):
                     if statement.target:
                         target_name = statement.target[0]
-                        self._check_expression_identifier(target_name, stmt_ctx, require_assigned=False)
+                        self._check_expression_identifier(
+                            target_name, stmt_ctx, require_assigned=False
+                        )
                         self._set_symbol_assigned(target_name)
                     _validate_ast_expr(statement.value)
                     return
@@ -1437,33 +1462,76 @@ def build_semantic_validator(base_visitor_cls):
             for struct in program.structs:
                 struct_ctx = self._ctx_from_location(struct.location)
                 if struct.name in self.structs:
-                    self._add_diagnostic(severity="error", code=SEMANTIC_DIAGNOSTIC_CODES["duplicate_declaration"], message=f"Duplicate struct declaration for '{struct.name}'.", ctx=struct_ctx, hint="Rename one struct declaration to keep type names unique.")
+                    self._add_diagnostic(
+                        severity="error",
+                        code=SEMANTIC_DIAGNOSTIC_CODES["duplicate_declaration"],
+                        message=f"Duplicate struct declaration for '{struct.name}'.",
+                        ctx=struct_ctx,
+                        hint="Rename one struct declaration to keep type names unique.",
+                    )
                     continue
                 fields = {}
                 for field in struct.fields:
                     field_ctx = self._ctx_from_location(field.location)
                     if field.name in fields:
-                        self._add_diagnostic(severity="error", code=SEMANTIC_DIAGNOSTIC_CODES["duplicate_struct_field"], message=f"Struct '{struct.name}' has duplicate field declaration '{field.name}'.", ctx=field_ctx, hint="Rename or remove duplicate struct member declarations.")
+                        self._add_diagnostic(
+                            severity="error",
+                            code=SEMANTIC_DIAGNOSTIC_CODES["duplicate_struct_field"],
+                            message=f"Struct '{struct.name}' has duplicate field declaration '{field.name}'.",
+                            ctx=field_ctx,
+                            hint="Rename or remove duplicate struct member declarations.",
+                        )
                         continue
-                    fields[field.name]=SemanticStructField(name=field.name, declared_type=field.declared_type.name)
-                self.structs[struct.name]=fields
+                    fields[field.name] = SemanticStructField(
+                        name=field.name, declared_type=str(field.declared_type)
+                    )
+                self.structs[struct.name] = fields
 
-            for collection, target in ((program.shaders, self.shaders), (program.filters, self.filters)):
+            for collection, target in (
+                (program.shaders, self.shaders),
+                (program.filters, self.filters),
+            ):
                 for kernel in collection:
-                    kctx=self._ctx_from_location(kernel.location)
-                    params=[SemanticKernelParam(name=p.name, declared_type=p.declared_type.name, modifier=p.modifier) for p in kernel.params]
+                    kctx = self._ctx_from_location(kernel.location)
+                    params = [
+                        SemanticKernelParam(
+                            name=p.name,
+                            declared_type=str(p.declared_type),
+                            modifier=p.modifier,
+                        )
+                        for p in kernel.params
+                    ]
                     if kernel.name in target:
-                        self._add_diagnostic(severity="error", code=SEMANTIC_DIAGNOSTIC_CODES["duplicate_kernel_declaration"], message=f"Duplicate shader/filter declaration for '{kernel.name}'.", ctx=kctx, hint="Rename one declaration to avoid symbol collisions.")
+                        self._add_diagnostic(
+                            severity="error",
+                            code=SEMANTIC_DIAGNOSTIC_CODES[
+                                "duplicate_kernel_declaration"
+                            ],
+                            message=f"Duplicate shader/filter declaration for '{kernel.name}'.",
+                            ctx=kctx,
+                            hint="Rename one declaration to avoid symbol collisions.",
+                        )
                     else:
-                        target[kernel.name]=params
+                        target[kernel.name] = params
 
             for pure in program.pure_functions:
-                self.pure_functions[pure.name]=SemanticPureFunctionSignature(return_type=pure.return_type.name, params=tuple(SemanticKernelParam(name=p.name, declared_type=p.declared_type.name, modifier="value") for p in pure.params), intrinsic=pure.intrinsic)
+                self.pure_functions[pure.name] = SemanticPureFunctionSignature(
+                    return_type=str(pure.return_type),
+                    params=tuple(
+                        SemanticKernelParam(
+                            name=p.name,
+                            declared_type=str(p.declared_type),
+                            modifier="value",
+                        )
+                        for p in pure.params
+                    ),
+                    intrinsic=pure.intrinsic,
+                )
             for kernel in (*program.shaders, *program.filters):
                 kernel_params = tuple(
                     SemanticKernelParam(
                         name=param.name,
-                        declared_type=param.declared_type.name,
+                        declared_type=str(param.declared_type),
                         modifier=param.modifier,
                     )
                     for param in kernel.params
@@ -1473,7 +1541,7 @@ def build_semantic_validator(base_visitor_cls):
                 pure_params = tuple(
                     SemanticKernelParam(
                         name=param.name,
-                        declared_type=param.declared_type.name,
+                        declared_type=str(param.declared_type),
                         modifier="value",
                     )
                     for param in pure.params
@@ -1485,14 +1553,32 @@ def build_semantic_validator(base_visitor_cls):
                 self._pipeline_resource_stack.append({})
                 self._pipeline_bind_usage_stack.append(set())
                 for stream in pipeline.streams:
-                    ctx=self._ctx_from_location(stream.location)
-                    self._declare(stream.name, stream.declared_type.name, ctx, duplicate_code="LCK306", kind="stream")
+                    ctx = self._ctx_from_location(stream.location)
+                    self._declare(
+                        stream.name,
+                        str(stream.declared_type),
+                        ctx,
+                        duplicate_code="LCK306",
+                        kind="stream",
+                    )
                 for accum in pipeline.accumulators:
-                    ctx=self._ctx_from_location(accum.location)
-                    self._declare(accum.name, accum.declared_type.name, ctx, duplicate_code="LCK306", kind="accumulator")
+                    ctx = self._ctx_from_location(accum.location)
+                    self._declare(
+                        accum.name,
+                        str(accum.declared_type),
+                        ctx,
+                        duplicate_code="LCK306",
+                        kind="accumulator",
+                    )
                 for uniform in pipeline.uniforms:
-                    ctx=self._ctx_from_location(uniform.location)
-                    self._declare(uniform.name, uniform.declared_type.name, ctx, duplicate_code="LCK306", kind="uniform")
+                    ctx = self._ctx_from_location(uniform.location)
+                    self._declare(
+                        uniform.name,
+                        str(uniform.declared_type),
+                        ctx,
+                        duplicate_code="LCK306",
+                        kind="uniform",
+                    )
                 self._pipeline_resource_stack.pop()
                 self._pipeline_bind_usage_stack.pop()
                 self._pop_scope()

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -20,7 +20,12 @@ from lockstep_compiler.ast import (
     AstExprCast,
     AstExprLiteral,
     AstExprVar,
+    AstKernelParam,
+    AstProgram,
+    AstPureDecl,
     AstReturnStmt,
+    AstType,
+    AstTypeArraySuffix,
     AstVarDeclStmt,
 )
 import pytest
@@ -112,7 +117,10 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
     assert result.entities["fused_bind_groups"] == []
 
     assert result.llvm_ir.startswith('; ModuleID = "lockstep"\n')
-    assert 'define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")' in result.llvm_ir
+    assert (
+        'define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")'
+        in result.llvm_ir
+    )
 
 
 def test_compile_lockstep_surfaces_typed_ast_type_error_without_legacy_fallback(
@@ -345,10 +353,7 @@ def test_emit_llvm_ir_generates_expected_declarations():
     assert 'define float @"pure_demo"()' in llvm_ir
     assert 'define void @"shader_ApplyGravity"()' in llvm_ir
     assert 'define void @"filter_Cull"()' in llvm_ir
-    assert (
-        'define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")'
-        in llvm_ir
-    )
+    assert 'define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")' in llvm_ir
     assert "; bind: out = ApplyGravity(inp, out, energy, dt);" in llvm_ir
     assert 'declare float @"llvm.maxnum.f32"(float %".1", float %".2")' in llvm_ir
     assert 'declare float @"llvm.minnum.f32"(float %".1", float %".2")' in llvm_ir
@@ -710,8 +715,6 @@ def test_emit_llvm_ir_keeps_integer_arithmetic_in_integer_domain():
     assert "fadd float" not in llvm_ir
 
 
-
-
 def test_emit_llvm_ir_lowers_select_builtin_for_integers():
     llvm_ir = emit_llvm_ir(
         {
@@ -795,7 +798,12 @@ def test_emit_llvm_ir_lowers_select_builtin_for_structs():
         }
     )
 
-    assert 'i1 %"condition_val", %"struct.Pair" %"a_val", %"struct.Pair" %"b_val"' in llvm_ir
+    assert (
+        'i1 %"condition_val", %"struct.Pair" %"a_val", %"struct.Pair" %"b_val"'
+        in llvm_ir
+    )
+
+
 def test_emit_llvm_ir_defaults_target_triple_and_simd_width_for_fold_reduce():
     llvm_ir = emit_llvm_ir(
         {
@@ -879,7 +887,10 @@ def test_emit_llvm_ir_lowers_fold_routes_to_vector_reduce_intrinsics():
 
     assert 'call fast float @"llvm.vector.reduce.fadd.v8f32"' in llvm_ir
     assert '%"struct.Lockstep_Arena" = type {[8 x i8]}' in llvm_ir
-    assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 0, i32 4' in llvm_ir
+    assert (
+        'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 0, i32 4'
+        in llvm_ir
+    )
 
 
 def test_emit_llvm_ir_honors_explicit_target_width_override():
@@ -1072,7 +1083,9 @@ def test_emit_c_header_generates_structs_offsets_and_tick_signature():
 
 
 def test_emit_c_header_honors_target_width_override_macro():
-    header = emit_c_header({"streams": [], "accumulators": [], "uniforms": []}, target_width=16)
+    header = emit_c_header(
+        {"streams": [], "accumulators": [], "uniforms": []}, target_width=16
+    )
     assert "#define LOCKSTEP_SIMD_WIDTH 16" in header
 
 
@@ -1386,7 +1399,9 @@ def test_compile_lockstep_enforces_parse_timeout(monkeypatch):
         lambda: (StubLexer, StubParser, StubVisitor),
     )
     monotonic_values = iter([0.0, 0.002])
-    monkeypatch.setattr(compiler_module.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(
+        compiler_module.time, "monotonic", lambda: next(monotonic_values)
+    )
 
     with pytest.raises(lockstep_compiler.LockstepCompileError) as exc_info:
         lockstep_compiler.compile_lockstep(
@@ -1396,6 +1411,7 @@ def test_compile_lockstep_enforces_parse_timeout(monkeypatch):
 
     assert exc_info.value.phase == "parse"
     assert exc_info.value.errors[0].code == "LCK004"
+
 
 def test_codegen_uses_unsigned_ops_for_uint_math():
     source = """
@@ -1441,3 +1457,41 @@ def test_codegen_uses_unsigned_ops_for_uint_struct_fields():
     assert "udiv i32" in llvm_ir
     assert "urem i32" in llvm_ir
     assert "icmp ult i32" in llvm_ir
+
+
+def test_emit_llvm_ir_preserves_multidimensional_local_array_layouts():
+    llvm_ir = emit_llvm_ir(
+        AstProgram(
+            pure_functions=(
+                AstPureDecl(
+                    name="demo_array_layout",
+                    return_type=AstType("float", kind="primitive"),
+                    params=(
+                        AstKernelParam(
+                            modifier="in",
+                            declared_type=AstType("float", kind="primitive"),
+                            name="value",
+                        ),
+                    ),
+                    body=(
+                        AstVarDeclStmt(
+                            declared_type=AstType(
+                                "float",
+                                kind="primitive",
+                                suffixes=(
+                                    AstTypeArraySuffix(2),
+                                    AstTypeArraySuffix(3),
+                                ),
+                            ),
+                            name="grid",
+                            initializer=None,
+                        ),
+                        AstReturnStmt(value=AstExprVar(path=("value",))),
+                    ),
+                ),
+            )
+        )
+    )
+
+    assert '%"grid" = alloca [2 x [3 x float]]' in llvm_ir
+    assert "store [2 x [3 x float]] zeroinitializer" in llvm_ir


### PR DESCRIPTION
### Motivation

- The parser/grammar permits composite types with array (`[N]`) and generic (`<T,arity?>`) suffixes but the LLVM lowering treated declared types as plain strings and lost layout information for locals and arrays.
- This resulted in local allocations defaulting to `i8*` and discarded multidimensional array shapes during IR emission.

### Description

- Add AST suffix nodes `AstTypeArraySuffix` and `AstTypeGenericSuffix` and extend `AstType` with a `suffixes` tuple to represent structural type suffixes and preserve their string form via `__str__` in `lockstep_compiler/ast.py`.
- Extend the parser-aware builder to produce `AstType` instances from `typeName` contexts (new `_parse_type_ctx`) and normalize parsed composite types via `parse_type_name` so `AstType` values are canonicalized in the AST.
- Change codegen lowering (`_llvm_type`) to accept `AstType | str`, normalize structural types, resolve base primitive/struct types, and recursively apply suffixes using a new `_apply_type_suffixes` helper that constructs nested `ir.ArrayType` layouts for array suffixes in `lockstep_compiler/codegen.py`.
- Propagate structural `AstType` usage into local variable lowering so allocations and initializers preserve correct multidimensional layouts, and update semantic validation to use the stringified `AstType` when checking declared types (`lockstep_compiler/semantic_validator.py`).
- Add a regression unit test that allocates a `float[2][3]` local and asserts the emitted IR contains `[2 x [3 x float]]` and the `zeroinitializer` store in `tests/test_compiler_api.py`.

### Testing

- Ran `python -m compileall -q lockstep_compiler tests/test_compiler_api.py` which succeeded to ensure module import/build correctness.
- Ran `python -m pytest tests/test_compiler_api.py::test_emit_llvm_ir_preserves_multidimensional_local_array_layouts -q` which passed and validates the nested `ir.ArrayType` emission for locals.
- Executed a small integration check via `compile_lockstep(...)` asserting `'[2 x [3 x float]]'` appears in the generated `llvm_ir` and that the AST holds `float[2][3]`, which succeeded.
- A broader run `python -m pytest tests/test_type_syntax.py tests/test_compiler_api.py -q` still reports failures unrelated to these changes (dependency resolver argument mismatch and existing tick/arena lowering cases), so the change is limited to type representation and lowering and does not resolve those separate failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1db1c127ec8328b37e8fc59f67c991)