### PR TITLE
Support array and template type suffixes in codegen

### DIFF
--- a/lockstep_compiler/ast.py
+++ b/lockstep_compiler/ast.py
@@ -5,29 +5,115 @@ from typing import Any
 
 
 @dataclass(frozen=True)
+class AstTypeSuffix:
+    kind: str
+    size: str | None = None
+    type_arg: "AstType | None" = None
+
+    def __str__(self) -> str:
+        if self.kind == "array":
+            return f"[{self.size}]"
+        if self.kind == "template":
+            size_segment = f",{self.size}" if self.size is not None else ""
+            return f"<{self.type_arg}{size_segment}>"
+        return ""
+
+
+@dataclass(frozen=True)
 class AstType:
     name: str
     kind: str = "named"
+    suffixes: tuple[AstTypeSuffix, ...] = ()
 
     def __str__(self) -> str:
-        return self.name
+        return f"{self.name}{''.join(str(suffix) for suffix in self.suffixes)}"
+
+
+def _parse_type_text(type_text: str) -> AstType:
+    text = type_text.strip()
+    index = 0
+    while index < len(text) and (text[index].isalnum() or text[index] == "_"):
+        index += 1
+    base_name = text[:index] or text
+    suffixes: list[AstTypeSuffix] = []
+
+    def _find_matching(start: int, opener: str, closer: str) -> int:
+        depth = 0
+        for cursor in range(start, len(text)):
+            char = text[cursor]
+            if char == opener:
+                depth += 1
+            elif char == closer:
+                depth -= 1
+                if depth == 0:
+                    return cursor
+        return len(text) - 1
+
+    while index < len(text):
+        char = text[index]
+        if char == "[":
+            end = text.find("]", index + 1)
+            if end < 0:
+                break
+            suffixes.append(AstTypeSuffix(kind="array", size=text[index + 1 : end]))
+            index = end + 1
+            continue
+        if char == "<":
+            end = _find_matching(index, "<", ">")
+            inner = text[index + 1 : end]
+            comma = _split_template_suffix(inner)
+            if comma is None:
+                suffixes.append(
+                    AstTypeSuffix(kind="template", type_arg=_parse_type_text(inner))
+                )
+            else:
+                suffixes.append(
+                    AstTypeSuffix(
+                        kind="template",
+                        type_arg=_parse_type_text(inner[:comma]),
+                        size=inner[comma + 1 :].strip(),
+                    )
+                )
+            index = end + 1
+            continue
+        index += 1
+
+    kind = (
+        "primitive"
+        if not suffixes
+        and base_name in {"int", "float", "bool", "uint", "double", "string"}
+        else "named"
+    )
+    return AstType(name=base_name, kind=kind, suffixes=tuple(suffixes))
+
+
+def _split_template_suffix(inner: str) -> int | None:
+    angle_depth = 0
+    bracket_depth = 0
+    for index, char in enumerate(inner):
+        if char == "<":
+            angle_depth += 1
+        elif char == ">":
+            angle_depth -= 1
+        elif char == "[":
+            bracket_depth += 1
+        elif char == "]":
+            bracket_depth -= 1
+        elif char == "," and angle_depth == 0 and bracket_depth == 0:
+            return index
+    return None
 
 
 def _normalize_type(value: AstType | str) -> AstType:
     if isinstance(value, AstType):
         return value
-    kind = (
-        "primitive"
-        if value in {"int", "float", "bool", "uint", "double", "string"}
-        else "named"
-    )
-    return AstType(name=value, kind=kind)
+    return _parse_type_text(value)
 
 
 def _type_name(value: AstType | str | None) -> str | None:
     if value is None:
         return None
-    return value.name if isinstance(value, AstType) else value
+    return str(value) if isinstance(value, AstType) else value
 
 
 @dataclass(frozen=True)
@@ -282,10 +368,67 @@ class AstBuilder(_AstBuilderMixin):
         self._active_bind_routes: list[AstBindRoute] = []
         self._types: dict[str, AstType] = {}
 
-    def _resolve_type(self, type_name: str) -> AstType:
-        if type_name not in self._types:
-            self._types[type_name] = _normalize_type(type_name)
-        return self._types[type_name]
+    def _resolve_type(self, type_name: AstType | str) -> AstType:
+        ast_type = _normalize_type(type_name)
+        cache_key = str(ast_type)
+        if cache_key not in self._types:
+            self._types[cache_key] = ast_type
+        return self._types[cache_key]
+
+    def _resolve_type_ctx(self, type_ctx: Any) -> AstType:
+        if type_ctx is None:
+            return self._resolve_type("float")
+
+        id_token = self._call(type_ctx, "ID")
+        suffix_ctxs = self._call(type_ctx, "typeSuffix", []) or []
+        if id_token is None or not isinstance(suffix_ctxs, list):
+            return self._resolve_type(type_ctx.getText())
+
+        suffixes: list[AstTypeSuffix] = []
+        for suffix_ctx in suffix_ctxs:
+            text = suffix_ctx.getText()
+            if text.startswith("["):
+                int_token = self._call(suffix_ctx, "INT")
+                suffixes.append(
+                    AstTypeSuffix(
+                        kind="array",
+                        size=(
+                            int_token.getText() if int_token is not None else text[1:-1]
+                        ),
+                    )
+                )
+                continue
+
+            nested_types = self._call(suffix_ctx, "typeName", []) or []
+            if not isinstance(nested_types, list):
+                nested_types = [nested_types]
+            nested_type = (
+                self._resolve_type_ctx(nested_types[0])
+                if nested_types
+                else self._resolve_type("void")
+            )
+            int_token = self._call(suffix_ctx, "INT")
+            suffixes.append(
+                AstTypeSuffix(
+                    kind="template",
+                    type_arg=nested_type,
+                    size=int_token.getText() if int_token is not None else None,
+                )
+            )
+
+        return self._resolve_type(
+            AstType(
+                name=id_token.getText(),
+                kind=(
+                    "primitive"
+                    if not suffixes
+                    and id_token.getText()
+                    in {"int", "float", "bool", "uint", "double", "string"}
+                    else "named"
+                ),
+                suffixes=tuple(suffixes),
+            )
+        )
 
     def _parse_params(self, param_list_ctx: Any) -> tuple[AstKernelParam, ...]:
         if param_list_ctx is None:
@@ -294,7 +437,7 @@ class AstBuilder(_AstBuilderMixin):
         params: list[AstKernelParam] = []
         for param in params_ctx:
             modifier = param.getChild(0).getText()
-            declared_type = self._resolve_type(self._call(param, "typeName").getText())
+            declared_type = self._resolve_type_ctx(self._call(param, "typeName"))
             name = self._call(param, "ID").getText()
             params.append(
                 AstKernelParam(
@@ -375,9 +518,7 @@ class AstBuilder(_AstBuilderMixin):
                 and ctx.getChild(2).getText() == ")"
             ):
                 return AstExprCast(
-                    target_type=self._resolve_type(
-                        self._call(ctx, "typeName").getText()
-                    ),
+                    target_type=self._resolve_type_ctx(self._call(ctx, "typeName")),
                     value=self.visit(nested),
                 )
             return AstExprUnary(
@@ -487,9 +628,7 @@ class AstBuilder(_AstBuilderMixin):
         members = self._call(ctx, "structMember", []) or []
         fields = tuple(
             AstStructField(
-                declared_type=self._resolve_type(
-                    self._call(member, "typeName").getText()
-                ),
+                declared_type=self._resolve_type_ctx(self._call(member, "typeName")),
                 name=self._call(member, "ID").getText(),
                 location=AstLocation(
                     line=getattr(
@@ -523,14 +662,14 @@ class AstBuilder(_AstBuilderMixin):
                 params.append(
                     AstKernelParam(
                         modifier="in",
-                        declared_type=self._resolve_type(declared_type.getText()),
+                        declared_type=self._resolve_type_ctx(declared_type),
                         name=name.getText(),
                     )
                 )
         self._pure_functions.append(
             AstPureDecl(
                 name=id_token.getText(),
-                return_type=self._resolve_type(self._call(ctx, "typeName").getText()),
+                return_type=self._resolve_type_ctx(self._call(ctx, "typeName")),
                 params=tuple(params),
                 body=self._parse_statement_text(ctx),
                 location=self._location(ctx),
@@ -589,7 +728,7 @@ class AstBuilder(_AstBuilderMixin):
         self._active_streams.append(
             AstStreamDecl(
                 name=self._call(ctx, "ID").getText(),
-                declared_type=self._resolve_type(self._call(ctx, "typeName").getText()),
+                declared_type=self._resolve_type_ctx(self._call(ctx, "typeName")),
                 capacity=self._call(ctx, "INT").getText(),
                 location=self._location(ctx),
             )
@@ -600,7 +739,7 @@ class AstBuilder(_AstBuilderMixin):
         self._active_accumulators.append(
             AstAccumulatorDecl(
                 name=self._call(ctx, "ID").getText(),
-                declared_type=self._resolve_type(self._call(ctx, "typeName").getText()),
+                declared_type=self._resolve_type_ctx(self._call(ctx, "typeName")),
                 location=self._location(ctx),
             )
         )
@@ -611,7 +750,7 @@ class AstBuilder(_AstBuilderMixin):
         self._active_uniforms.append(
             AstUniformDecl(
                 name=self._call(ctx, "ID").getText(),
-                declared_type=self._resolve_type(self._call(ctx, "typeName").getText()),
+                declared_type=self._resolve_type_ctx(self._call(ctx, "typeName")),
                 initializer=expr_ctx.getText() if expr_ctx else None,
                 location=self._location(ctx),
             )
@@ -627,9 +766,7 @@ class AstBuilder(_AstBuilderMixin):
                 self._active_bind_routes.append(
                     AstFoldBindRoute(
                         uniform_type=(
-                            self._resolve_type(
-                                self._call(bind_stmt, "typeName").getText()
-                            )
+                            self._resolve_type_ctx(self._call(bind_stmt, "typeName"))
                             if self._call(bind_stmt, "typeName")
                             else self._resolve_type("float")
                         ),
@@ -643,7 +780,9 @@ class AstBuilder(_AstBuilderMixin):
                 continue
 
             if len(id_tokens) >= 2:
-                arg_tokens = self._call(self._call(bind_stmt, "argList"), "ID", []) or []
+                arg_tokens = (
+                    self._call(self._call(bind_stmt, "argList"), "ID", []) or []
+                )
                 if not isinstance(arg_tokens, list):
                     arg_tokens = [arg_tokens]
                 self._active_bind_routes.append(

--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -23,6 +23,7 @@ from .ast import (
     AstType,
     AstUniformDecl,
     AstVarDeclStmt,
+    _normalize_type,
 )
 from .arena_layout import build_ast_arena_layout
 from .utils import sanitize_symbol as _sanitize_symbol
@@ -42,7 +43,7 @@ class CodegenError(RuntimeError):
 
 
 def _type_name(value: AstType | str) -> str:
-    return value.name if isinstance(value, AstType) else value
+    return str(value) if isinstance(value, AstType) else value
 
 
 class _FunctionLowerer:
@@ -271,13 +272,36 @@ class _FunctionLowerer:
         )
 
     def _llvm_type(
-        self, type_name: str, known_structs: dict[str, ir.IdentifiedStructType]
+        self,
+        type_name: AstType | str,
+        known_structs: dict[str, ir.IdentifiedStructType],
     ) -> ir.Type:
-        if type_name in _PRIMITIVE_TYPE_MAP:
-            return _PRIMITIVE_TYPE_MAP[type_name]
-        if type_name in known_structs:
-            return known_structs[type_name]
-        return ir.IntType(8).as_pointer()
+        ast_type = _normalize_type(type_name)
+        if any(suffix.kind == "template" for suffix in ast_type.suffixes):
+            return ir.IntType(8).as_pointer()
+
+        if ast_type.name in _PRIMITIVE_TYPE_MAP:
+            llvm_type = _PRIMITIVE_TYPE_MAP[ast_type.name]
+        elif ast_type.name in known_structs:
+            llvm_type = known_structs[ast_type.name]
+        else:
+            llvm_type = ir.IntType(8).as_pointer()
+
+        for suffix in reversed(ast_type.suffixes):
+            if suffix.kind != "array":
+                continue
+            try:
+                element_count = int(suffix.size or "0")
+            except ValueError:
+                self._compiler_error(
+                    f"array type '{ast_type}' has a non-integer element count"
+                )
+            if element_count < 0:
+                self._compiler_error(
+                    f"array type '{ast_type}' has a negative element count"
+                )
+            llvm_type = ir.ArrayType(llvm_type, element_count)
+        return llvm_type
 
     def _emit_numeric_unary_minus(self, value: ir.Value) -> ir.Value:
         if isinstance(value.type, (ir.FloatType, ir.DoubleType)):
@@ -709,7 +733,7 @@ def _kernel_param_llvm_type(
     param: AstKernelParam,
     known_structs: dict[str, ir.IdentifiedStructType],
 ) -> ir.Type:
-    param_type = lowerer._llvm_type(_kernel_param_type(param), known_structs)
+    param_type = lowerer._llvm_type(param.declared_type, known_structs)
     if param.modifier in {"out", "accum"}:
         return param_type.as_pointer()
     return param_type
@@ -755,11 +779,11 @@ def emit_llvm_ir(program: AstProgram, *, target_width: int | None = None) -> str
             field_types: list[ir.Type] = []
             can_lower = True
             for field in struct_fields[struct_name]:
-                field_type_name = _type_name(field.declared_type)
-                if field_type_name in known_structs and field_type_name in unresolved:
+                field_type = field.declared_type
+                if field_type.name in known_structs and field_type.name in unresolved:
                     can_lower = False
                     break
-                field_types.append(lowerer._llvm_type(field_type_name, known_structs))
+                field_types.append(lowerer._llvm_type(field_type, known_structs))
             if not can_lower:
                 continue
             if known_structs[struct_name].is_opaque:
@@ -774,9 +798,9 @@ def emit_llvm_ir(program: AstProgram, *, target_width: int | None = None) -> str
 
     function_map: dict[str, ir.Function] = {}
     for pure in pure_functions:
-        ret_ty = lowerer._llvm_type(_type_name(pure.return_type), known_structs)
+        ret_ty = lowerer._llvm_type(pure.return_type, known_structs)
         params = [
-            lowerer._llvm_type(_kernel_param_type(param), known_structs)
+            lowerer._llvm_type(param.declared_type, known_structs)
             for param in pure.params
         ]
         fn = ir.Function(

--- a/lockstep_compiler/semantic_validator.py
+++ b/lockstep_compiler/semantic_validator.py
@@ -562,7 +562,7 @@ def build_semantic_validator(base_visitor_cls):
                             continue
                         seen_field_names.add(field.name)
                         fields[field.name] = SemanticStructField(
-                            name=field.name, declared_type=field.declared_type.name
+                            name=field.name, declared_type=str(field.declared_type)
                         )
                     self.structs[struct.name] = fields
 
@@ -571,7 +571,7 @@ def build_semantic_validator(base_visitor_cls):
                     params = [
                         SemanticKernelParam(
                             name=param.name,
-                            declared_type=param.declared_type.name,
+                            declared_type=str(param.declared_type),
                             modifier=param.modifier,
                         )
                         for param in shader.params
@@ -592,7 +592,7 @@ def build_semantic_validator(base_visitor_cls):
                     params = [
                         SemanticKernelParam(
                             name=param.name,
-                            declared_type=param.declared_type.name,
+                            declared_type=str(param.declared_type),
                             modifier=param.modifier,
                         )
                         for param in filter_decl.params
@@ -1382,7 +1382,7 @@ def build_semantic_validator(base_visitor_cls):
                     return
                 if isinstance(expr, AstExprCast):
                     cast_ctx = self._ctx_from_location(getattr(expr, "location", None))
-                    self._validate_declared_type(expr.target_type.name, cast_ctx, "LCK310")
+                    self._validate_declared_type(str(expr.target_type), cast_ctx, "LCK310")
                     _validate_ast_expr(expr.value)
 
             def _validate_ast_statement(statement: AstStatement):
@@ -1390,12 +1390,12 @@ def build_semantic_validator(base_visitor_cls):
                 if isinstance(statement, AstVarDeclStmt):
                     if statement.declared_type is not None:
                         self._validate_declared_type(
-                            statement.declared_type.name, stmt_ctx, "LCK310"
+                            str(statement.declared_type), stmt_ctx, "LCK310"
                         )
                     if statement.initializer is not None:
                         _validate_ast_expr(statement.initializer)
                     declared_type_name = (
-                        statement.declared_type.name if statement.declared_type else "unknown"
+                        str(statement.declared_type) if statement.declared_type else "unknown"
                     )
                     self._declare(
                         statement.name,
@@ -1445,25 +1445,25 @@ def build_semantic_validator(base_visitor_cls):
                     if field.name in fields:
                         self._add_diagnostic(severity="error", code=SEMANTIC_DIAGNOSTIC_CODES["duplicate_struct_field"], message=f"Struct '{struct.name}' has duplicate field declaration '{field.name}'.", ctx=field_ctx, hint="Rename or remove duplicate struct member declarations.")
                         continue
-                    fields[field.name]=SemanticStructField(name=field.name, declared_type=field.declared_type.name)
+                    fields[field.name]=SemanticStructField(name=field.name, declared_type=str(field.declared_type))
                 self.structs[struct.name]=fields
 
             for collection, target in ((program.shaders, self.shaders), (program.filters, self.filters)):
                 for kernel in collection:
                     kctx=self._ctx_from_location(kernel.location)
-                    params=[SemanticKernelParam(name=p.name, declared_type=p.declared_type.name, modifier=p.modifier) for p in kernel.params]
+                    params=[SemanticKernelParam(name=p.name, declared_type=str(p.declared_type), modifier=p.modifier) for p in kernel.params]
                     if kernel.name in target:
                         self._add_diagnostic(severity="error", code=SEMANTIC_DIAGNOSTIC_CODES["duplicate_kernel_declaration"], message=f"Duplicate shader/filter declaration for '{kernel.name}'.", ctx=kctx, hint="Rename one declaration to avoid symbol collisions.")
                     else:
                         target[kernel.name]=params
 
             for pure in program.pure_functions:
-                self.pure_functions[pure.name]=SemanticPureFunctionSignature(return_type=pure.return_type.name, params=tuple(SemanticKernelParam(name=p.name, declared_type=p.declared_type.name, modifier="value") for p in pure.params), intrinsic=pure.intrinsic)
+                self.pure_functions[pure.name]=SemanticPureFunctionSignature(return_type=str(pure.return_type), params=tuple(SemanticKernelParam(name=p.name, declared_type=str(p.declared_type), modifier="value") for p in pure.params), intrinsic=pure.intrinsic)
             for kernel in (*program.shaders, *program.filters):
                 kernel_params = tuple(
                     SemanticKernelParam(
                         name=param.name,
-                        declared_type=param.declared_type.name,
+                        declared_type=str(param.declared_type),
                         modifier=param.modifier,
                     )
                     for param in kernel.params
@@ -1473,7 +1473,7 @@ def build_semantic_validator(base_visitor_cls):
                 pure_params = tuple(
                     SemanticKernelParam(
                         name=param.name,
-                        declared_type=param.declared_type.name,
+                        declared_type=str(param.declared_type),
                         modifier="value",
                     )
                     for param in pure.params
@@ -1486,13 +1486,13 @@ def build_semantic_validator(base_visitor_cls):
                 self._pipeline_bind_usage_stack.append(set())
                 for stream in pipeline.streams:
                     ctx=self._ctx_from_location(stream.location)
-                    self._declare(stream.name, stream.declared_type.name, ctx, duplicate_code="LCK306", kind="stream")
+                    self._declare(stream.name, str(stream.declared_type), ctx, duplicate_code="LCK306", kind="stream")
                 for accum in pipeline.accumulators:
                     ctx=self._ctx_from_location(accum.location)
-                    self._declare(accum.name, accum.declared_type.name, ctx, duplicate_code="LCK306", kind="accumulator")
+                    self._declare(accum.name, str(accum.declared_type), ctx, duplicate_code="LCK306", kind="accumulator")
                 for uniform in pipeline.uniforms:
                     ctx=self._ctx_from_location(uniform.location)
-                    self._declare(uniform.name, uniform.declared_type.name, ctx, duplicate_code="LCK306", kind="uniform")
+                    self._declare(uniform.name, str(uniform.declared_type), ctx, duplicate_code="LCK306", kind="uniform")
                 self._pipeline_resource_stack.pop()
                 self._pipeline_bind_usage_stack.pop()
                 self._pop_scope()

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -359,6 +359,38 @@ def test_emit_llvm_ir_generates_expected_declarations():
     assert "uitofp i1" in llvm_ir
 
 
+def test_emit_llvm_ir_lowers_array_type_suffixes_for_local_allocas():
+    llvm_ir = emit_llvm_ir(
+        AstProgram(
+            pure_functions=(
+                AstPureDecl(
+                    name="array_local",
+                    return_type="float",
+                    body=(
+                        AstVarDeclStmt(
+                            declared_type="float[2][3]",
+                            name="matrix",
+                            initializer=None,
+                        ),
+                        AstReturnStmt(value=AstExprLiteral(kind="float", value="1.0")),
+                    ),
+                ),
+            ),
+        )
+    )
+
+    assert "alloca [2 x [3 x float]]" in llvm_ir
+
+
+def test_compile_lockstep_preserves_array_type_suffixes_in_codegen():
+    result = lockstep_compiler.compile_lockstep(
+        "pure float array_local(){ float[2][3] matrix; return 1.0; }",
+        verbose=False,
+    )
+
+    assert "alloca [2 x [3 x float]]" in result.llvm_ir
+
+
 def test_emit_llvm_ir_rejects_assignment_to_undeclared_local():
     program = AstProgram(
         pure_functions=(


### PR DESCRIPTION
### Motivation
- The parser grammar permits type suffixes like arrays (`T[4]`) and templates (`Ctor<T>`), but the lowering helper ` _llvm_type` treated type names as plain strings and fell back to `i8*`, losing layout information for arrays.
- The change aims to preserve structural type information from the AST and lower multidimensional array suffixes into real LLVM `ir.ArrayType` layouts for local allocas and other uses.

### Description
- Added `AstTypeSuffix` and extended `AstType` with a `suffixes` field, plus parsing helpers `_parse_type_text` and `_normalize_type` to model array and template suffixes. 
- Updated AST construction to capture suffixes from parse-tree contexts via `AstBuilder._resolve_type_ctx` so `AstType` instances carry array/template structure instead of plain strings. 
- Reworked ` _llvm_type` to accept `AstType | str`, normalize it, map templates to fallback pointers, and recursively wrap element types with `ir.ArrayType` for array suffixes. 
- Adjusted call sites to pass `AstType` values through codegen (params, struct fields, pure signatures), preserved rendered suffixed type names with `str(...)` for validators and diagnostics, and added a regression test exercising multidimensional local `alloca`s.

### Testing
- Ran `pytest -q tests/test_compiler_api.py::test_emit_llvm_ir_lowers_array_type_suffixes_for_local_allocas`, which passed after the changes. 
- Ran `pytest -q tests/test_compiler_api.py::test_compile_lockstep_preserves_array_type_suffixes_in_codegen`, which passed and verifies the end-to-end `compile_lockstep` output contains `alloca [2 x [3 x float]]`.
- Ran `pytest -q tests/test_compiler_api.py::test_emit_llvm_ir_accepts_ast_program_input` and `pytest -q tests/test_lockstep_compiler_api.py::test_visitor_methods_print_expected_output`, both of which passed.
- Note: an initial run of `test_emit_llvm_ir_generates_expected_declarations` failed before these changes, and subsequent targeted test runs all succeeded after the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1db95d50808328bb84b74aff4d8b0a)