### PR TITLE
Fix arena leaf pointer byte offsets and replace struct GEPs with byte-pointer GEP in _leaf_ptr

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -920,8 +920,6 @@ def emit_llvm_ir(
     arena_struct_ty = module.context.get_identified_type("struct.Lockstep_Arena")
 
     arena_field_types: list[ir.Type] = []
-    leaf_field_indices: dict[tuple[str, str, tuple[str, ...]], int] = {}
-    leaf_field_is_array: dict[tuple[str, str, tuple[str, ...]], bool] = {}
     for leaf in layout.leaves:
         if leaf.type_name in _PRIMITIVE_TYPE_MAP:
             field_ty = _PRIMITIVE_TYPE_MAP[leaf.type_name]
@@ -933,14 +931,10 @@ def emit_llvm_ir(
         else:
             field_ty = ir.ArrayType(ir.IntType(8), max(leaf.size, 1))
 
-        leaf_key = (leaf.kind, leaf.binding_name, leaf.path)
-        leaf_field_indices[leaf_key] = len(arena_field_types)
         if leaf.element_count > 1:
             arena_field_types.append(ir.ArrayType(field_ty, max(leaf.element_count, 1)))
-            leaf_field_is_array[leaf_key] = True
         else:
             arena_field_types.append(field_ty)
-            leaf_field_is_array[leaf_key] = False
 
     if not arena_field_types:
         arena_field_types = [ir.ArrayType(ir.IntType(8), 1)]
@@ -979,30 +973,35 @@ def emit_llvm_ir(
         leaf_key = (kind, name, path)
         if leaf_key not in leaf_specs:
             return None
-        field_index = leaf_field_indices.get(leaf_key)
-        if field_index is None:
-            return None
-
-        gep_indices = [
-            ir.Constant(ir.IntType(32), 0),
-            ir.Constant(ir.IntType(32), field_index),
-        ]
-        if leaf_field_is_array.get(leaf_key, False):
-            element_index = (
-                loop_index_reg
-                if kind in {"stream", "accum"} and loop_index_reg is not None
-                else ir.Constant(ir.IntType(32), 0)
+        leaf_offset, leaf_size = leaf_specs[leaf_key]
+        byte_offset: ir.Value = ir.Constant(ir.IntType(32), leaf_offset)
+        if kind in {"stream", "accum"} and loop_index_reg is not None:
+            index_type = loop_index_reg.type
+            if isinstance(index_type, ir.IntType) and index_type != byte_offset.type:
+                byte_offset = ir.Constant(index_type, leaf_offset)
+            stride = ir.Constant(byte_offset.type, leaf_size)
+            scaled_index = tick_builder.mul(
+                loop_index_reg,
+                stride,
+                name=f"{kind}_{_sanitize_symbol(name)}_byte_index",
             )
-            gep_indices.append(element_index)
+            byte_offset = tick_builder.add(
+                byte_offset,
+                scaled_index,
+                name=f"{kind}_{_sanitize_symbol(name)}_byte_offset",
+            )
 
-        raw_ptr = tick_builder.gep(
+        bytes_ptr = tick_builder.bitcast(
             arena_ptr,
-            gep_indices,
-            name=f"{kind}_{_sanitize_symbol(name)}_{'_'.join(path) if path else 'value'}_ptr",
+            ir.IntType(8).as_pointer(),
+            name=f"{kind}_{_sanitize_symbol(name)}_arena_bytes",
         )
-        if raw_ptr.type.pointee == leaf_type:
-            return raw_ptr
-        typed_ptr = tick_builder.bitcast(raw_ptr, leaf_type.as_pointer())
+        leaf_byte_addr = tick_builder.gep(
+            bytes_ptr,
+            [byte_offset],
+            name=f"{kind}_{_sanitize_symbol(name)}_{'_'.join(path) if path else 'value'}_byte_ptr",
+        )
+        typed_ptr = tick_builder.bitcast(leaf_byte_addr, leaf_type.as_pointer())
         if typed_ptr.type.pointee != leaf_type:
             return None
         return typed_ptr

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -696,6 +696,10 @@ def test_emit_llvm_ir_accepts_ast_program_input():
 
     assert "route_ApplyGravity_cond" in llvm_ir
     assert 'icmp slt i32 %"idx", 2' in llvm_ir
+    assert '%"stream_inp_arena_bytes" = bitcast %"struct.Lockstep_Arena"* %"arena" to i8*' in llvm_ir
+    assert '%"stream_inp_value_byte_ptr" = getelementptr i8, i8* %"stream_inp_arena_bytes", i32 %"stream_inp_byte_offset"' in llvm_ir
+    assert 'bitcast i8* %"stream_inp_value_byte_ptr" to float*' in llvm_ir
+    assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 0' not in llvm_ir
 
 
 def test_emit_llvm_ir_lowers_kernel_bind_routes_into_counted_loops():


### PR DESCRIPTION
### Motivation

- The previous `_leaf_ptr` computed pointers using `getelementptr` into a packed `struct.Lockstep_Arena` field, which interpreted the layout field as a typed element array and scaled offsets by the first field's element size, producing warped addresses and potential out-of-bounds memory access.
- The intent of the change is to compute absolute byte addresses from arena layout metadata and perform byte-addressed pointer arithmetic so GEP calculations are correct and independent of the compiled per-field types.

### Description

- Reworked `_leaf_ptr` to read `(offset, size)` from `leaf_specs`, compute a byte offset `byte_offset`, and when indexing streams/accums scale the loop index by the leaf byte `size` before adding it to the base offset.
- Cast the arena pointer to a raw byte pointer (`i8*`), perform a single-index `getelementptr` with the computed `byte_offset`, and then `bitcast` the resulting `i8*` back to the requested `leaf_type*`.
- Removed obsolete bookkeeping (`leaf_field_indices` and `leaf_field_is_array`) and the old multi-index, typed struct `gep` usage that caused scaling by a field element width.
- Updated a unit test to assert the emitted IR now contains the `bitcast` to `i8*`, a single-index byte `getelementptr`, and the subsequent `bitcast` back to the leaf pointer type while ensuring the old struct-field `getelementptr` pattern is not emitted.

### Testing

- Ran `python -m py_compile lockstep_compiler/codegen.py tests/test_compiler_api.py`, which succeeded.
- Ran `python -m pytest tests/test_compiler_api.py::test_emit_llvm_ir_accepts_ast_program_input -q`, which succeeded and validated the new byte-pointer addressing IR emission.
- Ran the full `python -m pytest tests/test_compiler_api.py -q`, which surfaced unrelated existing suite failures (dictionary-style inputs to `emit_llvm_ir` now rejected in favor of `AstProgram` and `emit_c_header` treating `LayoutStructDecl` as non-subscriptable); these failures are not caused by the `_leaf_ptr` pointer arithmetic fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e2b30cad88328afa96b4c9fe972b7)