### PR TITLE
Remove unreachable local var type inference from visitVarDecl

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,9 +34,9 @@ The entity dict's `body` field (which contains statement text like `"new_pos.x =
 
 The remaining half of the semantic validator migration: `_resolve_expr_type` is rewritten to operate on the `AstExpr` discriminated union (`AstExprLiteral | AstExprVar | AstExprUnary | AstExprBinary | AstExprCall | AstExprCast`) using `isinstance` dispatch. This eliminates the `hasattr(ctx, 'mulExpr')` / `hasattr(ctx, 'bitwiseOrExpr')` pattern-matching on ANTLR context shapes, roughly halving the validator's line count and making it testable without constructing fake parse-tree nodes.
 
-### Exhaustive type inference for local variables
+### Explicit local variable declarations
 
-The current type inference for locals (`LCK423` when inference fails) is extended to propagate types through expression trees. If a variable is initialized with `mix(a, b, 0.5)` and `mix` is a known intrinsic returning `float`, the declared type is inferred as `float` without requiring an explicit annotation. This is a quality-of-life improvement that reduces boilerplate in shader bodies without weakening the strict type matching policy.
+Local variable declarations remain aligned with the grammar's `varDecl: typeName ID ('=' expr)? ';';` rule: every local declaration carries an explicit type annotation, and initializers are validated against that declared type. Editor tooling may still surface inferred hover information for already-declared variables, but the core language does not accept untyped local allocations.
 
 ### `uint` and `double` as first-class declared types
 

--- a/lockstep_compiler/semantic_validator.py
+++ b/lockstep_compiler/semantic_validator.py
@@ -974,44 +974,10 @@ def build_semantic_validator(base_visitor_cls):
                     )
 
         def visitVarDecl(self, ctx):
-            type_ctx = (
-                ctx.typeName()
-                if hasattr(ctx, "typeName") and callable(ctx.typeName)
-                else None
-            )
-            declared_type = type_ctx.getText() if type_ctx is not None else None
+            type_ctx = ctx.typeName()
+            declared_type = type_ctx.getText()
             symbol_name = ctx.ID().getText()
-            if declared_type is not None:
-                self._validate_declared_type(declared_type, type_ctx, "LCK310")
-
-            if declared_type is None:
-                existing_symbol = self._lookup(symbol_name)
-                if existing_symbol is not None:
-                    has_initializer = (
-                        hasattr(ctx, "expr")
-                        and callable(ctx.expr)
-                        and ctx.expr() is not None
-                    )
-                    if has_initializer:
-                        initializer_type = self._resolve_expr_type(ctx.expr())
-                        if (
-                            initializer_type is not None
-                            and existing_symbol.declared_type != initializer_type
-                        ):
-                            self._add_diagnostic(
-                                severity="error",
-                                code=SEMANTIC_DIAGNOSTIC_CODES[
-                                    "assignment_type_mismatch"
-                                ],
-                                message=(
-                                    "Type mismatch in assignment: "
-                                    f"left-hand side expects {existing_symbol.declared_type}, got {initializer_type}."
-                                ),
-                                ctx=ctx,
-                                hint="Assign expressions whose type matches the lvalue declaration.",
-                            )
-                    self._mark_symbol_used(symbol_name)
-                    return self.visitChildren(ctx)
+            self._validate_declared_type(declared_type, type_ctx, "LCK310")
 
             has_initializer = (
                 hasattr(ctx, "expr") and callable(ctx.expr) and ctx.expr() is not None
@@ -1019,20 +985,6 @@ def build_semantic_validator(base_visitor_cls):
             initializer_type = (
                 self._resolve_expr_type(ctx.expr()) if has_initializer else None
             )
-
-            if declared_type is None:
-                if initializer_type is None:
-                    self._add_diagnostic(
-                        severity="error",
-                        code=SEMANTIC_DIAGNOSTIC_CODES["cannot_infer_type"],
-                        message=(
-                            f"Cannot infer type for local variable '{symbol_name}' without a typed initializer."
-                        ),
-                        ctx=ctx,
-                        hint="Provide an explicit type or initialize with an expression whose type can be resolved.",
-                    )
-                    return self.visitChildren(ctx)
-                declared_type = initializer_type
 
             self._declare(
                 symbol_name,

--- a/tests/test_lockstep_compiler_api.py
+++ b/tests/test_lockstep_compiler_api.py
@@ -25,6 +25,7 @@ from lockstep_compiler import (
 )
 from lockstep_compiler.cli import main as cli_main
 
+from lockstep_compiler.ast import AstExprLiteral
 from lockstep_compiler.models import (
     SemanticKernelParam,
     SemanticPureFunctionSignature,
@@ -2090,7 +2091,7 @@ def test_semantic_validator_reports_var_initializer_type_mismatch():
         start_col=1,
         ID=lambda: _token("count"),
         typeName=lambda: _token("int"),
-        expr=lambda: _ctx(declared_type="float"),
+        expr=lambda: AstExprLiteral(kind="float", value="1.0"),
     )
 
     validator.visitVarDecl(var_decl_ctx)
@@ -2103,50 +2104,6 @@ def test_semantic_validator_reports_var_initializer_type_mismatch():
             line=72,
             column=1,
             hint="Use an initializer expression with the same type as the declared variable.",
-        )
-    ]
-
-
-def test_semantic_validator_infers_var_type_from_initializer():
-    validator = LockstepSemanticValidator()
-    validator._push_scope()
-
-    var_decl_ctx = _ctx(
-        ID=lambda: _token("mass"),
-        typeName=lambda: None,
-        expr=lambda: _ctx(declared_type="float"),
-    )
-
-    validator.visitVarDecl(var_decl_ctx)
-
-    assert validator.diagnostics == []
-    assert validator.scopes[-1]["mass"] == SemanticSymbol(
-        name="mass", declared_type="float", kind="local"
-    )
-
-
-def test_semantic_validator_reports_uninferrable_var_type():
-    validator = LockstepSemanticValidator()
-    validator._push_scope()
-
-    var_decl_ctx = _ctx(
-        start_line=72,
-        start_col=8,
-        ID=lambda: _token("mass"),
-        typeName=lambda: None,
-        expr=lambda: None,
-    )
-
-    validator.visitVarDecl(var_decl_ctx)
-
-    assert validator.diagnostics == [
-        LockstepDiagnostic(
-            severity="error",
-            code="LCK423",
-            message="Cannot infer type for local variable 'mass' without a typed initializer.",
-            line=72,
-            column=8,
-            hint="Provide an explicit type or initialize with an expression whose type can be resolved.",
         )
     ]
 


### PR DESCRIPTION
### Motivation
- The grammar mandates `varDecl: typeName ID ('=' expr)? ';'`, so local declarations always include a `typeName` and the branch that handled `declared_type is None` (implicit local type inference) is unreachable and inconsistent with the language spec.
- The roadmap previously described planned untyped local inference which conflicts with the parser; the project should align the roadmap and implementation with the grammar.

### Description
- Simplified `visitVarDecl` in `lockstep_compiler/semantic_validator.py` to always read and validate `ctx.typeName()` and remove the unreachable `declared_type is None` inference/assignment branch so locals require explicit declared types. 
- Kept initializer validation: the initializer expression is still resolved and compared against the explicit declared type, emitting `LCK416` on mismatch. 
- Updated `ROADMAP.md` to replace the planned exhaustive local inference section with text that documents explicit local variable declarations matching the grammar. 
- Removed two tests that targeted unparseable untyped local declarations and adjusted `test_semantic_validator_reports_var_initializer_type_mismatch` to use an `AstExprLiteral` initializer and added the necessary import in `tests/test_lockstep_compiler_api.py`.

### Testing
- Ran `pytest tests/test_lockstep_compiler_api.py::test_semantic_validator_reports_var_initializer_type_mismatch tests/test_type_syntax.py::test_local_var_declaration_requires_explicit_type_annotation -q`, and both tests passed. 
- Ran a broader `pytest tests/test_lockstep_compiler_api.py tests/test_type_syntax.py` run which produced failures unrelated to this change (existing bind/dependency and other semantic tests in the current branch), indicating the change itself did not break the targeted behavior. 
- Verified the updated unit test file and roadmap content compile / import correctly in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eb0d89c888328bbb08de67dc10c65)