### PR TITLE
Fix compiled entities for simulator pipeline

### DIFF
--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -708,7 +708,10 @@ def _compile_lockstep_with_dependencies(
 
     all_diagnostics = normalize_diagnostics(semantic_diagnostics)
 
-    entities = ast_to_entities(typed_ast)
+    # Runtime consumers (for example simulate_pipeline_source) rely on the
+    # compile result carrying the serialized compiler entities, not just the
+    # internal typed AST.
+    runtime_entities = ast_to_entities(typed_ast)
     optimized_bind_routes: list[str] = []
     fused_bind_groups: list[object] = []
     shader_names = {shader.name for shader in typed_ast.shaders}
@@ -751,8 +754,8 @@ def _compile_lockstep_with_dependencies(
         "optimized_bind_routes": optimized_bind_routes,
         "fused_groups": fused_bind_groups,
     }
-    entities = {
-        **entities,
+    runtime_entities = {
+        **runtime_entities,
         "optimized_bind_routes": optimized_bind_routes,
         "fused_bind_groups": fused_bind_groups,
     }
@@ -782,7 +785,7 @@ def _compile_lockstep_with_dependencies(
 
     return LockstepCompileResult(
         parse_tree=tree,
-        entities=entities,
+        entities=runtime_entities,
         ast=typed_ast,
         llvm_ir=llvm_ir,
         c_header=emit_c_header(typed_ast, target_width=target_width),

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -19,7 +19,39 @@ from lockstep_compiler.cli import run_cli
 from lockstep_compiler.simulator import (
     parse_simulation_inputs,
     simulate_pipeline_entities,
+    simulate_pipeline_source,
 )
+
+
+def test_simulate_pipeline_source_uses_compiled_runtime_entities():
+    source = """
+    shader Copy(in float src, out float dst) { dst = src; }
+
+    pipeline P {
+        stream<float, 4> inp;
+        stream<float, 4> dst;
+
+        bind {
+            dst = Copy(inp, dst);
+        }
+    }
+    """
+
+    simulation = simulate_pipeline_source(
+        source,
+        stream_inputs={"inp": [1.0, 2.0]},
+    )
+
+    assert simulation["streams"]["dst"] == [1.0, 2.0]
+    assert simulation["routes"] == [
+        {
+            "route": "dst=Copy(inp,dst);",
+            "kind": "shader",
+            "input_count": 2,
+            "output_count": 2,
+            "notes": None,
+        }
+    ]
 
 
 def test_simulate_pipeline_entities_tracks_route_cardinality_and_fold():


### PR DESCRIPTION
### Motivation
- The simulator entrypoint `simulate_pipeline_source` expected `LockstepCompileResult.entities` to contain the serialized runtime entities, but the compiler path returned an empty or missing entities payload causing the simulator to skip all streams/accumulators/uniforms and become non-functional. 
- The change ensures downstream runtime consumers receive the canonical serialized representation derived from the typed AST so simulations reflect the compiled program.

### Description
- Serialize the typed AST into a runtime entity payload using `ast_to_entities(typed_ast)` and store it in `runtime_entities` before optimization and codegen.
- Merge optimizer metadata (`optimized_bind_routes` and `fused_bind_groups`) into the `runtime_entities` object and return it as `LockstepCompileResult.entities` instead of an empty dict.
- Add a regression test `test_simulate_pipeline_source_uses_compiled_runtime_entities` in `tests/test_simulator.py` that compiles a simple pipeline and asserts the simulator receives the expected routes and stream outputs.

### Testing
- Ran `pytest tests/test_simulator.py::test_simulate_pipeline_source_uses_compiled_runtime_entities tests/test_compiler_api.py::test_compile_lockstep_works_without_passing_parser_classes`, and both tests passed (`2 passed`).
- Ensured the new test verifies `simulate_pipeline_source` uses compiled runtime entities and that other compile-path expectations remain intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eca5879b48328b60de5f9f22bb7c2)