### PR TITLE
Fix LLVM arena stream array fields

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -989,7 +989,7 @@ def emit_llvm_ir(
         else:
             field_ty = ir.ArrayType(ir.IntType(8), max(leaf.size, 1))
 
-        if leaf.element_count > 1:
+        if leaf.kind == "stream" or leaf.element_count > 1:
             arena_field_types.append(ir.ArrayType(field_ty, max(leaf.element_count, 1)))
         else:
             arena_field_types.append(field_ty)

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -702,6 +702,31 @@ def test_emit_llvm_ir_accepts_ast_program_input():
     assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 0' not in llvm_ir
 
 
+def test_emit_llvm_ir_uses_array_field_for_single_capacity_streams():
+    from lockstep_compiler.ast import (
+        AstPipelineDecl,
+        AstProgram,
+        AstStreamDecl,
+        AstUniformDecl,
+    )
+
+    llvm_ir = emit_llvm_ir(
+        AstProgram(
+            pipelines=(
+                AstPipelineDecl(
+                    name="Main",
+                    streams=(
+                        AstStreamDecl(name="inp", declared_type="float", capacity="1"),
+                    ),
+                    uniforms=(AstUniformDecl(name="dt", declared_type="float"),),
+                ),
+            ),
+        )
+    )
+
+    assert '%"struct.Lockstep_Arena" = type {[1 x float], float}' in llvm_ir
+
+
 def test_emit_llvm_ir_lowers_kernel_bind_routes_into_counted_loops():
     llvm_ir = emit_llvm_ir(
         {


### PR DESCRIPTION
### Motivation
- LLVM arena struct fields were generated as scalars for streams, while the C header emitted array fields for streams and multi-capacity blocks, producing an undersized `struct.Lockstep_Arena` and leading to overlapping memory in host usage.

### Description
- Update `lockstep_compiler/codegen.py` to treat stream leaves as arrays by checking `leaf.kind == "stream" or leaf.element_count > 1` and wrapping the field type with `ir.ArrayType(field_ty, leaf.element_count)` when appropriate.
- Add a regression test `test_emit_llvm_ir_uses_array_field_for_single_capacity_streams` in `tests/test_compiler_api.py` that asserts a `stream<float, 1>` yields a `%"struct.Lockstep_Arena"` field like `{"[1 x float]", float}`.

### Testing
- Ran `pytest -q tests/test_compiler_api.py::test_emit_llvm_ir_accepts_ast_program_input tests/test_compiler_api.py::test_emit_llvm_ir_uses_array_field_for_single_capacity_streams` and both tests passed.
- Running the full test suite (`pytest -q`) and a broader run with ignored property tests showed unrelated environment/test-suite issues (missing `hypothesis` and benchmark fixtures) which prevented successful collection; these failures are not caused by the arena field typing change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ecf147b1083288828928483725608)