### PR TITLE
Connect bind route optimizer to compiler

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -1437,9 +1437,7 @@ def emit_llvm_ir(
                 )
             return _load_tick_param("stream", arg_name, param.type, clamped_index)
         if modifier == "accum" and arg_name in accum_slots:
-            return _load_tick_param_ptr(
-                "accum", arg_name, param.type.pointee, current
-            )
+            return _load_tick_param_ptr("accum", arg_name, param.type.pointee, current)
         if modifier == "uniform" and arg_name in uniform_slots:
             return _load_tick_param("uniform", arg_name, param.type)
         return _zero_value(param.type)
@@ -1516,9 +1514,7 @@ def emit_llvm_ir(
             _lower_kernel_route(routes[0])
             return
 
-        index_ptr = tick_builder.alloca(
-            ir.IntType(32), name=f"fused_{group_index}_idx"
-        )
+        index_ptr = tick_builder.alloca(ir.IntType(32), name=f"fused_{group_index}_idx")
         tick_builder.store(ir.Constant(ir.IntType(32), 0), index_ptr)
 
         loop_cond = tick.append_basic_block(f"fused_{group_index}_cond")
@@ -1570,9 +1566,7 @@ def emit_llvm_ir(
                 name=f"fused_lane_{lane}_active",
             )
             lane_body = tick.append_basic_block(f"fused_{group_index}_lane_{lane}")
-            lane_next = tick.append_basic_block(
-                f"fused_{group_index}_lane_{lane}_next"
-            )
+            lane_next = tick.append_basic_block(f"fused_{group_index}_lane_{lane}_next")
             tick_builder.cbranch(lane_active, lane_body, lane_next)
             tick_builder.position_at_end(lane_body)
             _emit_fused_lane(lane_index)
@@ -1597,7 +1591,7 @@ def emit_llvm_ir(
         reduced = _reduce_fold(route.operator, source_name, uniform_type)
         _store_value("uniform", uniform_name, reduced, uniform_type_name)
 
-    for pipeline in program.pipelines:
+    for pipeline_index, pipeline in enumerate(program.pipelines):
         route_texts = [route.route for route in pipeline.bind_routes]
         route_ir = []
         for route in pipeline.bind_routes:
@@ -1623,7 +1617,16 @@ def emit_llvm_ir(
                     }
                 )
 
-        if bind_optimization is not None and len(program.pipelines) == 1:
+        pipeline_optimizations = (
+            bind_optimization.get("pipeline_optimizations")
+            if isinstance(bind_optimization, dict)
+            else None
+        )
+        if isinstance(pipeline_optimizations, list) and len(
+            pipeline_optimizations
+        ) == len(program.pipelines):
+            pipeline_optimization = pipeline_optimizations[pipeline_index]
+        elif bind_optimization is not None and len(program.pipelines) == 1:
             pipeline_optimization = bind_optimization
         else:
             pipeline_optimization = optimize_bind_routes(

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -29,7 +29,6 @@ from .optimizer import optimize_bind_routes
 from .prelude import load_intrinsics
 from .visitors import validate_semantics as _validate_semantics
 
-
 DEFAULT_SOURCE_FILE = "<stdin>"
 DEFAULT_MAX_SOURCE_BYTES = 1_048_576
 DEFAULT_PARSE_TIMEOUT_MS = 2_000
@@ -429,7 +428,9 @@ def _resolve_dependency_sources(
         elif parent_file.startswith("<") and parent_file.endswith(">"):
             resolved_candidate = (base_directory / candidate).resolve()
         else:
-            resolved_candidate = (Path(parent_file).resolve().parent / candidate).resolve()
+            resolved_candidate = (
+                Path(parent_file).resolve().parent / candidate
+            ).resolve()
 
         if canonical_dependency_root is not None:
             try:
@@ -596,6 +597,52 @@ def _remap_diagnostics(
     ]
 
 
+def _bind_route_ir(route: AstKernelBindRoute | AstFoldBindRoute) -> dict[str, object]:
+    if isinstance(route, AstKernelBindRoute):
+        return {
+            "kind": "kernel",
+            "target": route.target,
+            "kernel": route.kernel,
+            "args": list(route.args),
+            "route": route.route,
+        }
+    return {
+        "kind": "fold",
+        "uniform_type": route.uniform_type.name,
+        "uniform_name": route.uniform_name,
+        "operator": route.operator,
+        "source": route.source,
+        "route": route.route,
+    }
+
+
+def _build_bind_optimization(program: AstProgram) -> dict[str, object]:
+    optimized_bind_routes: list[str] = []
+    fused_bind_groups: list[object] = []
+    pipeline_optimizations: list[dict[str, list]] = []
+    shader_names = {shader.name for shader in program.shaders}
+    filter_names = {flt.name for flt in program.filters}
+
+    for pipeline in program.pipelines:
+        pipeline_routes = [route.route for route in pipeline.bind_routes]
+        pipeline_route_ir = [_bind_route_ir(route) for route in pipeline.bind_routes]
+        pipeline_optimization = optimize_bind_routes(
+            pipeline_routes,
+            shader_names=shader_names,
+            filter_names=filter_names,
+            bind_routes_ir=pipeline_route_ir,
+        )
+        pipeline_optimizations.append(pipeline_optimization)
+        optimized_bind_routes.extend(pipeline_optimization["optimized_bind_routes"])
+        fused_bind_groups.extend(pipeline_optimization["fused_groups"])
+
+    return {
+        "optimized_bind_routes": optimized_bind_routes,
+        "fused_groups": fused_bind_groups,
+        "pipeline_optimizations": pipeline_optimizations,
+    }
+
+
 def _compile_lockstep_with_dependencies(
     source_code: str,
     *,
@@ -612,7 +659,9 @@ def _compile_lockstep_with_dependencies(
     target_width: int = 8,
 ) -> LockstepCompileResult:
     source_map = source_map or [(1, _line_count(source_code), source_file)]
-    resolved_limits = _normalize_frontend_limits(frontend_limits, source_file=source_file)
+    resolved_limits = _normalize_frontend_limits(
+        frontend_limits, source_file=source_file
+    )
     _enforce_source_size_limit(
         source_code,
         source_file=source_file,
@@ -712,48 +761,9 @@ def _compile_lockstep_with_dependencies(
     # compile result carrying the serialized compiler entities, not just the
     # internal typed AST.
     runtime_entities = ast_to_entities(typed_ast)
-    optimized_bind_routes: list[str] = []
-    fused_bind_groups: list[object] = []
-    shader_names = {shader.name for shader in typed_ast.shaders}
-    filter_names = {flt.name for flt in typed_ast.filters}
-    for pipeline in typed_ast.pipelines:
-        pipeline_routes = [route.route for route in pipeline.bind_routes]
-        pipeline_route_ir = []
-        for route in pipeline.bind_routes:
-            if isinstance(route, AstKernelBindRoute):
-                pipeline_route_ir.append(
-                    {
-                        "kind": "kernel",
-                        "target": route.target,
-                        "kernel": route.kernel,
-                        "args": list(route.args),
-                        "route": route.route,
-                    }
-                )
-            elif isinstance(route, AstFoldBindRoute):
-                pipeline_route_ir.append(
-                    {
-                        "kind": "fold",
-                        "uniform_type": route.uniform_type.name,
-                        "uniform_name": route.uniform_name,
-                        "operator": route.operator,
-                        "source": route.source,
-                        "route": route.route,
-                    }
-                )
-        pipeline_optimization = optimize_bind_routes(
-            pipeline_routes,
-            shader_names=shader_names,
-            filter_names=filter_names,
-            bind_routes_ir=pipeline_route_ir,
-        )
-        optimized_bind_routes.extend(pipeline_optimization["optimized_bind_routes"])
-        fused_bind_groups.extend(pipeline_optimization["fused_groups"])
-
-    bind_optimization = {
-        "optimized_bind_routes": optimized_bind_routes,
-        "fused_groups": fused_bind_groups,
-    }
+    bind_optimization = _build_bind_optimization(typed_ast)
+    optimized_bind_routes = bind_optimization["optimized_bind_routes"]
+    fused_bind_groups = bind_optimization["fused_groups"]
     runtime_entities = {
         **runtime_entities,
         "optimized_bind_routes": optimized_bind_routes,
@@ -837,7 +847,9 @@ def compile_lockstep(
 ) -> LockstepCompileResult:
     resolved_library_sources: list[str] = list(library_sources or [])
     resolved_library_source_files: list[str] = list(library_source_files or [])
-    resolved_limits = _normalize_frontend_limits(frontend_limits, source_file=source_file)
+    resolved_limits = _normalize_frontend_limits(
+        frontend_limits, source_file=source_file
+    )
 
     dependency_sources, dependency_source_files = _resolve_dependency_sources(
         source_code,

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -227,11 +227,177 @@ def test_compile_pipeline_lowers_fused_group_to_single_simd_loop_without_interme
             "source_routes": ["tmp=A(inp,tmp);", "dst=B(tmp,dst);"],
         }
     ]
-    assert 'fused_0_body' in result.llvm_ir
-    assert 'route_A_body' not in result.llvm_ir
-    assert 'route_B_body' not in result.llvm_ir
+    assert "fused_0_body" in result.llvm_ir
+    assert "route_A_body" not in result.llvm_ir
+    assert "route_B_body" not in result.llvm_ir
     assert 'float* %"fused_tmp_slot"' in result.llvm_ir
-    assert 'stream_tmp_value_ptr' not in result.llvm_ir
+    assert "stream_tmp_value_ptr" not in result.llvm_ir
     assert 'call void @"shader_A"' in result.llvm_ir
     assert 'call void @"shader_B"' in result.llvm_ir
     llvm.parse_assembly(result.llvm_ir)
+
+
+def test_compile_passes_per_pipeline_bind_optimization_to_codegen(monkeypatch):
+    import lockstep_compiler
+    import lockstep_compiler.compiler as compiler_module
+
+    source = """
+    shader A(in float src, out float tmp) { tmp = src + 1.0; }
+    shader B(in float tmp, out float dst) { dst = tmp * 2.0; }
+
+    pipeline P1 {
+        stream<float, 4> inp;
+        stream<float, 4> tmp;
+        stream<float, 4> dst;
+
+        bind {
+            tmp = A(inp, tmp);
+            dst = B(tmp, dst);
+        }
+    }
+
+    pipeline P2 {
+        stream<float, 4> inp2;
+        stream<float, 4> tmp2;
+        stream<float, 4> dst2;
+
+        bind {
+            tmp2 = A(inp2, tmp2);
+            dst2 = B(tmp2, dst2);
+        }
+    }
+    """
+
+    optimization_calls = []
+    captured_bind_optimization = None
+
+    def fake_optimize_bind_routes(bind_routes, **kwargs):
+        optimization_calls.append((list(bind_routes), kwargs))
+        pipeline_number = len(optimization_calls)
+        return {
+            "optimized_bind_routes": [f"optimized-pipeline-{pipeline_number}"],
+            "fused_groups": [{"pipeline": pipeline_number}],
+        }
+
+    def fake_emit_llvm_ir(_program, *, bind_optimization=None, **_kwargs):
+        nonlocal captured_bind_optimization
+        captured_bind_optimization = bind_optimization
+        return '; ModuleID = "lockstep"\n'
+
+    monkeypatch.setattr(
+        compiler_module, "optimize_bind_routes", fake_optimize_bind_routes
+    )
+    monkeypatch.setattr(compiler_module, "emit_llvm_ir", fake_emit_llvm_ir)
+
+    result = lockstep_compiler.compile_lockstep(
+        source,
+        semantic_validator=lambda _tree, **_kwargs: [],
+        target_width=4,
+    )
+
+    assert [call[0] for call in optimization_calls] == [
+        ["tmp=A(inp,tmp);", "dst=B(tmp,dst);"],
+        ["tmp2=A(inp2,tmp2);", "dst2=B(tmp2,dst2);"],
+    ]
+    assert result.entities["optimized_bind_routes"] == [
+        "optimized-pipeline-1",
+        "optimized-pipeline-2",
+    ]
+    assert result.entities["fused_bind_groups"] == [
+        {"pipeline": 1},
+        {"pipeline": 2},
+    ]
+    assert captured_bind_optimization == {
+        "optimized_bind_routes": ["optimized-pipeline-1", "optimized-pipeline-2"],
+        "fused_groups": [{"pipeline": 1}, {"pipeline": 2}],
+        "pipeline_optimizations": [
+            {
+                "optimized_bind_routes": ["optimized-pipeline-1"],
+                "fused_groups": [{"pipeline": 1}],
+            },
+            {
+                "optimized_bind_routes": ["optimized-pipeline-2"],
+                "fused_groups": [{"pipeline": 2}],
+            },
+        ],
+    }
+    assert len(captured_bind_optimization["pipeline_optimizations"]) == len(
+        result.ast.pipelines
+    )
+
+
+def test_emit_llvm_ir_honors_per_pipeline_bind_optimization(monkeypatch):
+    from llvmlite import binding as llvm
+
+    import lockstep_compiler
+    import lockstep_compiler.codegen as codegen_module
+
+    source = """
+    shader A(in float src, out float tmp) { tmp = src + 1.0; }
+    shader B(in float tmp, out float dst) { dst = tmp * 2.0; }
+
+    pipeline P1 {
+        stream<float, 4> inp;
+        stream<float, 4> tmp;
+        stream<float, 4> dst;
+
+        bind {
+            tmp = A(inp, tmp);
+            dst = B(tmp, dst);
+        }
+    }
+
+    pipeline P2 {
+        stream<float, 4> inp2;
+        stream<float, 4> tmp2;
+        stream<float, 4> dst2;
+
+        bind {
+            tmp2 = A(inp2, tmp2);
+            dst2 = B(tmp2, dst2);
+        }
+    }
+    """
+    result = lockstep_compiler.compile_lockstep(
+        source,
+        semantic_validator=lambda _tree, **_kwargs: [],
+        target_width=4,
+    )
+
+    def fail_if_codegen_reoptimizes(*_args, **_kwargs):
+        raise AssertionError("emit_llvm_ir ignored supplied pipeline optimizations")
+
+    monkeypatch.setattr(
+        codegen_module, "optimize_bind_routes", fail_if_codegen_reoptimizes
+    )
+
+    llvm_ir = codegen_module.emit_llvm_ir(
+        result.ast,
+        target_width=4,
+        bind_optimization={
+            "optimized_bind_routes": [
+                "tmp=A(inp,tmp);",
+                "dst=B(tmp,dst);",
+                "tmp2=A(inp2,tmp2);",
+                "dst2=B(tmp2,dst2);",
+            ],
+            "fused_groups": [],
+            "pipeline_optimizations": [
+                {
+                    "optimized_bind_routes": ["tmp=A(inp,tmp);", "dst=B(tmp,dst);"],
+                    "fused_groups": [],
+                },
+                {
+                    "optimized_bind_routes": [
+                        "tmp2=A(inp2,tmp2);",
+                        "dst2=B(tmp2,dst2);",
+                    ],
+                    "fused_groups": [],
+                },
+            ],
+        },
+    )
+
+    assert "route_A_body" in llvm_ir
+    assert "route_B_body" in llvm_ir
+    llvm.parse_assembly(llvm_ir)


### PR DESCRIPTION
### Motivation
- The optimizer `optimize_bind_routes` was being imported but not integrated into the compilation chain, so the dead-code / fusion pass was never applied and the backend emitted unoptimized sequential code.
- The compiler must compute per-pipeline optimization data and present it to the LLVM lowering so fused routes and dead kernels are honored natively by codegen.

### Description
- Add `_bind_route_ir` and `_build_bind_optimization` helpers to `compiler.py` to build structured bind-route IR and run `optimize_bind_routes` per pipeline. 
- Collect and expose an aggregated `bind_optimization` payload (including `pipeline_optimizations`) and attach `optimized_bind_routes` / `fused_bind_groups` to the compile result `entities`.
- Pass the `bind_optimization` payload into `emit_llvm_ir` and update `codegen.py` to prefer per-pipeline `pipeline_optimizations` from the compiler when present instead of always recomputing.
- Add tests in `tests/test_optimizer.py` that assert the compiler invokes the optimizer per-pipeline and that the codegen honors supplied per-pipeline optimizations.

### Testing
- Ran Python byte-compile for modified modules with `python -m py_compile lockstep_compiler/compiler.py lockstep_compiler/codegen.py`, which succeeded.
- Ran optimizer-focused unit tests with `pytest -q tests/test_optimizer.py`, which passed (new tests included and succeeded).
- Ran broader test runs used during development; `tests/test_improvements.py` still contains unrelated pre-existing failures (CLI/header/LSP/dependency-limit areas) that were not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed14519c883289915d5d20b09b6c0)