### PR TITLE
Fix C header arena allocation overflow checks

### DIFF
--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -86,7 +86,8 @@ def emit_c_header(
     cumulative_layout_total = 0
     for leaf in layout.leaves:
         leaf_size = _PRIMITIVE_SIZE.get(leaf.type_name, 1)
-        if cumulative_layout_total > _MAX_U64 - leaf_size:
+        leaf_allocation_size = leaf_size * leaf.element_count
+        if cumulative_layout_total > _MAX_U64 - leaf_allocation_size:
             diagnostic = LockstepDiagnostic(
                 severity="error",
                 code="LCK502",
@@ -108,7 +109,7 @@ def emit_c_header(
                 phase="codegen",
                 source_file=diagnostic.source_file,
             )
-        cumulative_layout_total += leaf_size
+        cumulative_layout_total += leaf_allocation_size
         c_type_name = _c_type(leaf.type_name, known_structs)
         path_suffix = "_".join(_sanitize_symbol(part) for part in leaf.path) if leaf.path else "value"
         field_name = f"{leaf.kind}_{_sanitize_symbol(leaf.binding_name)}_{path_suffix}"

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -1345,6 +1345,21 @@ def test_emit_c_header_raises_lck502_when_cumulative_offsets_overflow(monkeypatc
     assert [diag.code for diag in exc_info.value.errors] == ["LCK502"]
 
 
+def test_emit_c_header_raises_lck502_when_single_leaf_allocation_overflows(monkeypatch):
+    monkeypatch.setattr(c_header_module, "_MAX_U64", 4)
+
+    with pytest.raises(lockstep_compiler.LockstepCompileError) as exc_info:
+        emit_c_header(
+            {
+                "streams": [{"name": "samples", "type": "float", "capacity": "2"}],
+                "accumulators": [],
+                "uniforms": [],
+            }
+        )
+
+    assert [diag.code for diag in exc_info.value.errors] == ["LCK502"]
+
+
 def test_build_arena_layout_raises_lck503_for_recursive_struct_layout_cycle():
     with pytest.raises(lockstep_compiler.LockstepCompileError) as exc_info:
         build_arena_layout(


### PR DESCRIPTION
### Motivation
- The C header generator validated cumulative arena size using only a scalar leaf size, ignoring per-leaf `element_count`, which underestimates actual allocation footprint and can miss overflow conditions.

### Description
- Replace the per-leaf overflow guard to compute `leaf_allocation_size = leaf_size * leaf.element_count` and use that value for both the pre-check and the cumulative increment in `emit_c_header`.
- Keep the diagnostic (`LCK502`) and raising behavior intact when the check trips.
- Add a regression test `test_emit_c_header_raises_lck502_when_single_leaf_allocation_overflows` to `tests/test_compiler_api.py` that verifies a single stream leaf with capacity can trigger `LCK502`.

### Testing
- Ran the focused tests `pytest tests/test_compiler_api.py::test_emit_c_header_raises_lck502_when_cumulative_offsets_overflow tests/test_compiler_api.py::test_emit_c_header_raises_lck502_when_single_leaf_allocation_overflows -q` and both passed.
- Running the whole `tests/test_compiler_api.py` (`pytest tests/test_compiler_api.py -q`) resulted in many failures unrelated to this change (existing `emit_llvm_ir` and `emit_c_header` dict/AstProgram compatibility and `LayoutStructDecl` usage), indicating preexisting issues outside the scope of this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed3eecde883289ec5270ff5fe21c9)