### PR TITLE
Validate AST semantic expression operands

### DIFF
--- a/lockstep_compiler/semantic_validator.py
+++ b/lockstep_compiler/semantic_validator.py
@@ -852,6 +852,43 @@ def build_semantic_validator(base_visitor_cls):
 
         def _resolve_ast_expr_type(self, expr: AstExpr) -> str | None:
             numeric_types = {"int", "uint", "float", "double"}
+            integer_types = {"int", "uint"}
+
+            def _operand_ctx(node):
+                return self._ctx_from_location(getattr(node, "location", None))
+
+            def _format_operand_types(*types: str) -> str:
+                return f"[{', '.join(types)}]"
+
+            def _report_invalid_operands(
+                node,
+                op: str,
+                expectation: str,
+                *actual_types: str,
+                code: str = SEMANTIC_DIAGNOSTIC_CODES["invalid_operand_types"],
+                message: str | None = None,
+                hint: str = "Adjust operand types so they match the operator semantics.",
+            ):
+                reported_nodes = getattr(self, "_reported_ast_operand_errors", None)
+                if reported_nodes is None:
+                    reported_nodes = set()
+                    self._reported_ast_operand_errors = reported_nodes
+                diagnostic_key = (id(node), op, code, actual_types)
+                if diagnostic_key in reported_nodes:
+                    return
+                reported_nodes.add(diagnostic_key)
+                if message is None:
+                    message = (
+                        f"Operator '{op}' expects {expectation} operand type(s), "
+                        f"but got {_format_operand_types(*actual_types)}."
+                    )
+                self._add_diagnostic(
+                    severity="error",
+                    code=code,
+                    message=message,
+                    ctx=_operand_ctx(node),
+                    hint=hint,
+                )
 
             def _resolve_binary(expr_binary: AstExprBinary) -> str | None:
                 left_type = self._resolve_ast_expr_type(expr_binary.left)
@@ -863,22 +900,51 @@ def build_semantic_validator(base_visitor_cls):
                 if op in {"+", "-", "*", "/"}:
                     if left_type in numeric_types and right_type == left_type:
                         return left_type
+                    if left_type in numeric_types and right_type in numeric_types:
+                        _report_invalid_operands(
+                            expr_binary,
+                            op,
+                            "matching numeric",
+                            left_type,
+                            right_type,
+                            code=SEMANTIC_DIAGNOSTIC_CODES["implicit_numeric_widening"],
+                            message=(
+                                f"Operator '{op}' mixes numeric operand types without an explicit cast."
+                            ),
+                            hint="Use explicit casts so numeric widening is intentional and target-compatible.",
+                        )
+                    else:
+                        _report_invalid_operands(
+                            expr_binary, op, "numeric", left_type, right_type
+                        )
                     return None
                 if op in {"&", "|", "^"}:
-                    if left_type in {"int", "uint"} and right_type == left_type:
+                    if left_type in integer_types and right_type == left_type:
                         return left_type
+                    _report_invalid_operands(
+                        expr_binary, op, "integer", left_type, right_type
+                    )
                     return None
                 if op in {"&&", "||"}:
                     if left_type == "bool" and right_type == "bool":
                         return "bool"
+                    _report_invalid_operands(
+                        expr_binary, op, "bool", left_type, right_type
+                    )
                     return None
                 if op in {"==", "!=", "<", "<=", ">", ">="}:
                     if left_type == right_type:
                         return "bool"
+                    _report_invalid_operands(
+                        expr_binary, op, "matching", left_type, right_type
+                    )
                     return None
                 if op in {"<<", ">>"}:
-                    if left_type in {"int", "uint"} and right_type in {"int", "uint"}:
+                    if left_type in integer_types and right_type in integer_types:
                         return left_type
+                    _report_invalid_operands(
+                        expr_binary, op, "integer", left_type, right_type
+                    )
                     return None
                 return None
 
@@ -897,25 +963,33 @@ def build_semantic_validator(base_visitor_cls):
                 signature = self.pure_functions.get(expr_call.name)
                 return signature.return_type if signature is not None else None
 
+            def _resolve_unary(expr_unary: AstExprUnary) -> str | None:
+                operand_type = self._resolve_ast_expr_type(expr_unary.operand)
+                if operand_type is None:
+                    return None
+                if expr_unary.op == "!":
+                    if operand_type == "bool":
+                        return "bool"
+                    _report_invalid_operands(
+                        expr_unary, expr_unary.op, "bool", operand_type
+                    )
+                    return None
+                if expr_unary.op == "-":
+                    if operand_type in numeric_types:
+                        return operand_type
+                    _report_invalid_operands(
+                        expr_unary, expr_unary.op, "numeric", operand_type
+                    )
+                    return None
+                return operand_type
+
             type_dispatch = {
                 AstExprLiteral: lambda node: node.kind,
                 AstExprVar: lambda node: self._lookup_path(node.path),
-                AstExprUnary: lambda node: (
-                    "bool"
-                    if node.op == "!"
-                    else (
-                        self._resolve_ast_expr_type(node.operand)
-                        if (
-                            node.op != "-"
-                            or self._resolve_ast_expr_type(node.operand)
-                            in numeric_types
-                        )
-                        else None
-                    )
-                ),
+                AstExprUnary: _resolve_unary,
                 AstExprBinary: _resolve_binary,
                 AstExprCall: _resolve_call,
-                AstExprCast: lambda node: node.target_type.name,
+                AstExprCast: lambda node: str(node.target_type),
             }
 
             for expr_type, resolver in type_dispatch.items():

--- a/tests/test_semantic_validator_ast_path.py
+++ b/tests/test_semantic_validator_ast_path.py
@@ -57,3 +57,13 @@ pipeline BadBind {
 
     assert "LCK305" in codes
     assert "LCK308" in codes
+
+
+def test_ast_validator_rejects_invalid_return_expression_operands():
+    codes = _semantic_error_codes("""
+pure int BadOperands(int value, float scale) {
+    return value + scale;
+}
+""")
+
+    assert "LCK424" in codes


### PR DESCRIPTION
### Motivation
- The AST-driven semantic validation path was silently returning `None` for invalid expression operand shapes and omitted several checks present in the parse-tree visitor path, allowing invalid operand combinations to escape diagnostics.
- Mixed numeric arithmetic, invalid logical/bitwise operand types, and unary operand errors needed to be reported in the single-source AST path so declarations, assignments, and returns can be fully type-checked.

### Description
- Added operand validation and diagnostic reporting inside `_resolve_ast_expr_type` in `lockstep_compiler/semantic_validator.py`, including formatted messages and de-duplication of repeated reports via a `_reported_ast_operand_errors` set.
- Implemented explicit checks for binary arithmetic, bitwise, logical, comparison, and shift operators and for unary operators, preserving the existing `LCK424` check for implicit numeric widening and using `LCK420`/`LCK424`/`LCK420`-style diagnostics consistently.
- Introduced helper routines `_operand_ctx`, `_format_operand_types`, and `_report_invalid_operands` and split unary handling into `_resolve_unary` to keep dispatch consistent and readable.
- Added a regression test `test_ast_validator_rejects_invalid_return_expression_operands` in `tests/test_semantic_validator_ast_path.py` which asserts that mixed numeric operands in a pure return emit `LCK424`.

### Testing
- Ran `pytest -q tests/test_semantic_validator_ast_path.py` which succeeded and exercised the new AST-path checks (including the added regression test). 
- Ran `pytest -q tests/test_negative_integration.py tests/test_semantic_validator_ast_path.py` which also succeeded. 
- Attempted a full `pytest -q` run but collection failed due to a missing environment dependency (`hypothesis`) so the complete suite was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed4af90dc8328b98eb5eaf2e5acb4)