### PR TITLE
Interpret mapping-style body_ast in simulator (evaluate AST expressions/statements)

### DIFF
--- a/lockstep_compiler/simulator.py
+++ b/lockstep_compiler/simulator.py
@@ -246,6 +246,29 @@ def _copy_sim_value(value: Any) -> Any:
     return value
 
 
+def _sim_mapping_value(value: Any, key: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _sim_type_text(type_value: Any) -> str | None:
+    if type_value is None:
+        return None
+    if isinstance(type_value, dict):
+        name = type_value.get("name")
+        return str(name) if name is not None else None
+    return str(type_value)
+
+
+def _sim_path_tuple(path_value: Any) -> tuple[str, ...]:
+    if isinstance(path_value, str):
+        return tuple(part for part in path_value.split(".") if part)
+    if isinstance(path_value, (list, tuple)):
+        return tuple(str(part) for part in path_value)
+    return ()
+
+
 def _default_sim_value(type_name: str | None = None) -> Any:
     if type_name in {"float", "double"}:
         return 0.0
@@ -352,75 +375,97 @@ def _eval_sim_expr(
         AstExprVar,
     )
 
-    if isinstance(expr, AstExprLiteral):
-        if expr.kind == "bool":
-            return expr.value == "true"
-        if expr.kind in {"int", "uint"}:
-            return int(expr.value)
-        if expr.kind in {"float", "double"}:
-            return float(expr.value)
-        return expr.value
-    if isinstance(expr, AstExprVar):
-        return _resolve_sim_path(env, expr.path)
-    if isinstance(expr, AstExprUnary):
-        operand = _eval_sim_expr(expr.operand, env, pure_functions)
-        if expr.op == "-":
+    is_mapping_expr = isinstance(expr, dict)
+    if isinstance(expr, AstExprLiteral) or (
+        is_mapping_expr
+        and "kind" in expr
+        and "value" in expr
+        and "op" not in expr
+        and "target_type" not in expr
+    ):
+        kind = _sim_mapping_value(expr, "kind")
+        value = _sim_mapping_value(expr, "value")
+        if kind == "bool":
+            return value == "true" if isinstance(value, str) else bool(value)
+        if kind in {"int", "uint"}:
+            return int(value)
+        if kind in {"float", "double"}:
+            return float(value)
+        return value
+    if isinstance(expr, AstExprVar) or (is_mapping_expr and "path" in expr):
+        return _resolve_sim_path(env, _sim_path_tuple(_sim_mapping_value(expr, "path")))
+    if isinstance(expr, AstExprUnary) or (is_mapping_expr and "operand" in expr):
+        op = _sim_mapping_value(expr, "op")
+        operand = _eval_sim_expr(
+            _sim_mapping_value(expr, "operand"), env, pure_functions
+        )
+        if op == "-":
             return -operand
         return not _truthy_sim_value(operand)
-    if isinstance(expr, AstExprCast):
+    if isinstance(expr, AstExprCast) or (is_mapping_expr and "target_type" in expr):
         return _eval_sim_call(
-            str(expr.target_type),
-            [_eval_sim_expr(expr.value, env, pure_functions)],
+            str(_sim_type_text(_sim_mapping_value(expr, "target_type"))),
+            [_eval_sim_expr(_sim_mapping_value(expr, "value"), env, pure_functions)],
             pure_functions,
         )
-    if isinstance(expr, AstExprCall):
+    if isinstance(expr, AstExprCall) or (
+        is_mapping_expr and "name" in expr and "args" in expr
+    ):
+        args = _sim_mapping_value(expr, "args", []) or []
         return _eval_sim_call(
-            expr.name,
-            [_eval_sim_expr(arg, env, pure_functions) for arg in expr.args],
+            str(_sim_mapping_value(expr, "name")),
+            [_eval_sim_expr(arg, env, pure_functions) for arg in args],
             pure_functions,
         )
-    if isinstance(expr, AstExprBinary):
-        if expr.op == "&&":
+    if isinstance(expr, AstExprBinary) or (
+        is_mapping_expr and "op" in expr and "left" in expr and "right" in expr
+    ):
+        op = _sim_mapping_value(expr, "op")
+        if op == "&&":
             return _truthy_sim_value(
-                _eval_sim_expr(expr.left, env, pure_functions)
-            ) and _truthy_sim_value(_eval_sim_expr(expr.right, env, pure_functions))
-        if expr.op == "||":
+                _eval_sim_expr(_sim_mapping_value(expr, "left"), env, pure_functions)
+            ) and _truthy_sim_value(
+                _eval_sim_expr(_sim_mapping_value(expr, "right"), env, pure_functions)
+            )
+        if op == "||":
             return _truthy_sim_value(
-                _eval_sim_expr(expr.left, env, pure_functions)
-            ) or _truthy_sim_value(_eval_sim_expr(expr.right, env, pure_functions))
-        left = _eval_sim_expr(expr.left, env, pure_functions)
-        right = _eval_sim_expr(expr.right, env, pure_functions)
-        if expr.op == "+":
+                _eval_sim_expr(_sim_mapping_value(expr, "left"), env, pure_functions)
+            ) or _truthy_sim_value(
+                _eval_sim_expr(_sim_mapping_value(expr, "right"), env, pure_functions)
+            )
+        left = _eval_sim_expr(_sim_mapping_value(expr, "left"), env, pure_functions)
+        right = _eval_sim_expr(_sim_mapping_value(expr, "right"), env, pure_functions)
+        if op == "+":
             return left + right
-        if expr.op == "-":
+        if op == "-":
             return left - right
-        if expr.op == "*":
+        if op == "*":
             return left * right
-        if expr.op == "/":
+        if op == "/":
             return left / right
-        if expr.op == "%":
+        if op == "%":
             return left % right
-        if expr.op == "<":
+        if op == "<":
             return left < right
-        if expr.op == "<=":
+        if op == "<=":
             return left <= right
-        if expr.op == ">":
+        if op == ">":
             return left > right
-        if expr.op == ">=":
+        if op == ">=":
             return left >= right
-        if expr.op == "==":
+        if op == "==":
             return left == right
-        if expr.op == "!=":
+        if op == "!=":
             return left != right
-        if expr.op == "&":
+        if op == "&":
             return int(left) & int(right)
-        if expr.op == "|":
+        if op == "|":
             return int(left) | int(right)
-        if expr.op == "^":
+        if op == "^":
             return int(left) ^ int(right)
-        if expr.op == "<<":
+        if op == "<<":
             return int(left) << int(right)
-        if expr.op == ">>":
+        if op == ">>":
             return int(left) >> int(right)
     return None
 
@@ -435,24 +480,43 @@ def _execute_sim_body(
     assigned: set[str] = set()
     return_value = None
     for statement in body_ast:
-        if isinstance(statement, AstVarDeclStmt):
-            env[statement.name] = (
-                _eval_sim_expr(statement.initializer, env, pure_functions)
-                if statement.initializer is not None
+        is_mapping_statement = isinstance(statement, dict)
+        if isinstance(statement, AstVarDeclStmt) or (
+            is_mapping_statement
+            and "name" in statement
+            and ("declared_type" in statement or "initializer" in statement)
+        ):
+            name = str(_sim_mapping_value(statement, "name"))
+            initializer = _sim_mapping_value(statement, "initializer")
+            env[name] = (
+                _eval_sim_expr(initializer, env, pure_functions)
+                if initializer is not None
                 else _default_sim_value(
-                    str(statement.declared_type) if statement.declared_type else None
+                    _sim_type_text(_sim_mapping_value(statement, "declared_type"))
                 )
             )
-            assigned.add(statement.name)
+            assigned.add(name)
             continue
-        if isinstance(statement, AstAssignStmt):
-            value = _eval_sim_expr(statement.value, env, pure_functions)
-            _assign_sim_path(env, statement.target, value)
-            if statement.target:
-                assigned.add(statement.target[0])
+        if isinstance(statement, AstAssignStmt) or (
+            is_mapping_statement and "target" in statement and "value" in statement
+        ):
+            value = _eval_sim_expr(
+                _sim_mapping_value(statement, "value"), env, pure_functions
+            )
+            target = _sim_path_tuple(_sim_mapping_value(statement, "target"))
+            _assign_sim_path(env, target, value)
+            if target:
+                assigned.add(target[0])
             continue
-        if isinstance(statement, AstReturnStmt):
-            return_value = _eval_sim_expr(statement.value, env, pure_functions)
+        if isinstance(statement, AstReturnStmt) or (
+            is_mapping_statement
+            and "value" in statement
+            and "target" not in statement
+            and "declared_type" not in statement
+        ):
+            return_value = _eval_sim_expr(
+                _sim_mapping_value(statement, "value"), env, pure_functions
+            )
             break
     return return_value, assigned
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -181,6 +181,78 @@ def test_simulate_pipeline_entities_executes_shader_body_ast_assignments():
     assert simulation["accumulators"]["energy"] == [5.0, 5.0]
 
 
+def test_simulate_pipeline_entities_interprets_mapping_body_ast_statements():
+    entities = {
+        "streams": [
+            {"name": "in_stream", "type": "float", "capacity": "8"},
+            {"name": "out_stream", "type": "float", "capacity": "8"},
+        ],
+        "accumulators": [{"name": "energy", "type": "float"}],
+        "uniforms": [{"name": "gain", "type": "float", "initializer": "3.0"}],
+        "pure_functions": [
+            {
+                "name": "offset",
+                "return_type": "float",
+                "params": [{"type": "float", "name": "x"}],
+                "body_ast": [
+                    {
+                        "value": {
+                            "op": "+",
+                            "left": {"path": ["x"]},
+                            "right": {"kind": "float", "value": "2.0"},
+                        }
+                    }
+                ],
+            }
+        ],
+        "shaders": [
+            {
+                "name": "Scale",
+                "params": [
+                    {"modifier": "in", "type": "float", "name": "src"},
+                    {"modifier": "out", "type": "float", "name": "dst"},
+                    {"modifier": "accum", "type": "float", "name": "energy"},
+                    {"modifier": "uniform", "type": "float", "name": "gain"},
+                ],
+                "body_ast": [
+                    {
+                        "declared_type": "float",
+                        "name": "scaled",
+                        "initializer": {
+                            "op": "*",
+                            "left": {"name": "offset", "args": [{"path": ["src"]}]},
+                            "right": {"path": ["gain"]},
+                        },
+                    },
+                    {"target": ["dst"], "value": {"path": ["scaled"]}},
+                    {
+                        "target": ["energy"],
+                        "value": {"name": "abs", "args": [{"path": ["dst"]}]},
+                    },
+                ],
+            }
+        ],
+        "filters": [],
+        "bind_routes": ["out_stream = Scale(in_stream, out_stream, energy, gain);"],
+        "bind_routes_ir": [
+            {
+                "kind": "kernel",
+                "target": "out_stream",
+                "kernel": "Scale",
+                "args": ["in_stream", "out_stream", "energy", "gain"],
+                "route": "out_stream = Scale(in_stream, out_stream, energy, gain);",
+            }
+        ],
+    }
+
+    simulation = simulate_pipeline_entities(
+        entities, stream_inputs={"in_stream": [1.0, -4.0]}
+    )
+
+    assert simulation["streams"]["out_stream"] == [9.0, -6.0]
+    assert simulation["accumulators"]["energy"] == [9.0, 6.0]
+
+
 def test_simulate_pipeline_entities_executes_filter_return_predicate_and_struct_fields():
     entities = {
         "streams": [


### PR DESCRIPTION
### Motivation
- The simulator previously faked shader/filter execution by packaging rows instead of evaluating the statements in `body_ast`, so user math, control, and pure calls were ignored.
- Downstream tooling and tests expect `body_ast` (both typed AST dataclasses and serialized mapping/dict forms) to be executed for meaningful simulation results.

### Description
- Added small helpers to normalize mapping-style AST payloads: `_sim_mapping_value`, `_sim_type_text`, and `_sim_path_tuple` to read dict-style `body_ast` entries alongside typed AST dataclasses.
- Extended expression evaluator `_eval_sim_expr` to interpret literals, vars, unary/cast/call expressions, logical short-circuiting, arithmetic, comparison, and bitwise binaries for both dataclass AST nodes and mapping/dict nodes.
- Extended statement interpreter `_execute_sim_body` to evaluate variable declarations, assignments, and returns from mapping-style statements (in addition to existing dataclass handling), preserving the same `env` and assigned-tracking semantics used by the simulator.
- Added a new simulator unit test `test_simulate_pipeline_entities_interprets_mapping_body_ast_statements` that supplies mapping-style `body_ast` payloads (including a pure function defined as a mapping) to ensure the simulator evaluates expressions, out/uniform/accum semantics, and pending accumulator writes.
- Changes touch `lockstep_compiler/simulator.py` and add test coverage in `tests/test_simulator.py`.

### Testing
- Ran `pytest -q tests/test_simulator.py` and the simulator-focused tests passed (all tests in that file succeeded). 
- Ran `python -m compileall -q lockstep_compiler/simulator.py tests/test_simulator.py` to verify byte-compilation succeeded. 
- Ran the full test suite `pytest -q` in this environment; it reported failures unrelated to the simulator change (missing benchmark fixture and other preexisting suite issues), so only the simulator-specific tests were validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed65bdea48328bfcb2d7d0039d664)