### PR TITLE
Handle undefined kernel routes in codegen

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -1555,7 +1555,11 @@ def emit_llvm_ir(
         return callee, signature[1] if signature is not None else ()
 
     def _kernel_route_trip_count(route: AstKernelBindRoute) -> int:
-        _, params = _kernel_function_and_params(route.kernel)
+        callee, params = _kernel_function_and_params(route.kernel)
+        if callee is None:
+            raise CodegenError(
+                f"undefined shader/filter '{route.kernel}' in bind route: {route.route}"
+            )
         trip_count = 0
         for index, arg_name in enumerate(route.args):
             if index >= len(params):

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -731,6 +731,32 @@ def test_emit_llvm_ir_uses_array_field_for_single_capacity_streams():
     assert '%"struct.Lockstep_Arena" = type {[1 x float], float}' in llvm_ir
 
 
+def test_emit_llvm_ir_reports_undefined_kernel_bind_route():
+    from lockstep_compiler.ast import AstKernelBindRoute, AstPipelineDecl, AstProgram
+
+    program = AstProgram(
+        pipelines=(
+            AstPipelineDecl(
+                name="Main",
+                bind_routes=(
+                    AstKernelBindRoute(
+                        target="out",
+                        kernel="MissingKernel",
+                        args=(),
+                        route="out = MissingKernel();",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    with pytest.raises(
+        CodegenError,
+        match="undefined shader/filter 'MissingKernel' in bind route",
+    ):
+        emit_llvm_ir(program)
+
+
 def test_emit_llvm_ir_lowers_kernel_bind_routes_into_counted_loops():
     llvm_ir = emit_llvm_ir(
         {


### PR DESCRIPTION
### Motivation
- Prevent a fatal `TypeError` when `_kernel_route_trip_count` encounters a bind route referencing an unresolved shader/filter by producing a clear, controlled diagnostic instead of returning implicit `None` during `max()` aggregation.

### Description
- Change `_kernel_route_trip_count` to explicitly resolve the callee with `_kernel_function_and_params` and raise `CodegenError` with the kernel name and original `route` when the callee is `None` (`lockstep_compiler/codegen.py`).
- Add a regression test `test_emit_llvm_ir_reports_undefined_kernel_bind_route` that constructs an `AstProgram` with a missing kernel and asserts `CodegenError` is raised (`tests/test_compiler_api.py`).

### Testing
- Ran `pytest tests/test_compiler_api.py::test_emit_llvm_ir_reports_undefined_kernel_bind_route -q`, which passed.
- Ran `python -m py_compile lockstep_compiler/codegen.py tests/test_compiler_api.py`, which succeeded with no syntax errors.
- Running the full test subset that included `test_emit_llvm_ir_lowers_kernel_bind_routes_into_counted_loops` produced an unrelated existing assertion mismatch in the LLVM IR test, and running the entire `pytest` suite failed collection due to the optional `hypothesis` dependency missing in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f042eacd0832898d6b565302611a4)