### PR TITLE
Raise simulator errors for missing lookups

### DIFF
--- a/lockstep_compiler/simulator.py
+++ b/lockstep_compiler/simulator.py
@@ -159,7 +159,7 @@ def _run_reduce_subprocess(values: list[float]) -> float:
 
 
 class SimulatorRuntimeError(RuntimeError):
-    """Raised when optional LLVM-backed simulation fails."""
+    """Raised when simulator execution encounters an invalid runtime state."""
 
 
 def _python_numeric_reduce(operator: str, values: list[Any]) -> Any:
@@ -279,15 +279,47 @@ def _default_sim_value(type_name: str | None = None) -> Any:
     return {}
 
 
+def _format_sim_path(path: tuple[str, ...]) -> str:
+    return ".".join(path) if path else "<empty>"
+
+
+def _format_available_sim_keys(value: dict[str, Any]) -> str:
+    if not value:
+        return "none"
+    return ", ".join(sorted(str(key) for key in value))
+
+
 def _resolve_sim_path(env: dict[str, Any], path: tuple[str, ...]) -> Any:
     if not path:
         return None
-    value = env.get(path[0], 0)
+
+    root = path[0]
+    if root not in env:
+        raise SimulatorRuntimeError(
+            "Unmapped simulator identifier "
+            f"'{root}' while resolving '{_format_sim_path(path)}'; "
+            f"available identifiers: {_format_available_sim_keys(env)}."
+        )
+
+    value = env[root]
+    resolved_path = (root,)
     for part in path[1:]:
-        if isinstance(value, dict):
-            value = value.get(part, 0)
-        else:
-            return 0
+        if not isinstance(value, dict):
+            raise SimulatorRuntimeError(
+                "Cannot resolve simulator member "
+                f"'{part}' on non-struct value at "
+                f"'{_format_sim_path(resolved_path)}' while resolving "
+                f"'{_format_sim_path(path)}'."
+            )
+        if part not in value:
+            raise SimulatorRuntimeError(
+                "Unmapped simulator member "
+                f"'{part}' at '{_format_sim_path(resolved_path)}' while resolving "
+                f"'{_format_sim_path(path)}'; available members: "
+                f"{_format_available_sim_keys(value)}."
+            )
+        value = value[part]
+        resolved_path = (*resolved_path, part)
     return _coerce_sim_value(value)
 
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -17,6 +17,7 @@ from lockstep_compiler.ast import (
 )
 from lockstep_compiler.cli import run_cli
 from lockstep_compiler.simulator import (
+    SimulatorRuntimeError,
     parse_simulation_inputs,
     simulate_pipeline_entities,
     simulate_pipeline_source,
@@ -251,6 +252,142 @@ def test_simulate_pipeline_entities_interprets_mapping_body_ast_statements():
 
     assert simulation["streams"]["out_stream"] == [9.0, -6.0]
     assert simulation["accumulators"]["energy"] == [9.0, 6.0]
+
+
+def test_simulate_pipeline_entities_rejects_missing_identifier_reference():
+    entities = {
+        "streams": [
+            {"name": "in_stream", "type": "float", "capacity": "8"},
+            {"name": "out_stream", "type": "float", "capacity": "8"},
+        ],
+        "accumulators": [],
+        "uniforms": [],
+        "shaders": [
+            {
+                "name": "BadReference",
+                "params": [
+                    {"modifier": "in", "type": "float", "name": "src"},
+                    {"modifier": "out", "type": "float", "name": "dst"},
+                ],
+                "body_ast": [
+                    AstAssignStmt(target=("dst",), value=AstExprVar(path=("missing",)))
+                ],
+            }
+        ],
+        "filters": [],
+        "bind_routes": ["out_stream = BadReference(in_stream, out_stream);"],
+        "bind_routes_ir": [
+            {
+                "kind": "kernel",
+                "target": "out_stream",
+                "kernel": "BadReference",
+                "args": ["in_stream", "out_stream"],
+                "route": "out_stream = BadReference(in_stream, out_stream);",
+            }
+        ],
+    }
+
+    try:
+        simulate_pipeline_entities(entities, stream_inputs={"in_stream": [1.0]})
+    except SimulatorRuntimeError as err:
+        message = str(err)
+        assert "Unmapped simulator identifier 'missing'" in message
+        assert "available identifiers: dst, src" in message
+    else:
+        raise AssertionError("Expected SimulatorRuntimeError for missing identifier")
+
+
+def test_simulate_pipeline_entities_rejects_missing_struct_member_reference():
+    entities = {
+        "streams": [
+            {"name": "in_stream", "type": "Particle", "capacity": "8"},
+            {"name": "out_stream", "type": "float", "capacity": "8"},
+        ],
+        "accumulators": [],
+        "uniforms": [],
+        "shaders": [
+            {
+                "name": "ReadMissingMember",
+                "params": [
+                    {"modifier": "in", "type": "Particle", "name": "src"},
+                    {"modifier": "out", "type": "float", "name": "dst"},
+                ],
+                "body_ast": [
+                    AstAssignStmt(
+                        target=("dst",), value=AstExprVar(path=("src", "missing"))
+                    )
+                ],
+            }
+        ],
+        "filters": [],
+        "bind_routes": ["out_stream = ReadMissingMember(in_stream, out_stream);"],
+        "bind_routes_ir": [
+            {
+                "kind": "kernel",
+                "target": "out_stream",
+                "kernel": "ReadMissingMember",
+                "args": ["in_stream", "out_stream"],
+                "route": "out_stream = ReadMissingMember(in_stream, out_stream);",
+            }
+        ],
+    }
+
+    try:
+        simulate_pipeline_entities(
+            entities, stream_inputs={"in_stream": [{"value": 1.0}]}
+        )
+    except SimulatorRuntimeError as err:
+        message = str(err)
+        assert "Unmapped simulator member 'missing'" in message
+        assert "while resolving 'src.missing'" in message
+        assert "available members: value" in message
+    else:
+        raise AssertionError("Expected SimulatorRuntimeError for missing struct member")
+
+
+def test_simulate_pipeline_entities_rejects_member_reference_on_scalar():
+    entities = {
+        "streams": [
+            {"name": "in_stream", "type": "float", "capacity": "8"},
+            {"name": "out_stream", "type": "float", "capacity": "8"},
+        ],
+        "accumulators": [],
+        "uniforms": [],
+        "shaders": [
+            {
+                "name": "ScalarMember",
+                "params": [
+                    {"modifier": "in", "type": "float", "name": "src"},
+                    {"modifier": "out", "type": "float", "name": "dst"},
+                ],
+                "body_ast": [
+                    AstAssignStmt(
+                        target=("dst",), value=AstExprVar(path=("src", "field"))
+                    )
+                ],
+            }
+        ],
+        "filters": [],
+        "bind_routes": ["out_stream = ScalarMember(in_stream, out_stream);"],
+        "bind_routes_ir": [
+            {
+                "kind": "kernel",
+                "target": "out_stream",
+                "kernel": "ScalarMember",
+                "args": ["in_stream", "out_stream"],
+                "route": "out_stream = ScalarMember(in_stream, out_stream);",
+            }
+        ],
+    }
+
+    try:
+        simulate_pipeline_entities(entities, stream_inputs={"in_stream": [1.0]})
+    except SimulatorRuntimeError as err:
+        message = str(err)
+        assert "Cannot resolve simulator member 'field'" in message
+        assert "non-struct value at 'src'" in message
+    else:
+        raise AssertionError("Expected SimulatorRuntimeError for scalar member reference")
 
 
 def test_simulate_pipeline_entities_executes_filter_return_predicate_and_struct_fields():


### PR DESCRIPTION
### Motivation
- The simulator silently returned `0` for missing root identifiers and struct members when resolving simulation paths, which masked real configuration and logic errors during simulation.
- The change aims to fail fast and provide descriptive diagnostics when an unmapped identifier or invalid member access is encountered so corrupted or invalid kernel configurations do not pass unnoticed.

### Description
- Replace the silent fallback in `_resolve_sim_path` with strict `SimulatorRuntimeError` exceptions for unmapped root identifiers, missing struct members, and member access on non-struct values, and include the queried path in the message.
- Add helpers ` _format_sim_path` and `_format_available_sim_keys` to build human-readable diagnostic messages listing available identifiers or members.
- Update `SimulatorRuntimeError` docstring to reflect broader runtime-state failures (not just LLVM runtime failures). 
- Add unit tests to `tests/test_simulator.py` to cover missing identifier lookups, missing struct members, and scalar-member access, and import `SimulatorRuntimeError` in the test module.

### Testing
- Ran `pytest tests/test_simulator.py -q` and the simulator unit tests including the new cases completed successfully (all green). 
- Ran `python -m py_compile lockstep_compiler/simulator.py tests/test_simulator.py` and the modified files compiled without syntax errors. 
- Ran the full test suite with `pytest -q`; this surfaced unrelated, preexisting failures (benchmark fixture / broader compiler/LSP/type tests) that are not caused by the simulator changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f04d027508328bded5d9af80ac0a0)