### PR TITLE
Vectorize fused kernel group lowering using LLVM SIMD vectors

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -1706,6 +1706,575 @@ def emit_llvm_ir(
 
         tick_builder.position_at_end(loop_exit)
 
+    def _vector_type_for_scalar(scalar_type: ir.Type) -> ir.VectorType | None:
+        if isinstance(
+            scalar_type, (ir.FloatType, ir.DoubleType, ir.IntType)
+        ) and not isinstance(scalar_type, ir.VectorType):
+            return ir.VectorType(scalar_type, simd_width)
+        return None
+
+    def _splat_to_vector(value: ir.Value, vector_ty: ir.VectorType) -> ir.Value:
+        if value.type == vector_ty:
+            return value
+        if value.type != vector_ty.element:
+            value = lowerer._coerce_value_to_type(value, vector_ty.element)
+        seed = tick_builder.insert_element(
+            ir.Constant(vector_ty, ir.Undefined), value, ir.Constant(ir.IntType(32), 0)
+        )
+        mask = ir.Constant(ir.VectorType(ir.IntType(32), simd_width), [0] * simd_width)
+        return tick_builder.shuffle_vector(
+            seed, ir.Constant(vector_ty, ir.Undefined), mask, name="fused_splat"
+        )
+
+    def _coerce_vector_value(
+        value: ir.Value, target_ty: ir.Type, type_name: str | None = None
+    ) -> ir.Value:
+        if value.type == target_ty:
+            return value
+        if isinstance(target_ty, ir.VectorType):
+            if not isinstance(value.type, ir.VectorType):
+                return _splat_to_vector(value, target_ty)
+            source_elem = value.type.element
+            target_elem = target_ty.element
+            if source_elem == target_elem:
+                return value
+            if isinstance(target_elem, ir.IntType) and isinstance(
+                source_elem, ir.IntType
+            ):
+                if source_elem.width < target_elem.width:
+                    return (
+                        tick_builder.zext(value, target_ty)
+                        if source_elem.width == 1
+                        else tick_builder.sext(value, target_ty)
+                    )
+                if source_elem.width > target_elem.width:
+                    return tick_builder.trunc(value, target_ty)
+            if isinstance(target_elem, (ir.FloatType, ir.DoubleType)) and isinstance(
+                source_elem, ir.IntType
+            ):
+                return tick_builder.sitofp(value, target_ty)
+            if isinstance(target_elem, ir.IntType) and isinstance(
+                source_elem, (ir.FloatType, ir.DoubleType)
+            ):
+                return (
+                    tick_builder.fptoui(value, target_ty)
+                    if type_name == "uint"
+                    else tick_builder.fptosi(value, target_ty)
+                )
+            if isinstance(target_elem, ir.FloatType) and isinstance(
+                source_elem, ir.DoubleType
+            ):
+                return tick_builder.fptrunc(value, target_ty)
+            if isinstance(target_elem, ir.DoubleType) and isinstance(
+                source_elem, ir.FloatType
+            ):
+                return tick_builder.fpext(value, target_ty)
+        if isinstance(value.type, ir.VectorType):
+            raise CodegenError(
+                f"cannot coerce vector value of type '{value.type}' to '{target_ty}'"
+            )
+        return lowerer._coerce_value_to_type(value, target_ty, type_name)
+
+    def _can_vectorize_fused_group(routes: tuple[AstKernelBindRoute, ...]) -> bool:
+        supported_statements = (AstAssignStmt, AstVarDeclStmt)
+        supported_exprs = (
+            AstExprLiteral,
+            AstExprVar,
+            AstExprUnary,
+            AstExprBinary,
+            AstExprCast,
+            AstExprCall,
+        )
+
+        def expr_supported(expr) -> bool:
+            if not isinstance(expr, supported_exprs):
+                return False
+            if isinstance(expr, (AstExprLiteral, AstExprVar)):
+                return True
+            if isinstance(expr, AstExprUnary):
+                return expr_supported(expr.operand)
+            if isinstance(expr, AstExprBinary):
+                return expr_supported(expr.left) and expr_supported(expr.right)
+            if isinstance(expr, AstExprCast):
+                return expr_supported(expr.value)
+            if isinstance(expr, AstExprCall):
+                return expr.name in {
+                    "select",
+                    "step",
+                    "mix",
+                    "min",
+                    "max",
+                    "clamp",
+                    "abs",
+                    "sign",
+                    "smoothstep",
+                    "int",
+                    "uint",
+                    "float",
+                    "double",
+                    "bool",
+                } and all(expr_supported(arg) for arg in expr.args)
+            return False
+
+        for route in routes:
+            signature = kernel_signatures.get(route.kernel)
+            if signature is None:
+                return False
+            kernel_decl, params = signature
+            for param in params:
+                param_ty = lowerer._llvm_type(param.declared_type, known_structs)
+                if _vector_type_for_scalar(param_ty) is None:
+                    return False
+                if param.modifier == "accum":
+                    return False
+            for statement in kernel_decl.body:
+                if not isinstance(statement, supported_statements):
+                    return False
+                if isinstance(statement, AstAssignStmt):
+                    if len(statement.target) != 1 or not expr_supported(
+                        statement.value
+                    ):
+                        return False
+                elif isinstance(statement, AstVarDeclStmt):
+                    declared = statement.declared_type or AstType("float")
+                    if (
+                        _vector_type_for_scalar(
+                            lowerer._llvm_type(declared, known_structs)
+                        )
+                        is None
+                    ):
+                        return False
+                    if statement.initializer is not None and not expr_supported(
+                        statement.initializer
+                    ):
+                        return False
+        return True
+
+    class _FusedVectorLowerer:
+        def __init__(self):
+            self.values: dict[str, ir.Value] = {}
+            self.types: dict[str, str] = {}
+
+        def _declared_vector_type(self, type_name: AstType | str) -> ir.VectorType:
+            scalar_ty = lowerer._llvm_type(type_name, known_structs)
+            vector_ty = _vector_type_for_scalar(scalar_ty)
+            if vector_ty is None:
+                raise CodegenError(f"type '{type_name}' cannot be SIMD-vectorized")
+            return vector_ty
+
+        @staticmethod
+        def _promote_scalar_type_names(
+            left_type: str | None, right_type: str | None
+        ) -> str | None:
+            if left_type is None or right_type is None:
+                return left_type or right_type
+            if left_type == right_type:
+                return left_type
+            if left_type in {"int", "uint"} and right_type in {"int", "uint"}:
+                return "uint" if "uint" in {left_type, right_type} else "int"
+            return None
+
+        def _infer_binary_operand_type(self, node: AstExprBinary) -> str | None:
+            left_type = self._infer_expr_type(node.left)
+            right_type = self._infer_expr_type(node.right)
+            op = node.op
+            if op in {"&&", "||"}:
+                return "bool" if left_type == "bool" and right_type == "bool" else None
+            if op in {"<<", ">>"}:
+                return left_type if left_type in {"int", "uint"} else None
+            if op in {
+                "+",
+                "-",
+                "*",
+                "/",
+                "%",
+                "&",
+                "|",
+                "^",
+                "<",
+                "<=",
+                ">",
+                ">=",
+                "==",
+                "!=",
+            }:
+                return self._promote_scalar_type_names(left_type, right_type)
+            return None
+
+        def _infer_expr_type(self, node) -> str | None:
+            if isinstance(node, AstExprLiteral):
+                return node.kind if node.kind in _PRIMITIVE_TYPE_MAP else None
+            if isinstance(node, AstExprVar):
+                return self.types.get(_sanitize_symbol(node.path[0]))
+            if isinstance(node, AstExprCast):
+                return _type_name(node.target_type)
+            if isinstance(node, AstExprUnary):
+                return self._infer_expr_type(node.operand)
+            if isinstance(node, AstExprCall):
+                if node.name in {"int", "uint", "float", "double", "bool"}:
+                    return node.name
+                if node.name == "select" and len(node.args) == 3:
+                    return self._infer_expr_type(node.args[1])
+                if node.name in {
+                    "step",
+                    "mix",
+                    "min",
+                    "max",
+                    "clamp",
+                    "abs",
+                    "sign",
+                    "smoothstep",
+                }:
+                    return "float"
+                return None
+            if isinstance(node, AstExprBinary):
+                operand_type = self._infer_binary_operand_type(node)
+                return (
+                    "bool"
+                    if node.op in {"<", "<=", ">", ">=", "==", "!=", "&&", "||"}
+                    and operand_type is not None
+                    else operand_type
+                )
+            return None
+
+        def _literal(self, node: AstExprLiteral) -> ir.Value:
+            if node.kind == "float":
+                scalar = ir.Constant(ir.FloatType(), float(node.value))
+            elif node.kind == "double":
+                scalar = ir.Constant(ir.DoubleType(), float(node.value))
+            elif node.kind in {"int", "uint"}:
+                scalar = ir.Constant(ir.IntType(32), int(node.value))
+            elif node.kind == "bool":
+                scalar = ir.Constant(ir.IntType(1), int(node.value == "true"))
+            else:
+                raise CodegenError("strings cannot be SIMD-vectorized")
+            return _splat_to_vector(scalar, ir.VectorType(scalar.type, simd_width))
+
+        def _load_var(self, node: AstExprVar) -> ir.Value:
+            if len(node.path) != 1:
+                raise CodegenError("struct field access cannot be SIMD-vectorized")
+            key = _sanitize_symbol(node.path[0])
+            if key not in self.values:
+                raise CodegenError(f"undefined vector variable '{node.path[0]}'")
+            return self.values[key]
+
+        def _numeric_unary_minus(self, value: ir.Value) -> ir.Value:
+            zero = ir.Constant(value.type, None)
+            if isinstance(value.type.element, (ir.FloatType, ir.DoubleType)):
+                return tick_builder.fsub(zero, value, name="fused_neg")
+            if isinstance(value.type.element, ir.IntType):
+                return tick_builder.sub(zero, value, name="fused_neg")
+            raise CodegenError(f"unary '-' is unsupported for type '{value.type}'")
+
+        def _binary(
+            self, op: str, lhs: ir.Value, rhs: ir.Value, type_name: str | None
+        ) -> ir.Value:
+            if isinstance(lhs.type, ir.VectorType) and not isinstance(
+                rhs.type, ir.VectorType
+            ):
+                rhs = _splat_to_vector(rhs, lhs.type)
+            elif isinstance(rhs.type, ir.VectorType) and not isinstance(
+                lhs.type, ir.VectorType
+            ):
+                lhs = _splat_to_vector(lhs, rhs.type)
+            if lhs.type != rhs.type:
+                raise CodegenError(
+                    f"operator '{op}' requires matching vector operand types, got '{lhs.type}' and '{rhs.type}'"
+                )
+            elem_ty = lhs.type.element
+            if op in {"+", "-", "*", "/", "%"}:
+                if isinstance(elem_ty, (ir.FloatType, ir.DoubleType)):
+                    return {
+                        "+": tick_builder.fadd,
+                        "-": tick_builder.fsub,
+                        "*": tick_builder.fmul,
+                        "/": tick_builder.fdiv,
+                        "%": tick_builder.frem,
+                    }[op](lhs, rhs, name="fused_math")
+                if isinstance(elem_ty, ir.IntType):
+                    return {
+                        "+": tick_builder.add,
+                        "-": tick_builder.sub,
+                        "*": tick_builder.mul,
+                        "/": (
+                            tick_builder.udiv
+                            if type_name == "uint"
+                            else tick_builder.sdiv
+                        ),
+                        "%": (
+                            tick_builder.urem
+                            if type_name == "uint"
+                            else tick_builder.srem
+                        ),
+                    }[op](lhs, rhs, name="fused_math")
+            if op in {"&", "|", "^", "<<", ">>"} and isinstance(elem_ty, ir.IntType):
+                if op == "&":
+                    return tick_builder.and_(lhs, rhs, name="fused_and")
+                if op == "|":
+                    return tick_builder.or_(lhs, rhs, name="fused_or")
+                if op == "^":
+                    return tick_builder.xor(lhs, rhs, name="fused_xor")
+                if op == "<<":
+                    return tick_builder.shl(lhs, rhs, name="fused_shl")
+                return (
+                    tick_builder.lshr if type_name == "uint" else tick_builder.ashr
+                )(lhs, rhs, name="fused_shr")
+            if op in {"<", "<=", ">", ">=", "==", "!="}:
+                rel_map = {
+                    "<": "<",
+                    "<=": "<=",
+                    ">": ">",
+                    ">=": ">=",
+                    "==": "==",
+                    "!=": "!=",
+                }
+                if isinstance(elem_ty, (ir.FloatType, ir.DoubleType)):
+                    return tick_builder.fcmp_ordered(
+                        rel_map[op], lhs, rhs, name="fused_cmp"
+                    )
+                if isinstance(elem_ty, ir.IntType):
+                    cmp_op = (
+                        tick_builder.icmp_unsigned
+                        if type_name == "uint"
+                        else tick_builder.icmp_signed
+                    )
+                    return cmp_op(rel_map[op], lhs, rhs, name="fused_cmp")
+            if op == "&&" or op == "||":
+                return (tick_builder.and_ if op == "&&" else tick_builder.or_)(
+                    lhs, rhs, name="fused_bool"
+                )
+            raise CodegenError(f"unsupported vector binary operator '{op}'")
+
+        def _call(self, name: str, args: list[ir.Value]) -> ir.Value:
+            if name in {"int", "uint", "float", "double", "bool"} and len(args) == 1:
+                return _coerce_vector_value(
+                    args[0], self._declared_vector_type(name), name
+                )
+            if name == "select" and len(args) == 3:
+                return tick_builder.select(
+                    args[0], args[1], args[2], name="fused_select"
+                )
+            if name == "mix" and len(args) == 3:
+                a, b, t = args
+                one = _splat_to_vector(ir.Constant(ir.FloatType(), 1.0), a.type)
+                return tick_builder.fadd(
+                    tick_builder.fmul(
+                        a, tick_builder.fsub(one, t, name="fused_mix_omt")
+                    ),
+                    tick_builder.fmul(b, t),
+                    name="fused_mix",
+                )
+            if name == "step" and len(args) == 2:
+                edge, x_val = args
+                cmp_result = tick_builder.fcmp_ordered(
+                    ">=", x_val, edge, name="fused_step_cmp"
+                )
+                return tick_builder.uitofp(cmp_result, x_val.type, name="fused_step")
+            if name in {"min", "max"} and len(args) == 2:
+                lhs, rhs = args
+                pred = tick_builder.fcmp_ordered(
+                    "<" if name == "min" else ">", lhs, rhs, name=f"fused_{name}_cmp"
+                )
+                return tick_builder.select(pred, lhs, rhs, name=f"fused_{name}")
+            if name == "clamp" and len(args) == 3:
+                x_val, lo, hi = args
+                lower = self._call("max", [x_val, lo])
+                return self._call("min", [lower, hi])
+            if name == "abs" and len(args) == 1:
+                x_val = args[0]
+                zero = ir.Constant(x_val.type, None)
+                neg = tick_builder.fsub(zero, x_val, name="fused_abs_neg")
+                pred = tick_builder.fcmp_ordered("<", x_val, zero, name="fused_abs_cmp")
+                return tick_builder.select(pred, neg, x_val, name="fused_abs")
+            if name == "sign" and len(args) == 1:
+                x_val = args[0]
+                zero = ir.Constant(x_val.type, None)
+                one = _splat_to_vector(ir.Constant(ir.FloatType(), 1.0), x_val.type)
+                neg_one = _splat_to_vector(
+                    ir.Constant(ir.FloatType(), -1.0), x_val.type
+                )
+                pos = tick_builder.fcmp_ordered(">", x_val, zero, name="fused_sign_pos")
+                neg = tick_builder.fcmp_ordered("<", x_val, zero, name="fused_sign_neg")
+                return tick_builder.select(
+                    pos, one, tick_builder.select(neg, neg_one, zero), name="fused_sign"
+                )
+            if name == "smoothstep" and len(args) == 3:
+                edge0, edge1, x_val = args
+                zero = _splat_to_vector(ir.Constant(ir.FloatType(), 0.0), x_val.type)
+                one = _splat_to_vector(ir.Constant(ir.FloatType(), 1.0), x_val.type)
+                two = _splat_to_vector(ir.Constant(ir.FloatType(), 2.0), x_val.type)
+                three = _splat_to_vector(ir.Constant(ir.FloatType(), 3.0), x_val.type)
+                t_raw = tick_builder.fdiv(
+                    tick_builder.fsub(x_val, edge0, name="fused_ss_diff"),
+                    tick_builder.fsub(edge1, edge0, name="fused_ss_range"),
+                    name="fused_ss_raw",
+                )
+                t = self._call("clamp", [t_raw, zero, one])
+                return tick_builder.fmul(
+                    tick_builder.fmul(t, t, name="fused_ss_tsq"),
+                    tick_builder.fsub(
+                        three, tick_builder.fmul(two, t), name="fused_ss_poly"
+                    ),
+                    name="fused_smoothstep",
+                )
+            raise CodegenError(f"unsupported vector call '{name}'")
+
+        def lower_expr(self, node) -> ir.Value:
+            if isinstance(node, AstExprLiteral):
+                return self._literal(node)
+            if isinstance(node, AstExprVar):
+                return self._load_var(node)
+            if isinstance(node, AstExprUnary):
+                operand = self.lower_expr(node.operand)
+                if node.op == "-":
+                    return self._numeric_unary_minus(operand)
+                return tick_builder.not_(operand, name="fused_not")
+            if isinstance(node, AstExprCall):
+                return self._call(
+                    node.name, [self.lower_expr(arg) for arg in node.args]
+                )
+            if isinstance(node, AstExprCast):
+                return _coerce_vector_value(
+                    self.lower_expr(node.value),
+                    self._declared_vector_type(node.target_type),
+                    _type_name(node.target_type),
+                )
+            if isinstance(node, AstExprBinary):
+                lhs = self.lower_expr(node.left)
+                rhs = self.lower_expr(node.right)
+                expr_type_name = self._infer_expr_type(
+                    node.left
+                ) or self._infer_expr_type(node.right)
+                operand_type_name = (
+                    self._infer_binary_operand_type(node) or expr_type_name
+                )
+                if operand_type_name in _PRIMITIVE_TYPE_MAP:
+                    vector_ty = self._declared_vector_type(operand_type_name)
+                    lhs = _coerce_vector_value(lhs, vector_ty, operand_type_name)
+                    rhs = _coerce_vector_value(rhs, vector_ty, operand_type_name)
+                return self._binary(node.op, lhs, rhs, operand_type_name)
+            raise CodegenError(
+                f"unsupported vector expression node '{type(node).__name__}'"
+            )
+
+        def lower_statement(self, statement: AstStatement) -> None:
+            if isinstance(statement, AstAssignStmt):
+                if len(statement.target) != 1:
+                    raise CodegenError("field assignment cannot be SIMD-vectorized")
+                key = _sanitize_symbol(statement.target[0])
+                target_ty = self.values[key].type
+                type_name = self.types.get(key)
+                self.values[key] = _coerce_vector_value(
+                    self.lower_expr(statement.value), target_ty, type_name
+                )
+                return
+            if isinstance(statement, AstVarDeclStmt):
+                key = _sanitize_symbol(statement.name)
+                declared_type = (
+                    _type_name(statement.declared_type)
+                    if statement.declared_type
+                    else "float"
+                )
+                vector_ty = self._declared_vector_type(declared_type)
+                self.types[key] = declared_type
+                self.values[key] = ir.Constant(vector_ty, None)
+                if statement.initializer is not None:
+                    self.values[key] = _coerce_vector_value(
+                        self.lower_expr(statement.initializer), vector_ty, declared_type
+                    )
+                return
+            raise CodegenError(
+                f"unsupported vector statement node '{type(statement).__name__}'"
+            )
+
+    def _vector_lane_indices(current: ir.Value) -> ir.Value:
+        vector_ty = ir.VectorType(ir.IntType(32), simd_width)
+        lanes = ir.Constant(vector_ty, list(range(simd_width)))
+        return tick_builder.add(
+            _splat_to_vector(current, vector_ty), lanes, name="fused_lane_indices"
+        )
+
+    def _load_stream_vector(
+        name: str, scalar_ty: ir.Type, lane_indices: ir.Value
+    ) -> ir.Value:
+        vector_ty = ir.VectorType(scalar_ty, simd_width)
+        result = ir.Constant(vector_ty, ir.Undefined)
+        for lane in range(simd_width):
+            lane_index = tick_builder.extract_element(
+                lane_indices,
+                ir.Constant(ir.IntType(32), lane),
+                name=f"fused_load_lane_{lane}_idx",
+            )
+            clamped = _clamped_stream_index(name, lane_index)
+            lane_value = _load_tick_param("stream", name, scalar_ty, clamped)
+            result = tick_builder.insert_element(
+                result,
+                lane_value,
+                ir.Constant(ir.IntType(32), lane),
+                name=f"fused_{_sanitize_symbol(name)}_lane_{lane}",
+            )
+        return result
+
+    def _store_stream_vector(
+        name: str, value: ir.Value, lane_indices: ir.Value
+    ) -> None:
+        for lane in range(simd_width):
+            lane_index = tick_builder.extract_element(
+                lane_indices,
+                ir.Constant(ir.IntType(32), lane),
+                name=f"fused_store_lane_{lane}_idx",
+            )
+            clamped = _clamped_stream_index(name, lane_index)
+            ptr = _load_tick_param_ptr("stream", name, value.type.element, clamped)
+            if ptr is not None:
+                lane_value = tick_builder.extract_element(
+                    value,
+                    ir.Constant(ir.IntType(32), lane),
+                    name=f"fused_store_lane_{lane}",
+                )
+                tick_builder.store(lane_value, ptr)
+
+    def _emit_vector_fused_chunk(
+        routes: tuple[AstKernelBindRoute, ...],
+        current: ir.Value,
+        eliminated_targets: set[str],
+    ) -> None:
+        lane_indices = _vector_lane_indices(current)
+        route_values: dict[str, ir.Value] = {}
+        for route in routes:
+            signature = kernel_signatures[route.kernel]
+            kernel_decl, params = signature
+            vector_lowerer = _FusedVectorLowerer()
+            out_params: list[tuple[str, str]] = []
+            for index, param in enumerate(params):
+                arg_name = route.args[index] if index < len(route.args) else ""
+                key = _sanitize_symbol(param.name)
+                scalar_ty = lowerer._llvm_type(param.declared_type, known_structs)
+                vector_ty = ir.VectorType(scalar_ty, simd_width)
+                vector_lowerer.types[key] = _type_name(param.declared_type)
+                if param.modifier == "in" and arg_name in route_values:
+                    vector_lowerer.values[key] = route_values[arg_name]
+                elif param.modifier == "in" and arg_name in stream_slots:
+                    vector_lowerer.values[key] = _load_stream_vector(
+                        arg_name, scalar_ty, lane_indices
+                    )
+                elif param.modifier == "uniform" and arg_name in uniform_slots:
+                    scalar = _load_tick_param("uniform", arg_name, scalar_ty)
+                    vector_lowerer.values[key] = _splat_to_vector(scalar, vector_ty)
+                elif param.modifier == "out":
+                    vector_lowerer.values[key] = ir.Constant(vector_ty, None)
+                    out_params.append((arg_name, key))
+                else:
+                    vector_lowerer.values[key] = ir.Constant(vector_ty, None)
+            for statement in kernel_decl.body:
+                vector_lowerer.lower_statement(statement)
+            for arg_name, key in out_params:
+                value = vector_lowerer.values[key]
+                if arg_name in eliminated_targets:
+                    route_values[arg_name] = value
+                elif arg_name in stream_slots:
+                    _store_stream_vector(arg_name, value, lane_indices)
+
     def _lower_fused_kernel_group(
         routes: tuple[AstKernelBindRoute, ...], group_index: int
     ):
@@ -1716,7 +2285,12 @@ def emit_llvm_ir(
         if not eliminated_targets:
             _lower_kernel_route(routes[0])
             return
+        if not _can_vectorize_fused_group(routes):
+            for route in routes:
+                _lower_kernel_route(route)
+            return
 
+        full_trip_count = (trip_count // simd_width) * simd_width
         index_ptr = tick_builder.alloca(ir.IntType(32), name=f"fused_{group_index}_idx")
         tick_builder.store(ir.Constant(ir.IntType(32), 0), index_ptr)
 
@@ -1728,13 +2302,44 @@ def emit_llvm_ir(
         tick_builder.position_at_end(loop_cond)
         current = tick_builder.load(index_ptr, name="fused_idx")
         cond = tick_builder.icmp_signed(
-            "<", current, ir.Constant(ir.IntType(32), trip_count), name="fused_active"
+            "<",
+            current,
+            ir.Constant(ir.IntType(32), full_trip_count),
+            name="fused_vector_active",
         )
         tick_builder.cbranch(cond, loop_body, loop_exit)
 
         tick_builder.position_at_end(loop_body)
+        _emit_vector_fused_chunk(routes, current, eliminated_targets)
+        next_index = tick_builder.add(
+            current, ir.Constant(ir.IntType(32), simd_width), name="fused_idx_next"
+        )
+        tick_builder.store(next_index, index_ptr)
+        tick_builder.branch(loop_cond)
 
-        def _emit_fused_lane(lane_index: ir.Value) -> None:
+        tick_builder.position_at_end(loop_exit)
+
+        if full_trip_count < trip_count:
+            tail_index_ptr = tick_builder.alloca(
+                ir.IntType(32), name=f"fused_{group_index}_tail_idx"
+            )
+            tick_builder.store(
+                ir.Constant(ir.IntType(32), full_trip_count), tail_index_ptr
+            )
+            tail_cond = tick.append_basic_block(f"fused_{group_index}_tail_cond")
+            tail_body = tick.append_basic_block(f"fused_{group_index}_tail_body")
+            tail_exit = tick.append_basic_block(f"fused_{group_index}_tail_exit")
+            tick_builder.branch(tail_cond)
+            tick_builder.position_at_end(tail_cond)
+            tail_current = tick_builder.load(tail_index_ptr, name="fused_tail_idx")
+            tail_active = tick_builder.icmp_signed(
+                "<",
+                tail_current,
+                ir.Constant(ir.IntType(32), trip_count),
+                name="fused_tail_active",
+            )
+            tick_builder.cbranch(tail_active, tail_body, tail_exit)
+            tick_builder.position_at_end(tail_body)
             local_slots: dict[str, ir.AllocaInstr] = {}
             for route in routes:
                 callee, params = _kernel_function_and_params(route.kernel)
@@ -1751,38 +2356,15 @@ def emit_llvm_ir(
                     ):
                         slot_name = _sanitize_symbol(route.args[index])
                         local_slots[route.args[index]] = tick_builder.alloca(
-                            param.type.pointee, name=f"fused_{slot_name}_slot"
+                            param.type.pointee, name=f"fused_{slot_name}_tail_slot"
                         )
-                _emit_kernel_call(route, lane_index, local_slots=local_slots)
-
-        _emit_fused_lane(current)
-        for lane in range(1, simd_width):
-            lane_index = tick_builder.add(
-                current,
-                ir.Constant(ir.IntType(32), lane),
-                name=f"fused_lane_{lane}_idx",
+                _emit_kernel_call(route, tail_current, local_slots=local_slots)
+            tail_next = tick_builder.add(
+                tail_current, ir.Constant(ir.IntType(32), 1), name="fused_tail_next"
             )
-            lane_active = tick_builder.icmp_signed(
-                "<",
-                lane_index,
-                ir.Constant(ir.IntType(32), trip_count),
-                name=f"fused_lane_{lane}_active",
-            )
-            lane_body = tick.append_basic_block(f"fused_{group_index}_lane_{lane}")
-            lane_next = tick.append_basic_block(f"fused_{group_index}_lane_{lane}_next")
-            tick_builder.cbranch(lane_active, lane_body, lane_next)
-            tick_builder.position_at_end(lane_body)
-            _emit_fused_lane(lane_index)
-            tick_builder.branch(lane_next)
-            tick_builder.position_at_end(lane_next)
-
-        next_index = tick_builder.add(
-            current, ir.Constant(ir.IntType(32), simd_width), name="fused_idx_next"
-        )
-        tick_builder.store(next_index, index_ptr)
-        tick_builder.branch(loop_cond)
-
-        tick_builder.position_at_end(loop_exit)
+            tick_builder.store(tail_next, tail_index_ptr)
+            tick_builder.branch(tail_cond)
+            tick_builder.position_at_end(tail_exit)
 
     def _lower_fold_route(route: AstFoldBindRoute) -> None:
         source_name = route.source

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -230,10 +230,12 @@ def test_compile_pipeline_lowers_fused_group_to_single_simd_loop_without_interme
     assert "fused_0_body" in result.llvm_ir
     assert "route_A_body" not in result.llvm_ir
     assert "route_B_body" not in result.llvm_ir
-    assert 'float* %"fused_tmp_slot"' in result.llvm_ir
+    assert "<4 x float>" in result.llvm_ir
+    assert '"fused_math" = fadd <4 x float>' in result.llvm_ir
+    assert '"fused_math.1" = fmul <4 x float>' in result.llvm_ir
     assert "stream_tmp_value_ptr" not in result.llvm_ir
-    assert 'call void @"shader_A"' in result.llvm_ir
-    assert 'call void @"shader_B"' in result.llvm_ir
+    assert 'call void @"shader_A"' not in result.llvm_ir
+    assert 'call void @"shader_B"' not in result.llvm_ir
     llvm.parse_assembly(result.llvm_ir)
 
 


### PR DESCRIPTION
### Motivation
- The existing fused-kernel lowering emitted per-lane scalar basic blocks, which prevented LLVM from using native SIMD vector instructions and reduced performance.
- Replace scalar unrolling with true vectorized codegen so eliminated intermediate values can live in vector registers and the backend can generate hardware SIMD math.

### Description
- Implement SIMD helpers and coercions in `lockstep_compiler/codegen.py` to construct `<N x T>` vector types, splat scalars to vectors, and coerce between vector/element types.
- Add `_FusedVectorLowerer` that lowers kernel/filter bodies to vector expressions and emits vector ops (add/mul/select/compare/etc.) instead of per-lane scalar calls. 
- Replace the old per-lane fused emission with a vector-chunk loop plus stream gather/scatter and a scalar tail loop to handle non-multiple-of-width counts. 
- Update tests to assert vector IR appears and that scalar shader/filter calls are not used for the vectorized fused path (`tests/test_optimizer.py`).

### Testing
- Ran `python -m py_compile lockstep_compiler/codegen.py tests/test_optimizer.py` which succeeded. 
- Ran `pytest -q tests/test_optimizer.py` which passed (optimizer tests covering the new fused vector lowering succeeded). 
- Ran the broader `pytest -q tests/test_optimizer.py tests/test_compiler_api.py`; optimizer tests passed but some `test_compiler_api.py` expectations (unrelated ABI/header/semantic expectations) failed and are reported separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f06902a38832889b106fd2935e9b4)