### PR TITLE
Preserve uint context during float->int vector coercion (use fptoui for uint targets)

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -1724,11 +1724,13 @@ def emit_llvm_ir(
             return ir.VectorType(scalar_type, simd_width)
         return None
 
-    def _splat_to_vector(value: ir.Value, vector_ty: ir.VectorType) -> ir.Value:
+    def _splat_to_vector(
+        value: ir.Value, vector_ty: ir.VectorType, type_name: str | None = None
+    ) -> ir.Value:
         if value.type == vector_ty:
             return value
         if value.type != vector_ty.element:
-            value = lowerer._coerce_value_to_type(value, vector_ty.element)
+            value = lowerer._coerce_value_to_type(value, vector_ty.element, type_name)
         seed = tick_builder.insert_element(
             ir.Constant(vector_ty, ir.Undefined), value, ir.Constant(ir.IntType(32), 0)
         )
@@ -1744,7 +1746,7 @@ def emit_llvm_ir(
             return value
         if isinstance(target_ty, ir.VectorType):
             if not isinstance(value.type, ir.VectorType):
-                return _splat_to_vector(value, target_ty)
+                return _splat_to_vector(value, target_ty, type_name)
             source_elem = value.type.element
             target_elem = target_ty.element
             if source_elem == target_elem:


### PR DESCRIPTION
### Motivation

- Floating-point to integer coercions previously always emitted `fptosi`, which is incorrect when the declared target is an unsigned integer (`uint`) and can corrupt values in the high unsigned range.
- Scalar-to-vector "splat" coercions dropped the declared target type-name context, preventing vectorized float->uint conversions from selecting the unsigned `fptoui` instruction.

### Description

- Added an optional `type_name: str | None` parameter to `_splat_to_vector` and threaded it through callers so scalar splatting preserves the declared target type context.
- Forwarded the `type_name` into the scalar coercion call `lowerer._coerce_value_to_type(value, vector_ty.element, type_name)` so `uint` context reaches the scalar coercion helper.
- Updated `_coerce_vector_value` to call `_splat_to_vector(value, target_ty, type_name)` when converting scalars into vectors.
- This enables the existing `target_type_name == "uint"` path in `_coerce_value_to_type` to select `fptoui` for unsigned targets (and leave `fptosi` for signed targets).

### Testing

- Ran the focused tests `pytest tests/test_compiler_api.py::test_emit_llvm_ir_lowers_explicit_numeric_casts_to_llvm_conversions` and `pytest tests/test_compiler_api.py::test_emit_llvm_ir_uses_unsigned_float_to_integer_cast_for_uint_targets`, both passed.
- Verified `python -m py_compile lockstep_compiler/codegen.py` succeeded.
- Executed `pytest tests/test_compiler_api.py` to exercise broader behaviors; the run produced unrelated failures (9 fails, 43 passes) that pre-existed and are not caused by these coercion-context changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f0971d6a48328a8380ec398b0df4c)