### PR TITLE
Optimize reduce fold strip-mined vector loads

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -1436,22 +1436,12 @@ def emit_llvm_ir(
         identity_value = _identity_value()
         vector_accumulator = ir.Constant(vector_ty, [identity_value] * simd_width)
 
-        def _load_accum_chunk_vector(element_index: ir.Value) -> ir.Value:
+        def _load_accum_chunk_vector(chunk_vector_ptr: ir.Value) -> ir.Value:
             # The strip-mined fold consumes a contiguous SIMD-width chunk of the
-            # accumulator.  Load that chunk through one base pointer rather than
-            # synthesizing a separate scalar address stream for every lane; LLVM
-            # can then lower the vector load to the target's preferred memory
-            # access pattern.
-            chunk_base_ptr = _leaf_ptr(
-                "accum", source_name, (), uniform_type, element_index
-            )
-            if chunk_base_ptr is None:
-                return ir.Constant(vector_ty, [identity_value] * simd_width)
-            chunk_vector_ptr = tick_builder.bitcast(
-                chunk_base_ptr,
-                vector_ty.as_pointer(),
-                name=f"fold_{_sanitize_symbol(source_name)}_chunk_ptr",
-            )
+            # accumulator.  The strip loop carries a vector pointer induction
+            # variable, so the loop body performs one uniform vector load and
+            # one vector-strided pointer increment instead of rebuilding scalar
+            # byte offsets independently for every SIMD lane.
             return tick_builder.load(
                 chunk_vector_ptr, name=f"fold_{_sanitize_symbol(source_name)}_chunk"
             )
@@ -1505,47 +1495,66 @@ def emit_llvm_ir(
         # after the strip loop and any scalar tail have been merged.
         full_chunk_limit = (lane_count // simd_width) * simd_width
         if full_chunk_limit:
-            preheader_block = tick_builder.block
-            loop_cond = tick.append_basic_block(
-                f"fold_{_sanitize_symbol(source_name)}_strip_cond"
-            )
-            loop_body = tick.append_basic_block(
-                f"fold_{_sanitize_symbol(source_name)}_strip_body"
-            )
-            loop_exit = tick.append_basic_block(
-                f"fold_{_sanitize_symbol(source_name)}_strip_exit"
-            )
+            first_chunk_ptr = _leaf_ptr("accum", source_name, (), uniform_type)
+            if first_chunk_ptr is not None:
+                first_chunk_vector_ptr = tick_builder.bitcast(
+                    first_chunk_ptr,
+                    vector_ty.as_pointer(),
+                    name=f"fold_{_sanitize_symbol(source_name)}_chunk_ptr",
+                )
+                preheader_block = tick_builder.block
+                loop_cond = tick.append_basic_block(
+                    f"fold_{_sanitize_symbol(source_name)}_strip_cond"
+                )
+                loop_body = tick.append_basic_block(
+                    f"fold_{_sanitize_symbol(source_name)}_strip_body"
+                )
+                loop_exit = tick.append_basic_block(
+                    f"fold_{_sanitize_symbol(source_name)}_strip_exit"
+                )
 
-            tick_builder.branch(loop_cond)
-            tick_builder.position_at_end(loop_cond)
-            loop_index = tick_builder.phi(ir.IntType(32), name="fold_index")
-            loop_accumulator = tick_builder.phi(vector_ty, name="fold_vector_acc")
-            loop_index.add_incoming(ir.Constant(ir.IntType(32), 0), preheader_block)
-            loop_accumulator.add_incoming(vector_accumulator, preheader_block)
-            in_full_chunks = tick_builder.icmp_unsigned(
-                "<",
-                loop_index,
-                ir.Constant(ir.IntType(32), full_chunk_limit),
-                name="fold_has_full_chunk",
-            )
-            tick_builder.cbranch(in_full_chunks, loop_body, loop_exit)
+                tick_builder.branch(loop_cond)
+                tick_builder.position_at_end(loop_cond)
+                loop_index = tick_builder.phi(ir.IntType(32), name="fold_index")
+                loop_chunk_ptr = tick_builder.phi(
+                    first_chunk_vector_ptr.type, name="fold_chunk_ptr"
+                )
+                loop_accumulator = tick_builder.phi(vector_ty, name="fold_vector_acc")
+                loop_index.add_incoming(
+                    ir.Constant(ir.IntType(32), 0), preheader_block
+                )
+                loop_chunk_ptr.add_incoming(first_chunk_vector_ptr, preheader_block)
+                loop_accumulator.add_incoming(vector_accumulator, preheader_block)
+                in_full_chunks = tick_builder.icmp_unsigned(
+                    "<",
+                    loop_index,
+                    ir.Constant(ir.IntType(32), full_chunk_limit),
+                    name="fold_has_full_chunk",
+                )
+                tick_builder.cbranch(in_full_chunks, loop_body, loop_exit)
 
-            tick_builder.position_at_end(loop_body)
-            chunk_vector = _load_accum_chunk_vector(loop_index)
-            next_accumulator = _combine_vectors(
-                loop_accumulator, chunk_vector, "fold_vector_next"
-            )
-            next_index = tick_builder.add(
-                loop_index,
-                ir.Constant(ir.IntType(32), simd_width),
-                name="fold_index_next",
-            )
-            tick_builder.branch(loop_cond)
-            loop_index.add_incoming(next_index, tick_builder.block)
-            loop_accumulator.add_incoming(next_accumulator, tick_builder.block)
+                tick_builder.position_at_end(loop_body)
+                chunk_vector = _load_accum_chunk_vector(loop_chunk_ptr)
+                next_accumulator = _combine_vectors(
+                    loop_accumulator, chunk_vector, "fold_vector_next"
+                )
+                next_index = tick_builder.add(
+                    loop_index,
+                    ir.Constant(ir.IntType(32), simd_width),
+                    name="fold_index_next",
+                )
+                next_chunk_ptr = tick_builder.gep(
+                    loop_chunk_ptr,
+                    [ir.Constant(ir.IntType(32), 1)],
+                    name="fold_chunk_ptr_next",
+                )
+                tick_builder.branch(loop_cond)
+                loop_index.add_incoming(next_index, tick_builder.block)
+                loop_chunk_ptr.add_incoming(next_chunk_ptr, tick_builder.block)
+                loop_accumulator.add_incoming(next_accumulator, tick_builder.block)
 
-            tick_builder.position_at_end(loop_exit)
-            vector_accumulator = loop_accumulator
+                tick_builder.position_at_end(loop_exit)
+                vector_accumulator = loop_accumulator
 
         tail_count = lane_count - full_chunk_limit
         if tail_count:

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -1069,8 +1069,22 @@ def test_emit_llvm_ir_strip_mines_large_fold_without_truncating_to_target_width(
     assert 'call fast float @"llvm.vector.reduce.fadd.v8f32"' in llvm_ir
     assert '%"struct.Lockstep_Arena" = type {[512 x float], float}' in llvm_ir
     assert '%"fold_energy_chunk_ptr" = bitcast float*' in llvm_ir
-    assert '%"fold_energy_chunk" = load <8 x float>, <8 x float>* %"fold_energy_chunk_ptr"' in llvm_ir
-    assert '%"accum_energy_byte_index" = mul i32 %"fold_index", 4' in llvm_ir
+    assert (
+        '%"fold_chunk_ptr" = phi  <8 x float>* '
+        '[%"fold_energy_chunk_ptr", %"entry"], '
+        '[%"fold_chunk_ptr_next", %"fold_energy_strip_body"]'
+        in llvm_ir
+    )
+    assert (
+        '%"fold_energy_chunk" = load <8 x float>, <8 x float>* %"fold_chunk_ptr"'
+        in llvm_ir
+    )
+    assert (
+        '%"fold_chunk_ptr_next" = getelementptr <8 x float>, '
+        '<8 x float>* %"fold_chunk_ptr", i32 1'
+        in llvm_ir
+    )
+    assert '%"accum_energy_byte_index" = mul i32 %"fold_index", 4' not in llvm_ir
     assert '%"fold_elem_7" = add i32 %"fold_index", 7' not in llvm_ir
 
 
@@ -1108,6 +1122,15 @@ def test_compile_lockstep_strip_mines_fold_across_accumulator_route_width():
     assert '%"fold_index_next" = add i32 %"fold_index", 8' in result.llvm_ir
     assert 'mul i32 %"idx", 4' in result.llvm_ir
     assert 'mul i32 16, 4' in result.llvm_ir
+    assert (
+        '%"fold_chunk_ptr_next" = getelementptr <8 x float>, '
+        '<8 x float>* %"fold_chunk_ptr", i32 1'
+        in result.llvm_ir
+    )
+    assert (
+        '%"accum_energy_byte_index" = mul i32 %"fold_index", 4'
+        not in result.llvm_ir
+    )
     assert (
         '%"fold_avg" = fdiv float %"fold_reduce", 0x4031000000000000'
         in result.llvm_ir


### PR DESCRIPTION
### Motivation
- The inner strip-mined fold loop rebuilt per-lane scalar byte offsets by calling `_leaf_ptr` with a dynamic index for every SIMD lane, which emitted redundant `mul`/`add` address arithmetic and cluttered the generated LLVM IR.
- Consolidate address calculation so the strip loop performs a single uniform vector load and a vector-strided pointer increment, enabling cleaner IR and less pressure on downstream optimizers.

### Description
- Change `_reduce_fold` to hoist the first accumulator chunk pointer and bitcast it to a `vector_ty*`, then carry that pointer through the strip-mined loop as a PHI (`fold_chunk_ptr`).
- Replace per-lane scalar address synthesis with a loop body that calls `_load_accum_chunk_vector` with the carried `chunk_ptr`, performs one `load <N x T>` and advances the pointer with a `getelementptr` by `1` each iteration.
- Adjust `_load_accum_chunk_vector` signature to accept a `chunk_vector_ptr` and simply emit the vector load; keep the existing scalar tail path that inserts lane values when the accumulator is not present.
- Update unit tests in `tests/test_compiler_api.py` to assert the presence of the vector pointer PHI/load/GEP pattern and the absence of the redundant `accum_* = mul` scalar byte-index stream.

### Testing
- Ran targeted compiler tests `pytest tests/test_compiler_api.py::test_emit_llvm_ir_strip_mines_large_fold_without_truncating_to_target_width tests/test_compiler_api.py::test_compile_lockstep_strip_mines_fold_across_accumulator_route_width -q`, both of which passed.
- Ran the broader `tests/test_compiler_api.py -q`, which reported unrelated existing failures in `c_header` handling of `LayoutStructDecl` and semantic uint/type validation unrelated to this change.
- Ran `git diff --check` and formatting checks, which flagged that files would be reformatted by `black`; formatting changes to tests were applied to keep assertions stable under formatting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f0993b7a48328a8e0f35aec971041)