### PR TITLE
Use LLVM vector loads/stores for fused kernels

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -2205,10 +2205,39 @@ def emit_llvm_ir(
             _splat_to_vector(current, vector_ty), lanes, name="fused_lane_indices"
         )
 
+    def _stream_has_contiguous_vector_chunk(name: str, chunk_trip_count: int) -> bool:
+        return name in stream_capacities and stream_capacities[name] >= chunk_trip_count
+
+    def _stream_vector_ptr(
+        name: str, scalar_ty: ir.Type, current: ir.Value
+    ) -> ir.Value | None:
+        scalar_ptr = _load_tick_param_ptr("stream", name, scalar_ty, current)
+        if scalar_ptr is None:
+            return None
+        vector_ty = ir.VectorType(scalar_ty, simd_width)
+        return tick_builder.bitcast(
+            scalar_ptr,
+            vector_ty.as_pointer(),
+            name=f"fused_{_sanitize_symbol(name)}_vector_ptr",
+        )
+
     def _load_stream_vector(
-        name: str, scalar_ty: ir.Type, lane_indices: ir.Value
+        name: str,
+        scalar_ty: ir.Type,
+        current: ir.Value,
+        chunk_trip_count: int,
     ) -> ir.Value:
         vector_ty = ir.VectorType(scalar_ty, simd_width)
+        if _stream_has_contiguous_vector_chunk(name, chunk_trip_count):
+            vector_ptr = _stream_vector_ptr(name, scalar_ty, current)
+            if vector_ptr is not None:
+                vector_load = tick_builder.load(
+                    vector_ptr, name=f"fused_{_sanitize_symbol(name)}_vector"
+                )
+                vector_load.align = 1
+                return vector_load
+
+        lane_indices = _vector_lane_indices(current)
         result = ir.Constant(vector_ty, ir.Undefined)
         for lane in range(simd_width):
             lane_index = tick_builder.extract_element(
@@ -2227,8 +2256,20 @@ def emit_llvm_ir(
         return result
 
     def _store_stream_vector(
-        name: str, value: ir.Value, lane_indices: ir.Value
+        name: str,
+        value: ir.Value,
+        current: ir.Value,
+        chunk_trip_count: int,
     ) -> None:
+        scalar_ty = value.type.element
+        if _stream_has_contiguous_vector_chunk(name, chunk_trip_count):
+            vector_ptr = _stream_vector_ptr(name, scalar_ty, current)
+            if vector_ptr is not None:
+                vector_store = tick_builder.store(value, vector_ptr)
+                vector_store.align = 1
+                return
+
+        lane_indices = _vector_lane_indices(current)
         for lane in range(simd_width):
             lane_index = tick_builder.extract_element(
                 lane_indices,
@@ -2236,7 +2277,7 @@ def emit_llvm_ir(
                 name=f"fused_store_lane_{lane}_idx",
             )
             clamped = _clamped_stream_index(name, lane_index)
-            ptr = _load_tick_param_ptr("stream", name, value.type.element, clamped)
+            ptr = _load_tick_param_ptr("stream", name, scalar_ty, clamped)
             if ptr is not None:
                 lane_value = tick_builder.extract_element(
                     value,
@@ -2249,8 +2290,8 @@ def emit_llvm_ir(
         routes: tuple[AstKernelBindRoute, ...],
         current: ir.Value,
         eliminated_targets: set[str],
+        chunk_trip_count: int,
     ) -> None:
-        lane_indices = _vector_lane_indices(current)
         route_values: dict[str, ir.Value] = {}
         for route in routes:
             signature = kernel_signatures[route.kernel]
@@ -2267,7 +2308,10 @@ def emit_llvm_ir(
                     vector_lowerer.values[key] = route_values[arg_name]
                 elif param.modifier == "in" and arg_name in stream_slots:
                     vector_lowerer.values[key] = _load_stream_vector(
-                        arg_name, scalar_ty, lane_indices
+                        arg_name,
+                        scalar_ty,
+                        current,
+                        chunk_trip_count,
                     )
                 elif param.modifier == "uniform" and arg_name in uniform_slots:
                     scalar = _load_tick_param("uniform", arg_name, scalar_ty)
@@ -2284,7 +2328,7 @@ def emit_llvm_ir(
                 if arg_name in eliminated_targets:
                     route_values[arg_name] = value
                 elif arg_name in stream_slots:
-                    _store_stream_vector(arg_name, value, lane_indices)
+                    _store_stream_vector(arg_name, value, current, chunk_trip_count)
 
     def _lower_fused_kernel_group(
         routes: tuple[AstKernelBindRoute, ...], group_index: int
@@ -2321,7 +2365,7 @@ def emit_llvm_ir(
         tick_builder.cbranch(cond, loop_body, loop_exit)
 
         tick_builder.position_at_end(loop_body)
-        _emit_vector_fused_chunk(routes, current, eliminated_targets)
+        _emit_vector_fused_chunk(routes, current, eliminated_targets, trip_count)
         next_index = tick_builder.add(
             current, ir.Constant(ir.IntType(32), simd_width), name="fused_idx_next"
         )

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -231,8 +231,12 @@ def test_compile_pipeline_lowers_fused_group_to_single_simd_loop_without_interme
     assert "route_A_body" not in result.llvm_ir
     assert "route_B_body" not in result.llvm_ir
     assert "<4 x float>" in result.llvm_ir
+    assert '"fused_inp_vector" = load <4 x float>' in result.llvm_ir
+    assert 'store <4 x float> %"fused_math.1"' in result.llvm_ir
     assert '"fused_math" = fadd <4 x float>' in result.llvm_ir
     assert '"fused_math.1" = fmul <4 x float>' in result.llvm_ir
+    assert "fused_load_lane_" not in result.llvm_ir
+    assert "fused_store_lane_" not in result.llvm_ir
     assert "stream_tmp_value_ptr" not in result.llvm_ir
     assert 'call void @"shader_A"' not in result.llvm_ir
     assert 'call void @"shader_B"' not in result.llvm_ir


### PR DESCRIPTION
### Motivation
- Fused kernel lowering previously assembled per-lane scalar loads/stores and inserted those lanes into vector values, producing scalar pack/scatter IR that prevents LLVM from generating native vector memory operations.
- The goal is to let LLVM operate on true vector registers (e.g. `<N x T>`) by loading/storing contiguous SIMD-width chunks directly when the stream backing store can safely provide contiguous memory for the fused chunk.

### Description
- Add `_stream_has_contiguous_vector_chunk` and `_stream_vector_ptr` helpers to detect and obtain a vector pointer for a stream chunk and to centralize the contiguous-chunk logic. 
- Update `_load_stream_vector` to prefer an LLVM `load <N x T>` from a bitcast vector pointer when the stream can service the chunk, falling back to the existing per-lane `extract/insert` scalar path otherwise.
- Update `_store_stream_vector` to prefer an LLVM `store <N x T>` to a bitcast vector pointer when safe, and fall back to per-lane scalar stores otherwise; set alignment on the vector loads/stores.
- Thread the fused-group `trip_count` (named `chunk_trip_count`) into `_emit_vector_fused_chunk` and `_lower_fused_kernel_group` so the contiguous-chunk decision is made per fused iteration chunk.
- Add assertions in the fused-group optimizer test to expect vector `<4 x float>` loads/stores and to ensure scalar per-lane load/store IR is not emitted in the contiguous case (`tests/test_optimizer.py`).

### Testing
- Ran `python -m pytest tests/test_optimizer.py -q` and the optimizer tests passed (including the strengthened fused-kernel assertions). 
- Ran the fused-kernel unit `tests/test_optimizer.py::test_compile_pipeline_lowers_fused_group_to_single_simd_loop_without_intermediate_stream_writes` and it passed and now verifies vector `load <4 x float>` and `store <4 x float>` are emitted while per-lane load/store patterns are absent. 
- Ran broader `pytest` including `tests/test_compiler_api.py` subsets and observed unrelated pre-existing failures in compiler API/header expectations not caused by the fused-vector change; these failures remain and are outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f099c25948328ad603ce997902742)