### PR TITLE
Implement true short-circuit lowering for && and ||

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -563,23 +563,50 @@ class _FunctionLowerer:
             return self.builder.ashr(lhs, rhs)
         if op in {"<", "<=", ">", ">=", "==", "!="}:
             return self._emit_relational_compare(op, lhs, rhs, type_name=type_name)
-        if op == "&&":
-            if (
-                not isinstance(lhs.type, ir.IntType)
-                or lhs.type.width != 1
-                or lhs.type != rhs.type
-            ):
-                self._compiler_error("operator '&&' expects matching boolean operands")
-            return self.builder.and_(lhs, rhs)
-        if op == "||":
-            if (
-                not isinstance(lhs.type, ir.IntType)
-                or lhs.type.width != 1
-                or lhs.type != rhs.type
-            ):
-                self._compiler_error("operator '||' expects matching boolean operands")
-            return self.builder.or_(lhs, rhs)
         self._compiler_error(f"unsupported binary operator '{op}'")
+
+    def _validate_logical_operand(self, op: str, value: ir.Value) -> ir.Value:
+        if not isinstance(value.type, ir.IntType) or value.type.width != 1:
+            self._compiler_error(f"operator '{op}' expects boolean operands")
+        return value
+
+    def _lower_logical_binary_op(self, node: AstExprBinary) -> ir.Value:
+        expr_type_name = self._infer_binary_operand_type(node)
+        bool_ty = ir.IntType(1)
+        lhs = self._validate_logical_operand(node.op, self._lower_expr(node.left))
+        if expr_type_name == "bool":
+            lhs = self._coerce_value_to_type(lhs, bool_ty, "bool")
+
+        lhs_block = self.builder.block
+        rhs_block = lhs_block.function.append_basic_block(
+            f"logic_{'and' if node.op == '&&' else 'or'}_rhs"
+        )
+        merge_block = lhs_block.function.append_basic_block(
+            f"logic_{'and' if node.op == '&&' else 'or'}_merge"
+        )
+
+        if node.op == "&&":
+            short_value = ir.Constant(bool_ty, 0)
+            self.builder.cbranch(lhs, rhs_block, merge_block)
+        else:
+            short_value = ir.Constant(bool_ty, 1)
+            self.builder.cbranch(lhs, merge_block, rhs_block)
+
+        self.builder.position_at_end(rhs_block)
+        rhs = self._validate_logical_operand(node.op, self._lower_expr(node.right))
+        if expr_type_name == "bool":
+            rhs = self._coerce_value_to_type(rhs, bool_ty, "bool")
+        rhs_value_block = self.builder.block
+        rhs_reaches_merge = not rhs_value_block.is_terminated
+        if rhs_reaches_merge:
+            self.builder.branch(merge_block)
+
+        self.builder.position_at_end(merge_block)
+        result = self.builder.phi(bool_ty, name="logic_result")
+        result.add_incoming(short_value, lhs_block)
+        if rhs_reaches_merge:
+            result.add_incoming(rhs, rhs_value_block)
+        return result
 
     def _lower_expr(
         self,
@@ -623,6 +650,8 @@ class _FunctionLowerer:
             )
         if not isinstance(node, AstExprBinary):
             self._compiler_error(f"unsupported expression node '{type(node).__name__}'")
+        if node.op in {"&&", "||"}:
+            return self._lower_logical_binary_op(node)
         lhs, rhs = self._lower_expr(node.left), self._lower_expr(node.right)
         expr_type_name = self._infer_binary_operand_type(node)
         if expr_type_name in _PRIMITIVE_TYPE_MAP:

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -17,6 +17,8 @@ from lockstep_compiler.ast import (
     AstAssignStmt,
     AstProgram,
     AstPureDecl,
+    AstKernelParam,
+    AstType,
     AstExprBinary,
     AstExprCall,
     AstExprCast,
@@ -116,6 +118,88 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
     assert result.llvm_ir.startswith('; ModuleID = "lockstep"\n')
     assert 'define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")' in result.llvm_ir
 
+
+def test_codegen_logical_and_short_circuits_rhs_division():
+    program = AstProgram(
+        pure_functions=(
+            AstPureDecl(
+                name="guarded",
+                return_type=AstType("bool"),
+                params=(
+                    AstKernelParam(
+                        modifier="", declared_type=AstType("int"), name="x"
+                    ),
+                ),
+                body=(
+                    AstReturnStmt(
+                        value=AstExprBinary(
+                            op="&&",
+                            left=AstExprBinary(
+                                op="!=",
+                                left=AstExprVar(path=("x",)),
+                                right=AstExprLiteral(kind="int", value="0"),
+                            ),
+                            right=AstExprBinary(
+                                op=">",
+                                left=AstExprBinary(
+                                    op="/",
+                                    left=AstExprLiteral(kind="int", value="100"),
+                                    right=AstExprVar(path=("x",)),
+                                ),
+                                right=AstExprLiteral(kind="int", value="5"),
+                            ),
+                        )
+                    ),
+                ),
+            ),
+        )
+    )
+
+    ir_text = emit_llvm_ir(program)
+
+    assert 'br i1 %".4", label %"logic_and_rhs", label %"logic_and_merge"' in ir_text
+    assert 'logic_and_rhs:' in ir_text
+    assert 'sdiv i32 100' in ir_text
+    assert 'logic_and_merge:' in ir_text
+    assert '[0, %"entry"], [%".7", %"logic_and_rhs"]' in ir_text
+
+
+def test_codegen_logical_or_short_circuits_rhs_call():
+    program = AstProgram(
+        pure_functions=(
+            AstPureDecl(
+                name="expensive",
+                return_type=AstType("bool"),
+                body=(AstReturnStmt(value=AstExprLiteral(kind="bool", value="true")),),
+            ),
+            AstPureDecl(
+                name="guarded",
+                return_type=AstType("bool"),
+                params=(
+                    AstKernelParam(
+                        modifier="", declared_type=AstType("bool"), name="ready"
+                    ),
+                ),
+                body=(
+                    AstReturnStmt(
+                        value=AstExprBinary(
+                            op="||",
+                            left=AstExprVar(path=("ready",)),
+                            right=AstExprCall(name="expensive", args=()),
+                        )
+                    ),
+                ),
+            ),
+        )
+    )
+
+    ir_text = emit_llvm_ir(program)
+
+    assert 'br i1 %"ready_val", label %"logic_or_merge", label %"logic_or_rhs"' in ir_text
+    assert 'logic_or_rhs:' in ir_text
+    assert 'call i1 @"pure_expensive"()' in ir_text
+    assert 'logic_or_merge:' in ir_text
+    assert '[1, %"entry"], [%"call_expensive", %"logic_or_rhs"]' in ir_text
 
 def test_compile_lockstep_surfaces_typed_ast_type_error_without_legacy_fallback(
     monkeypatch,


### PR DESCRIPTION
### Motivation
- Binary lowering previously evaluated both operands unconditionally, which broke short-circuit semantics and could produce runtime errors (e.g., divide-by-zero) when the RHS should not be evaluated. 
- Logical `&&` and `||` require conditional evaluation and branching so the right-hand side is only computed when the left-hand side necessitates it.

### Description
- Removed eager boolean lowering from the generic `_lower_binary_op` path and added a dedicated `_lower_logical_binary_op` helper that emits conditional basic blocks and a PHI node to implement short-circuit semantics. 
- Added `_validate_logical_operand` to enforce boolean operand types for logical operators. 
- Updated `_lower_expr` to dispatch `&&`/`||` to the new short-circuit lowering before the generic binary lowering. 
- Added regression tests that assert generated IR contains conditional RHS blocks and PHI combination for guarded `&&` division and `||` that skips an expensive call; changes in `lockstep_compiler/codegen.py` and `tests/test_compiler_api.py`.

### Testing
- Verified Python syntax/compilation of the changed modules with `python -m py_compile lockstep_compiler/codegen.py tests/test_compiler_api.py` which succeeded. 
- Ran focused codegen regression tests with `pytest -q tests/test_compiler_api.py::test_codegen_logical_and_short_circuits_rhs_division tests/test_compiler_api.py::test_codegen_logical_or_short_circuits_rhs_call`, and both tests passed. 
- Ran the broader `tests/test_compiler_api.py` file which reported existing failures in various declaration/header/uint-related tests (for example `test_emit_llvm_ir_generates_expected_declarations`, `test_emit_c_header_generates_structs_offsets_and_tick_signature`, and `test_codegen_uses_unsigned_ops_for_uint_struct_fields`); these failures appear unrelated to the logical operator lowering but surfaced during the full test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f29a254fc8328902c91333b561405)