### PR TITLE
Preserve truthiness when casting integers to bool (use icmp ne instead of trunc)

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -228,6 +228,13 @@ class _FunctionLowerer:
                     return self.builder.zext(value, target_type)
                 return self.builder.sext(value, target_type)
             if value.type.width > target_type.width:
+                if target_type.width == 1:
+                    return self.builder.icmp_signed(
+                        "!=",
+                        value,
+                        ir.Constant(value.type, 0),
+                        name="int_to_bool",
+                    )
                 return self.builder.trunc(value, target_type)
 
         if isinstance(target_type, (ir.FloatType, ir.DoubleType)) and isinstance(
@@ -1770,6 +1777,13 @@ def emit_llvm_ir(
                         else tick_builder.sext(value, target_ty)
                     )
                 if source_elem.width > target_elem.width:
+                    if target_elem.width == 1:
+                        return tick_builder.icmp_signed(
+                            "!=",
+                            value,
+                            ir.Constant(value.type, None),
+                            name="fused_int_to_bool",
+                        )
                     return tick_builder.trunc(value, target_ty)
             if isinstance(target_elem, (ir.FloatType, ir.DoubleType)) and isinstance(
                 source_elem, ir.IntType

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -1335,6 +1335,51 @@ def test_emit_llvm_ir_lowers_explicit_numeric_casts_to_llvm_conversions():
     assert "fptoui float" in llvm_ir
 
 
+def test_emit_llvm_ir_casts_wide_integer_to_bool_with_nonzero_compare():
+    llvm_ir = emit_llvm_ir(
+        {
+            "structs": [],
+            "pure_functions": [
+                {
+                    "name": "int_to_bool",
+                    "return_type": "bool",
+                    "params": [{"modifier": "in", "type": "int", "name": "x"}],
+                    "body_ast": [
+                        AstReturnStmt(
+                            value=AstExprCast(
+                                target_type="bool",
+                                value=AstExprVar(path=("x",)),
+                            )
+                        )
+                    ],
+                },
+                {
+                    "name": "uint_to_bool",
+                    "return_type": "bool",
+                    "params": [{"modifier": "in", "type": "uint", "name": "x"}],
+                    "body_ast": [
+                        AstReturnStmt(
+                            value=AstExprCast(
+                                target_type="bool",
+                                value=AstExprVar(path=("x",)),
+                            )
+                        )
+                    ],
+                },
+            ],
+            "shaders": [],
+            "filters": [],
+            "streams": [],
+            "accumulators": [],
+            "uniforms": [],
+            "bind_routes": [],
+        }
+    )
+
+    assert llvm_ir.count("icmp ne i32") == 2
+    assert "trunc i32" not in llvm_ir
+
+
 def test_emit_llvm_ir_uses_unsigned_float_to_integer_cast_for_uint_targets():
     llvm_ir = emit_llvm_ir(
         {


### PR DESCRIPTION
### Motivation

- Narrowing integer-to-bool casts previously used a raw `trunc`, which silently kept the low bit and made values like `2` evaluate to `false` instead of `true`.

### Description

- Update scalar integer coercion in `lockstep_compiler/codegen.py::_coerce_value_to_type` to emit `icmp ne <int>, 0` when narrowing to an `i1` target instead of `trunc`.
- Apply the same nonzero comparison in the fused/vector coercion path (`_coerce_vector_value`) when vector integer elements narrow to `i1` lanes using `icmp ne` produced by `tick_builder`.
- Add a regression test `test_emit_llvm_ir_casts_wide_integer_to_bool_with_nonzero_compare` in `tests/test_compiler_api.py` that verifies `icmp ne i32` is emitted for both `int->bool` and `uint->bool` and that `trunc i32` is not used.

### Testing

- Ran `pytest -q tests/test_compiler_api.py::test_emit_llvm_ir_casts_wide_integer_to_bool_with_nonzero_compare` which passed.
- Ran `pytest -q tests/test_compiler_api.py::test_emit_llvm_ir_lowers_explicit_numeric_casts_to_llvm_conversions tests/test_compiler_api.py::test_emit_llvm_ir_casts_wide_integer_to_bool_with_nonzero_compare` which passed.
- Ran `pytest -q tests/test_compiler_api.py` and observed existing unrelated failures in declaration/header/uint tests that predate this change and are not caused by this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f29a889448328a7cf772c89c832d1)