### PR TITLE
Fix saturated stream FIFO windowing

### DIFF
--- a/lockstep_compiler/simulator.py
+++ b/lockstep_compiler/simulator.py
@@ -213,13 +213,7 @@ def _apply_saturated_writes(rows: list[Any], capacity: int) -> list[Any]:
     if capacity <= 0:
         return []
 
-    saturated_rows: list[Any] = []
-    for value in rows:
-        if len(saturated_rows) < capacity:
-            saturated_rows.append(value)
-            continue
-        saturated_rows[capacity - 1] = value
-    return saturated_rows
+    return list(rows[-capacity:])
 
 
 def _coerce_sim_value(value: Any) -> Any:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -614,7 +614,7 @@ def test_run_cli_rejects_combined_dump_and_simulate_modes():
         )
 
 
-def test_simulate_pipeline_entities_saturates_stream_writes_at_capacity():
+def test_simulate_pipeline_entities_keeps_fifo_window_for_saturated_stream_writes():
     entities = {
         "streams": [
             {"name": "in_stream", "type": "int", "capacity": "5"},
@@ -649,7 +649,7 @@ def test_simulate_pipeline_entities_saturates_stream_writes_at_capacity():
     )
 
     assert simulation["streams"]["out_stream"] == [
-        {"_source": 1, "_kernel": "Project"},
+        {"_source": 3, "_kernel": "Project"},
         {"_source": 4, "_kernel": "Project"},
     ]
 


### PR DESCRIPTION
### Motivation
- Correct a defect where writes beyond a stream's capacity all clobbered the same final slot, destroying the chronological order of buffered rows and making saturated streams unreliable.

### Description
- Replace the previous overwrite loop in `_apply_saturated_writes` with `return list(rows[-capacity:])` in `lockstep_compiler/simulator.py` and update `tests/test_simulator.py` to assert the FIFO sliding-window semantics (keep the newest `capacity` rows).

### Testing
- Ran `pytest -q tests/test_simulator.py -q` which exercised the modified scenario and passed.  
- Running the full test suite with `pytest -q` fails during collection in this environment due to a missing test dependency (`hypothesis`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f305ae1ec83289dfb035e5cca541d)