### PR TITLE
Fix simulator multi-input trip counts

### DIFF
--- a/lockstep_compiler/simulator.py
+++ b/lockstep_compiler/simulator.py
@@ -633,10 +633,9 @@ def _simulate_kernel_rows(
                 continue
             if modifier == "in" and isinstance(arg_name, str) and arg_name in streams:
                 arg_rows = streams[arg_name]["rows"]
-                source_index = min(row_index, len(arg_rows) - 1) if arg_rows else 0
                 env[param_name] = (
-                    _copy_sim_value(arg_rows[source_index])
-                    if arg_rows
+                    _copy_sim_value(arg_rows[row_index])
+                    if row_index < len(arg_rows)
                     else _default_sim_value(param.get("type"))
                 )
             elif modifier == "out":
@@ -767,17 +766,26 @@ def simulate_pipeline_entities(
 
             source_count = 0
             rows: list[Any] = []
+            first_input_type: str | None = None
             args = (
                 route_ir.get("args") if isinstance(route_ir.get("args"), list) else []
             )
+            params = kernel["params"]
             for index, arg_name in enumerate(args):
-                params = kernel["params"]
                 if index >= len(params):
                     break
                 if params[index]["modifier"] == "in" and arg_name in streams:
-                    rows = list(streams[arg_name]["rows"])
-                    source_count = len(rows)
-                    break
+                    arg_rows = list(streams[arg_name]["rows"])
+                    if first_input_type is None:
+                        first_input_type = params[index].get("type")
+                        rows = arg_rows
+                    source_count = max(source_count, len(arg_rows))
+
+            if len(rows) < source_count:
+                rows = rows + [
+                    _default_sim_value(first_input_type)
+                    for _ in range(source_count - len(rows))
+                ]
 
             output_rows, pending_accum = _simulate_kernel_rows(
                 kernel_name=str(route_ir.get("kernel", "")),

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -84,6 +84,46 @@ def test_simulate_pipeline_source_uses_compiled_runtime_entities():
     ]
 
 
+def test_simulate_pipeline_entities_iterates_over_longest_input_stream():
+    source = """
+    shader Sum(in float a, in float b, out float dst) {
+        dst = a + b;
+    }
+
+    pipeline P {
+        stream<float, 16> a;
+        stream<float, 16> b;
+        stream<float, 16> dst;
+
+        bind {
+            dst = Sum(a, b, dst);
+        }
+    }
+    """
+
+    simulation = simulate_pipeline_source(
+        source,
+        stream_inputs={
+            "a": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "b": [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0],
+        },
+    )
+
+    assert simulation["streams"]["dst"] == [
+        11.0,
+        22.0,
+        33.0,
+        44.0,
+        55.0,
+        60.0,
+        70.0,
+        80.0,
+        90.0,
+        100.0,
+    ]
+    assert simulation["routes"][0]["input_count"] == 10
+    assert simulation["routes"][0]["output_count"] == 10
+
 def test_simulate_pipeline_entities_tracks_route_cardinality_and_fold():
     entities = {
         "streams": [


### PR DESCRIPTION
### Motivation
- The compiled LLVM backend computes kernel trip counts from the maximum capacity of all mapped input streams, but the Python simulator iterated only over the first discovered input stream, causing deterministic divergence between simulation and compiled runs.
- The simulator must mirror LLVM behavior by iterating the kernel for the longest input and padding shorter inputs with typed defaults so tests and runtime match.

### Description
- Updated per-parameter input binding in `_simulate_kernel_rows` to index streams by the current `row_index` and return a typed default when a stream is exhausted instead of clamping to the last element. (`lockstep_compiler/simulator.py`)
- In `simulate_pipeline_entities`, precompute `source_count` as the maximum row length across all mapped `in` stream arguments, choose a primary `rows` list to drive iteration, and pad it with `_default_sim_value(...)` entries up to `source_count`. (`lockstep_compiler/simulator.py`)
- Added a regression test `test_simulate_pipeline_entities_iterates_over_longest_input_stream` that asserts a two-input shader runs for the longest input stream and that shorter inputs are padded with default values. (`tests/test_simulator.py`)

### Testing
- Ran the targeted test: `pytest -q tests/test_simulator.py::test_simulate_pipeline_entities_iterates_over_longest_input_stream` which passed. 
- Ran the simulator test module: `pytest -q tests/test_simulator.py` which passed. 
- Ran the full test suite via `pytest -q`, which exercised unrelated areas and reported failures unrelated to this change (baseline/environment issues such as missing fixtures and unrelated semantic/codegen test failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f3053bcc883288104b23d2ef0c5f3)