### PR TITLE
Implement unified numeric type promotion

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -218,6 +218,7 @@ class _FunctionLowerer:
         value: ir.Value,
         target_type: ir.Type,
         target_type_name: str | None = None,
+        source_type_name: str | None = None,
     ) -> ir.Value:
         if value.type == target_type:
             return value
@@ -240,6 +241,8 @@ class _FunctionLowerer:
         if isinstance(target_type, (ir.FloatType, ir.DoubleType)) and isinstance(
             value.type, ir.IntType
         ):
+            if source_type_name == "uint":
+                return self.builder.uitofp(value, target_type)
             return self.builder.sitofp(value, target_type)
 
         if isinstance(target_type, ir.IntType) and isinstance(
@@ -431,8 +434,10 @@ class _FunctionLowerer:
             return left_type or right_type
         if left_type == right_type:
             return left_type
-        if left_type in {"int", "uint"} and right_type in {"int", "uint"}:
-            return "uint" if "uint" in {left_type, right_type} else "int"
+
+        numeric_rank = {"int": 0, "uint": 1, "float": 2, "double": 3}
+        if left_type in numeric_rank and right_type in numeric_rank:
+            return max((left_type, right_type), key=numeric_rank.__getitem__)
         return None
 
     def _infer_binary_operand_type(self, node: AstExprBinary) -> str | None:
@@ -448,8 +453,12 @@ class _FunctionLowerer:
             ):
                 return left_type
             return None
-        if op in {"+", "-", "*", "/", "%", "&", "|", "^"}:
+        if op in {"+", "-", "*", "/", "%"}:
             return self._promote_scalar_type_names(left_type, right_type)
+        if op in {"&", "|", "^"}:
+            if left_type in {"int", "uint"} and right_type in {"int", "uint"}:
+                return self._promote_scalar_type_names(left_type, right_type)
+            return None
         if op in {"<", "<=", ">", ">=", "==", "!="}:
             return self._promote_scalar_type_names(left_type, right_type)
         return None
@@ -663,8 +672,14 @@ class _FunctionLowerer:
         expr_type_name = self._infer_binary_operand_type(node)
         if expr_type_name in _PRIMITIVE_TYPE_MAP:
             operand_type = self._llvm_type(expr_type_name, self.known_structs)
-            lhs = self._coerce_value_to_type(lhs, operand_type, expr_type_name)
-            rhs = self._coerce_value_to_type(rhs, operand_type, expr_type_name)
+            lhs_type_name = self._infer_expr_type(node.left)
+            rhs_type_name = self._infer_expr_type(node.right)
+            lhs = self._coerce_value_to_type(
+                lhs, operand_type, expr_type_name, lhs_type_name
+            )
+            rhs = self._coerce_value_to_type(
+                rhs, operand_type, expr_type_name, rhs_type_name
+            )
         return self._lower_binary_op(node.op, lhs, rhs, type_name=expr_type_name)
 
     def _lower_assignment(self, target_name: str, value: ir.Value):
@@ -1815,12 +1830,17 @@ def emit_llvm_ir(
         return leaves
 
     def _splat_to_vector(
-        value: ir.Value, vector_ty: ir.VectorType, type_name: str | None = None
+        value: ir.Value,
+        vector_ty: ir.VectorType,
+        type_name: str | None = None,
+        source_type_name: str | None = None,
     ) -> ir.Value:
         if value.type == vector_ty:
             return value
         if value.type != vector_ty.element:
-            value = lowerer._coerce_value_to_type(value, vector_ty.element, type_name)
+            value = lowerer._coerce_value_to_type(
+                value, vector_ty.element, type_name, source_type_name
+            )
         seed = tick_builder.insert_element(
             ir.Constant(vector_ty, ir.Undefined), value, ir.Constant(ir.IntType(32), 0)
         )
@@ -1830,13 +1850,16 @@ def emit_llvm_ir(
         )
 
     def _coerce_vector_value(
-        value: ir.Value, target_ty: ir.Type, type_name: str | None = None
+        value: ir.Value,
+        target_ty: ir.Type,
+        type_name: str | None = None,
+        source_type_name: str | None = None,
     ) -> ir.Value:
         if value.type == target_ty:
             return value
         if isinstance(target_ty, ir.VectorType):
             if not isinstance(value.type, ir.VectorType):
-                return _splat_to_vector(value, target_ty, type_name)
+                return _splat_to_vector(value, target_ty, type_name, source_type_name)
             source_elem = value.type.element
             target_elem = target_ty.element
             if source_elem == target_elem:
@@ -1862,6 +1885,8 @@ def emit_llvm_ir(
             if isinstance(target_elem, (ir.FloatType, ir.DoubleType)) and isinstance(
                 source_elem, ir.IntType
             ):
+                if source_type_name == "uint":
+                    return tick_builder.uitofp(value, target_ty)
                 return tick_builder.sitofp(value, target_ty)
             if isinstance(target_elem, ir.IntType) and isinstance(
                 source_elem, (ir.FloatType, ir.DoubleType)
@@ -1883,7 +1908,9 @@ def emit_llvm_ir(
             raise CodegenError(
                 f"cannot coerce vector value of type '{value.type}' to '{target_ty}'"
             )
-        return lowerer._coerce_value_to_type(value, target_ty, type_name)
+        return lowerer._coerce_value_to_type(
+            value, target_ty, type_name, source_type_name
+        )
 
     def _can_vectorize_fused_group(routes: tuple[AstKernelBindRoute, ...]) -> bool:
         supported_statements = (AstAssignStmt, AstVarDeclStmt)
@@ -2073,8 +2100,10 @@ def emit_llvm_ir(
                 return left_type or right_type
             if left_type == right_type:
                 return left_type
-            if left_type in {"int", "uint"} and right_type in {"int", "uint"}:
-                return "uint" if "uint" in {left_type, right_type} else "int"
+
+            numeric_rank = {"int": 0, "uint": 1, "float": 2, "double": 3}
+            if left_type in numeric_rank and right_type in numeric_rank:
+                return max((left_type, right_type), key=numeric_rank.__getitem__)
             return None
 
         def _infer_binary_operand_type(self, node: AstExprBinary) -> str | None:
@@ -2085,23 +2114,12 @@ def emit_llvm_ir(
                 return "bool" if left_type == "bool" and right_type == "bool" else None
             if op in {"<<", ">>"}:
                 return left_type if left_type in {"int", "uint"} else None
-            if op in {
-                "+",
-                "-",
-                "*",
-                "/",
-                "%",
-                "&",
-                "|",
-                "^",
-                "<",
-                "<=",
-                ">",
-                ">=",
-                "==",
-                "!=",
-            }:
+            if op in {"+", "-", "*", "/", "%", "<", "<=", ">", ">=", "==", "!="}:
                 return self._promote_scalar_type_names(left_type, right_type)
+            if op in {"&", "|", "^"}:
+                if left_type in {"int", "uint"} and right_type in {"int", "uint"}:
+                    return self._promote_scalar_type_names(left_type, right_type)
+                return None
             return None
 
         def _infer_expr_type(self, node) -> str | None:
@@ -2356,8 +2374,14 @@ def emit_llvm_ir(
                 )
                 if operand_type_name in _PRIMITIVE_TYPE_MAP:
                     vector_ty = self._declared_vector_type(operand_type_name)
-                    lhs = _coerce_vector_value(lhs, vector_ty, operand_type_name)
-                    rhs = _coerce_vector_value(rhs, vector_ty, operand_type_name)
+                    lhs_type_name = self._infer_expr_type(node.left)
+                    rhs_type_name = self._infer_expr_type(node.right)
+                    lhs = _coerce_vector_value(
+                        lhs, vector_ty, operand_type_name, lhs_type_name
+                    )
+                    rhs = _coerce_vector_value(
+                        rhs, vector_ty, operand_type_name, rhs_type_name
+                    )
                 return self._binary(node.op, lhs, rhs, operand_type_name)
             raise CodegenError(
                 f"unsupported vector expression node '{type(node).__name__}'"

--- a/lockstep_compiler/semantic_validator.py
+++ b/lockstep_compiler/semantic_validator.py
@@ -532,6 +532,12 @@ def build_semantic_validator(base_visitor_cls):
         def _resolve_ast_expr_type(self, expr: AstExpr) -> str | None:
             numeric_types = {"int", "uint", "float", "double"}
             integer_types = {"int", "uint"}
+            numeric_rank = {"int": 0, "uint": 1, "float": 2, "double": 3}
+
+            def _promote_numeric(left_type: str, right_type: str) -> str | None:
+                if left_type in numeric_rank and right_type in numeric_rank:
+                    return max((left_type, right_type), key=numeric_rank.__getitem__)
+                return None
 
             def _operand_ctx(node):
                 return self._ctx_from_location(getattr(node, "location", None))
@@ -576,26 +582,13 @@ def build_semantic_validator(base_visitor_cls):
 
                 if left_type is None or right_type is None:
                     return None
-                if op in {"+", "-", "*", "/"}:
-                    if left_type in numeric_types and right_type == left_type:
-                        return left_type
-                    if left_type in numeric_types and right_type in numeric_types:
-                        _report_invalid_operands(
-                            expr_binary,
-                            op,
-                            "matching numeric",
-                            left_type,
-                            right_type,
-                            code=SEMANTIC_DIAGNOSTIC_CODES["implicit_numeric_widening"],
-                            message=(
-                                f"Operator '{op}' mixes numeric operand types without an explicit cast."
-                            ),
-                            hint="Use explicit casts so numeric widening is intentional and target-compatible.",
-                        )
-                    else:
-                        _report_invalid_operands(
-                            expr_binary, op, "numeric", left_type, right_type
-                        )
+                if op in {"+", "-", "*", "/", "%"}:
+                    promoted_type = _promote_numeric(left_type, right_type)
+                    if promoted_type is not None:
+                        return promoted_type
+                    _report_invalid_operands(
+                        expr_binary, op, "numeric", left_type, right_type
+                    )
                     return None
                 if op in {"&", "|", "^"}:
                     if left_type in integer_types and right_type == left_type:
@@ -612,7 +605,9 @@ def build_semantic_validator(base_visitor_cls):
                     )
                     return None
                 if op in {"==", "!=", "<", "<=", ">", ">="}:
-                    if left_type == right_type:
+                    if left_type == right_type or _promote_numeric(
+                        left_type, right_type
+                    ):
                         return "bool"
                     _report_invalid_operands(
                         expr_binary, op, "matching", left_type, right_type

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -977,7 +977,140 @@ def test_emit_llvm_ir_keeps_integer_arithmetic_in_integer_domain():
     assert "fadd float" not in llvm_ir
 
 
+def test_emit_llvm_ir_promotes_mixed_numeric_binary_operands():
+    llvm_ir = emit_llvm_ir(
+        {
+            "structs": [],
+            "pure_functions": [
+                {
+                    "name": "promote_float_int",
+                    "return_type": "double",
+                    "params": [
+                        {"type": "float", "name": "f"},
+                        {"type": "int", "name": "i"},
+                        {"type": "double", "name": "d"},
+                        {"type": "uint", "name": "u"},
+                    ],
+                    "body_ast": [
+                        AstReturnStmt(
+                            value=AstExprBinary(
+                                op="+",
+                                left=AstExprBinary(
+                                    op="*",
+                                    left=AstExprVar(path=("f",)),
+                                    right=AstExprVar(path=("i",)),
+                                ),
+                                right=AstExprBinary(
+                                    op="/",
+                                    left=AstExprVar(path=("d",)),
+                                    right=AstExprVar(path=("u",)),
+                                ),
+                            )
+                        )
+                    ],
+                }
+            ],
+            "shaders": [],
+            "filters": [],
+            "streams": [],
+            "accumulators": [],
+            "uniforms": [],
+            "bind_routes": [],
+        }
+    )
 
+    assert "sitofp i32" in llvm_ir
+    assert "fmul float" in llvm_ir
+    assert "fpext float" in llvm_ir
+    assert "uitofp i32" in llvm_ir
+    assert "fdiv double" in llvm_ir
+    assert "fadd double" in llvm_ir
+
+
+def test_emit_llvm_ir_promotes_mixed_numeric_operands_in_fused_vectors():
+    first_route = "mid = Promote(inp, mid, scale, count);"
+    second_route = "out = Copy(mid, out);"
+    llvm_ir = emit_llvm_ir(
+        {
+            "structs": [],
+            "shaders": [
+                {
+                    "name": "Promote",
+                    "params": [
+                        {"modifier": "in", "type": "float", "name": "inp"},
+                        {"modifier": "out", "type": "double", "name": "out"},
+                        {"modifier": "uniform", "type": "double", "name": "scale"},
+                        {"modifier": "uniform", "type": "uint", "name": "count"},
+                    ],
+                    "body_ast": [
+                        AstAssignStmt(
+                            target=("out",),
+                            value=AstExprBinary(
+                                op="+",
+                                left=AstExprBinary(
+                                    op="*",
+                                    left=AstExprVar(path=("inp",)),
+                                    right=AstExprVar(path=("scale",)),
+                                ),
+                                right=AstExprVar(path=("count",)),
+                            ),
+                        )
+                    ],
+                },
+                {
+                    "name": "Copy",
+                    "params": [
+                        {"modifier": "in", "type": "double", "name": "inp"},
+                        {"modifier": "out", "type": "double", "name": "out"},
+                    ],
+                    "body_ast": [
+                        AstAssignStmt(
+                            target=("out",), value=AstExprVar(path=("inp",))
+                        )
+                    ],
+                },
+            ],
+            "filters": [],
+            "pure_functions": [],
+            "streams": [
+                {"name": "inp", "type": "float", "capacity": 8},
+                {"name": "mid", "type": "double", "capacity": 8},
+                {"name": "out", "type": "double", "capacity": 8},
+            ],
+            "accumulators": [],
+            "uniforms": [
+                {"name": "scale", "type": "double"},
+                {"name": "count", "type": "uint"},
+            ],
+            "bind_routes": [first_route, second_route],
+            "bind_routes_ir": [
+                {
+                    "kind": "kernel",
+                    "target": "mid",
+                    "kernel": "Promote",
+                    "args": ["inp", "mid", "scale", "count"],
+                    "route": first_route,
+                },
+                {
+                    "kind": "kernel",
+                    "target": "out",
+                    "kernel": "Copy",
+                    "args": ["mid", "out"],
+                    "route": second_route,
+                },
+            ],
+        },
+        bind_optimization={
+            "optimized_bind_routes": [first_route, second_route],
+            "fused_groups": [{"source_routes": [first_route, second_route]}],
+        },
+    )
+
+    assert "fused_0_body" in llvm_ir
+    assert "fpext <8 x float>" in llvm_ir
+    assert "uitofp <8 x i32>" in llvm_ir
+    assert "fmul <8 x double>" in llvm_ir
+    assert "fadd <8 x double>" in llvm_ir
 
 def test_emit_llvm_ir_lowers_select_builtin_for_integers():
     llvm_ir = emit_llvm_ir(
@@ -1308,35 +1441,37 @@ def test_emit_llvm_ir_honors_explicit_target_width_override():
     assert 'store float %"fold_reduce"' in llvm_ir
 
 
-def test_emit_llvm_ir_raises_on_mixed_int_float_expression():
-    with pytest.raises(CodegenError, match="requires matching operand types"):
-        emit_llvm_ir(
-            {
-                "structs": [],
-                "pure_functions": [
-                    {
-                        "name": "bad_mix",
-                        "return_type": "float",
-                        "params": [],
-                        "body_ast": [
-                            AstReturnStmt(
-                                value=AstExprBinary(
-                                    op="+",
-                                    left=AstExprLiteral(kind="int", value="1"),
-                                    right=AstExprLiteral(kind="float", value="1.0"),
-                                )
+def test_emit_llvm_ir_promotes_mixed_int_float_expression():
+    llvm_ir = emit_llvm_ir(
+        {
+            "structs": [],
+            "pure_functions": [
+                {
+                    "name": "mixed_int_float",
+                    "return_type": "float",
+                    "params": [],
+                    "body_ast": [
+                        AstReturnStmt(
+                            value=AstExprBinary(
+                                op="+",
+                                left=AstExprLiteral(kind="int", value="1"),
+                                right=AstExprLiteral(kind="float", value="1.0"),
                             )
-                        ],
-                    }
-                ],
-                "shaders": [],
-                "filters": [],
-                "streams": [],
-                "accumulators": [],
-                "uniforms": [],
-                "bind_routes": [],
-            }
-        )
+                        )
+                    ],
+                }
+            ],
+            "shaders": [],
+            "filters": [],
+            "streams": [],
+            "accumulators": [],
+            "uniforms": [],
+            "bind_routes": [],
+        }
+    )
+
+    assert "sitofp i32 1 to float" in llvm_ir
+    assert "fadd float" in llvm_ir
 
 
 def test_compile_lockstep_supports_c_and_function_style_cast_syntax():


### PR DESCRIPTION
### Motivation
- The scalar binary lowering lacked floating-point promotion, causing mixed numeric expressions (e.g. `int + float`) to return `None` and crash the code generator with "operator requires matching operand types".
- The compiler must consistently choose a numeric result type and inject implicit casts (preserving `uint` signedness) so arithmetic and comparisons work across `int`, `uint`, `float`, and `double`.

### Description
- Implemented a promotion hierarchy `double > float > uint > int` in `._promote_scalar_type_names` for both `_FunctionLowerer` and `_FusedVectorLowerer` so mixed numeric operands resolve to a single promoted type. (`_promote_scalar_type_names`)
- Propagated operand source type information into coercion helpers by adding a `source_type_name` parameter to `_coerce_value_to_type`, `_coerce_vector_value`, and `_splat_to_vector` and wiring inferred operand type names through lowering sites (`_lower_expr` / vector lowering). (`_coerce_value_to_type`, `_coerce_vector_value`, `_splat_to_vector`)
- Preserve unsigned semantics when widening integers to floating point by emitting `uitofp` for `uint -> float/double` conversions and `sitofp` for signed integers. (signed/unsigned-specific branches in coercion code)
- Restrict bitwise operators (`&`, `|`, `^`) to integer domains and keep them from participating in numeric promotion, while allowing arithmetic and comparison ops to use the promotion model. (operator handling changes in binary operand inference)
- Updated the semantic validator so mixed numeric arithmetic and comparisons resolve via the same promotion model rather than being rejected earlier, providing consistent behavior between semantic analysis and codegen. (`semantic_validator._resolve_ast_expr_type`)
- Added focused regression tests that exercise scalar promotion, fused-vector promotion, and mixed `int`/`float` lowering to verify the behavior. (new/edited tests in `tests/test_compiler_api.py`)

### Testing
- Ran focused pytest for promotion and related casting tests: `tests/test_compiler_api.py::test_emit_llvm_ir_promotes_mixed_numeric_binary_operands`, `::test_emit_llvm_ir_promotes_mixed_numeric_operands_in_fused_vectors`, `::test_emit_llvm_ir_promotes_mixed_int_float_expression`, `::test_codegen_promotes_asymmetric_uint_binary_operands`, and `::test_compile_lockstep_supports_c_and_function_style_cast_syntax` — all passed.
- Ran `python -m compileall lockstep_compiler tests/test_compiler_api.py` which succeeded and `git diff --check` which reported no whitespace/format issues.
- A full `python -m pytest tests/test_compiler_api.py -q` run was attempted earlier and exposed unrelated pre-existing failures (test expectations for bind-route comments and `c_header` layout handling) that are outside the scope of this change and were not introduced by the promotion fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f304c2b5c8328bedf115a4a2ecf5c)