### PR TITLE
Improve Lockstep formatter token handling and coverage

### DIFF
--- a/lockstep_compiler/formatter.py
+++ b/lockstep_compiler/formatter.py
@@ -21,11 +21,14 @@ from .errors import ParseErrorCollector
 
 
 def _lex_tokens(source: str) -> list[str]:
-
     lexer = LockstepLexer(InputStream(source))
     stream = CommonTokenStream(lexer)
     stream.fill()
-    return [token.text for token in stream.tokens if token.type != -1]
+    return [
+        token.text
+        for token in stream.tokens
+        if token.type != -1 and token.channel == LockstepLexer.DEFAULT_TOKEN_CHANNEL
+    ]
 
 
 def _needs_space(previous: str, current: str) -> bool:
@@ -35,6 +38,8 @@ def _needs_space(previous: str, current: str) -> bool:
         return False
     if previous in {"(", "[", "{", ",", "<", ".", "="}:
         return False
+    if current[0] in {'"', "'"} and (previous[-1].isalnum() or previous[-1] == "_"):
+        return True
     if previous[-1] == ">" and (current[0].isalnum() or current[0] == "_"):
         return True
     return (previous[-1].isalnum() or previous[-1] == "_") and (
@@ -110,6 +115,22 @@ class _FormattingVisitor(LockstepVisitor):
         self._depth = max(self._depth - 1, 0)
         self._append(f"}}{suffix}")
 
+    def _format_context_tokens(self, ctx) -> str:
+        stream = ctx.parser.getTokenStream()
+        stream.fill()
+        if ctx.start is None or ctx.stop is None:
+            return ""
+
+        text = ""
+        for token in stream.tokens[ctx.start.tokenIndex : ctx.stop.tokenIndex + 1]:
+            if token.type == -1 or token.channel != LockstepLexer.DEFAULT_TOKEN_CHANNEL:
+                continue
+            if _needs_space(text, token.text):
+                text = f"{text} {token.text}"
+            else:
+                text = f"{text}{token.text}"
+        return text
+
     def _format_params(self, param_list_ctx):
         if param_list_ctx is None:
             return ""
@@ -122,6 +143,11 @@ class _FormattingVisitor(LockstepVisitor):
 
     def visitDeclaration(self, ctx: LockstepParser.DeclarationContext):
         return self.visitChildren(ctx)
+
+    def visitDependencyDecl(self, ctx: LockstepParser.DependencyDeclContext):
+        keyword = ctx.getChild(0).getText()
+        path = ctx.STRING().getText()
+        self._append(f"{keyword} {path};")
 
     def visitStructDecl(self, ctx: LockstepParser.StructDeclContext):
         self._open_block(f"struct {ctx.ID().getText()}")
@@ -244,37 +270,52 @@ class _FormattingVisitor(LockstepVisitor):
         return self.visit(ctx.logicalOrExpr())
 
     def visitLogicalOrExpr(self, ctx: LockstepParser.LogicalOrExprContext):
-        return ctx.getText()
+        return self._format_context_tokens(ctx)
 
     def visitLogicalAndExpr(self, ctx: LockstepParser.LogicalAndExprContext):
-        return ctx.getText()
+        return self._format_context_tokens(ctx)
+
+    def visitBitwiseOrExpr(self, ctx: LockstepParser.BitwiseOrExprContext):
+        return self._format_context_tokens(ctx)
+
+    def visitBitwiseXorExpr(self, ctx: LockstepParser.BitwiseXorExprContext):
+        return self._format_context_tokens(ctx)
+
+    def visitBitwiseAndExpr(self, ctx: LockstepParser.BitwiseAndExprContext):
+        return self._format_context_tokens(ctx)
 
     def visitEqualityExpr(self, ctx: LockstepParser.EqualityExprContext):
-        return ctx.getText()
+        return self._format_context_tokens(ctx)
 
     def visitRelExpr(self, ctx: LockstepParser.RelExprContext):
-        return ctx.getText()
+        return self._format_context_tokens(ctx)
+
+    def visitShiftExpr(self, ctx: LockstepParser.ShiftExprContext):
+        return self._format_context_tokens(ctx)
 
     def visitAddExpr(self, ctx: LockstepParser.AddExprContext):
-        return ctx.getText()
+        return self._format_context_tokens(ctx)
 
     def visitMulExpr(self, ctx: LockstepParser.MulExprContext):
-        return ctx.getText()
+        return self._format_context_tokens(ctx)
 
     def visitUnaryExpr(self, ctx: LockstepParser.UnaryExprContext):
-        return ctx.getText()
+        return self._format_context_tokens(ctx)
 
     def visitPrimaryExpr(self, ctx: LockstepParser.PrimaryExprContext):
-        return ctx.getText()
+        return self._format_context_tokens(ctx)
 
     def visitExprList(self, ctx: LockstepParser.ExprListContext):
         return ",".join(self.visit(expr) for expr in ctx.expr())
 
     def visitLvalue(self, ctx: LockstepParser.LvalueContext):
-        return ctx.getText()
+        return self._format_context_tokens(ctx)
 
     def visitTypeName(self, ctx: LockstepParser.TypeNameContext):
-        return ctx.getText()
+        return self._format_context_tokens(ctx)
+
+    def visitTypeSuffix(self, ctx: LockstepParser.TypeSuffixContext):
+        return self._format_context_tokens(ctx)
 
 
 def format_lockstep_source(source, *, indent="    "):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -55,3 +55,44 @@ def test_format_lockstep_source_preserves_comments_by_skipping_reformat():
     source = "pipeline Main{ // keep me\nstream<float,4> s;\n}\n"
 
     assert format_lockstep_source(source) == source
+
+
+def test_format_lockstep_source_formats_dependencies_and_composite_types():
+    source = (
+        'import"math.lock";#include"kernels.lock";'
+        "pipeline Main{stream<Vec<float,4>,16> samples;bind{}}"
+    )
+
+    assert format_lockstep_source(source) == (
+        'import "math.lock";\n'
+        '#include "kernels.lock";\n'
+        "pipeline Main {\n"
+        "    stream<Vec<float,4>,16> samples;\n"
+        "    bind {\n"
+        "    }\n"
+        "}\n"
+    )
+
+
+def test_format_lockstep_source_formats_fold_declarations_and_casts():
+    source = (
+        "shader Normalize(in Vec<float,4> p){"
+        "Vec<float,4> next=(Vec<float,4>)p;return next;}"
+        "pipeline Main{stream<Vec<float,4>,16> samples;"
+        "uniform Vec<float,4> seed=Vec<float,4>(1,2);"
+        "bind{uniform Vec<float,4> total=fold sum(samples);}}"
+    )
+
+    assert format_lockstep_source(source) == (
+        "shader Normalize(in Vec<float,4> p) {\n"
+        "    Vec<float,4> next=(Vec<float,4>)p;\n"
+        "    return next;\n"
+        "}\n"
+        "pipeline Main {\n"
+        "    stream<Vec<float,4>,16> samples;\n"
+        "    uniform Vec<float,4> seed=Vec<float,4>(1,2);\n"
+        "    bind {\n"
+        "        uniform Vec<float,4> total=fold sum(samples);\n"
+        "    }\n"
+        "}\n"
+    )


### PR DESCRIPTION
### Motivation
- Produce canonical indentation/spacing for Lockstep source while preserving important syntax like struct terminators and dependency declarations. 
- Avoid brittle raw-string formatting for nested expressions by using lexer/parser token information. 
- Preserve line comments by skipping reformat when input contains comments and ensure CLI `--format` prints the formatted source without invoking compilation.

### Description
- Filter token streams to ignore hidden/comment-channel tokens and refine spacing rules to handle string tokens next to identifiers. 
- Add `_format_context_tokens` which extracts a contiguous token interval from parser contexts and use it for expressions, lvalues, composite type names, casts, and type suffixes instead of `ctx.getText()`. 
- Add `visitDependencyDecl` to preserve `import`/`#include` declarations in formatted output and keep struct terminators intact. 
- Keep the existing token-stream fallback (`_format_token_stream`) for parse errors and maintain the CLI behavior where `run_cli --format` prints formatted source and returns before calling the compiler.
- Add tests exercising dependency declarations, composite type syntax, fold declarations, and casts in `tests/test_formatter.py` and ensure CLI formatting behavior in `tests/test_cli_format.py`.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_formatter.py tests/test_cli_format.py`, and both targeted test files passed. 
- Ran code formatting (`black`) and ensured the modified files were reformatted automatically during the change. 
- Attempted a full test run (`PYTHONPATH=. pytest -q`) but collection of unrelated property tests failed in this environment due to a missing optional test dependency (`hypothesis`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f4dcf770083289d59060b4068a02d)