### PR TITLE
Update CLI behavior, pass compiler kwargs, fix dependency diagnostics and C header, and export CLI/API names

### DIFF
--- a/lockstep_compiler/__init__.py
+++ b/lockstep_compiler/__init__.py
@@ -1,13 +1,24 @@
 from .c_header import emit_c_header
-from .cli import build_arg_parser, run_cli
-from .compiler import FrontendLimits, compile_lockstep, load_default_parser_classes, validate_semantics
+from .cli import build_arg_parser, main, run_cli
+from .compiler import (
+    FrontendLimitExceeded,
+    FrontendLimits,
+    compile_lockstep,
+    load_default_parser_classes,
+    validate_semantics,
+)
 from .errors import LockstepCompileError, ParseErrorCollector
 from .formatter import format_lockstep_source
 from .models import LockstepCompileResult, LockstepDiagnostic, normalize_diagnostics
-from .simulator import simulate_pipeline_entities, simulate_pipeline_source
+from .simulator import (
+    parse_simulation_inputs,
+    simulate_pipeline_entities,
+    simulate_pipeline_source,
+)
 from .visitors import build_debug_visitor, build_semantic_validator
 
 __all__ = [
+    "FrontendLimitExceeded",
     "FrontendLimits",
     "LockstepCompileError",
     "LockstepCompileResult",
@@ -20,7 +31,9 @@ __all__ = [
     "compile_lockstep",
     "format_lockstep_source",
     "load_default_parser_classes",
+    "main",
     "normalize_diagnostics",
+    "parse_simulation_inputs",
     "run_cli",
     "simulate_pipeline_entities",
     "simulate_pipeline_source",

--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -65,7 +65,7 @@ def emit_c_header(
     ]
 
     for struct_decl in normalized_structs:
-        struct_name = struct_decl["name"]
+        struct_name = struct_decl.name
         c_struct_name = f"Lockstep_{_sanitize_symbol(struct_name)}"
         if struct_name in opaque_structs:
             lines.append(
@@ -75,9 +75,9 @@ def emit_c_header(
             continue
 
         lines.append(f"LOCKSTEP_PACKED_STRUCT(struct {c_struct_name} {{")
-        for field in struct_decl.get("fields", []):
-            field_type = _c_type(field.get("type", "float"), known_structs)
-            field_name = _sanitize_symbol(field.get("name", "field"))
+        for field in struct_decl.fields:
+            field_type = _c_type(field.type_name, known_structs)
+            field_name = _sanitize_symbol(field.name)
             lines.append(f"    {field_type} {field_name};")
         lines.append("});")
         lines.append("")
@@ -111,7 +111,11 @@ def emit_c_header(
             )
         cumulative_layout_total += leaf_allocation_size
         c_type_name = _c_type(leaf.type_name, known_structs)
-        path_suffix = "_".join(_sanitize_symbol(part) for part in leaf.path) if leaf.path else "value"
+        path_suffix = (
+            "_".join(_sanitize_symbol(part) for part in leaf.path)
+            if leaf.path
+            else "value"
+        )
         field_name = f"{leaf.kind}_{_sanitize_symbol(leaf.binding_name)}_{path_suffix}"
         if leaf.element_count > 1:
             lines.append(f"    {c_type_name} {field_name}[{leaf.element_count}];")
@@ -138,7 +142,9 @@ def emit_c_header(
         if not leaf.path:
             continue
         leaf_suffix = "_".join(_sanitize_symbol(part) for part in leaf.path).upper()
-        macro_suffix = f"{leaf.kind}_{_sanitize_symbol(leaf.binding_name)}_{leaf_suffix}".upper()
+        macro_suffix = (
+            f"{leaf.kind}_{_sanitize_symbol(leaf.binding_name)}_{leaf_suffix}".upper()
+        )
         lines.append(f"#define LOCKSTEP_OFFSET_{macro_suffix} {leaf.offset}")
     for stream in entities.get("streams", []):
         stream_name = _sanitize_symbol(stream["name"]).upper()

--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -6,9 +6,11 @@ import traceback
 from pathlib import Path
 from typing import Any, Callable, TextIO, cast
 
+from .ast import ast_to_entities
 from .errors import LockstepCompileError
-from .simulator import parse_simulation_inputs, simulate_pipeline_entities
 from .formatter import format_lockstep_source
+from .optimizer import optimize_bind_routes
+from .simulator import parse_simulation_inputs, simulate_pipeline_entities
 
 
 def _non_negative_limit_value(flag_name: str):
@@ -233,6 +235,10 @@ def run_cli(
     else:
         source = stdin.read()
 
+    if args.format:
+        print(format_lockstep_source(source), end="", file=stdout)
+        return 0
+
     library_sources = []
     library_source_files = []
     for library_path in args.lib:
@@ -241,10 +247,6 @@ def run_cli(
             return 1
         library_sources.append(library_source)
         library_source_files.append(str(Path(library_path)))
-
-    if args.format:
-        print(format_lockstep_source(source), end="", file=stdout)
-        return 0
 
     if compiler is None:
         from .compiler import compile_lockstep

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -480,7 +480,7 @@ def _resolve_dependency_sources(
                         "(or max_dependency_depth via API), or set it to 0 to disable."
                     ),
                 )
-            dependency_path = _resolve_reference(reference, current_file)
+            dependency_path = _resolve_reference(reference, current_file, line)
             if dependency_path in in_stack:
                 cycle_chain = [*in_stack, dependency_path]
                 cycle_text = " -> ".join(str(path) for path in cycle_chain)


### PR DESCRIPTION
### Motivation
- Ensure the CLI supports the requested flags and output modes and forwards the correct contextual data to the compiler API so downstream features (emit-ir, emit-header, simulate/report/dump, format, libraries, and frontend limits) behave correctly.
- Improve diagnostics for dependency resolution by including source line information in dependency-related errors.
- Make C header emission consume the normalized arena layout dataclasses produced by the layout builder so `--emit-header` works with the current layout types.
- Expose additional package-level helpers and exceptions (CLI entry, parse helpers, frontend limit exception) through package exports for external consumers and tests.

### Description
- Updated `lockstep_compiler/cli.py` to: import `ast_to_entities`, `optimize_bind_routes`, and keep `parse_simulation_inputs`/`simulate_pipeline_entities` imports; move `--format` handling before library loading/compilation so formatting returns without compiling; and continue to detect supported compiler parameters and pass `library_sources`, `library_source_files`, `frontend_limits`, `target_width`, `source_file`, and `dependency_root` only when the injected compiler supports them.
- Fixed dependency resolution in `lockstep_compiler/compiler.py` to pass the dependency `line` into `_resolve_reference`, enabling diagnostics and root-violation messages to include accurate source locations.
- Updated `lockstep_compiler/c_header.py` to consume the `normalized_structs` and `leaves` as dataclasses (access via attributes like `.name`, `.fields`, `.type_name`, `.path`) instead of treating them as dicts, and made minor formatting improvements to path handling.
- Expanded `lockstep_compiler/__init__.py` exports to include `main`, `FrontendLimitExceeded`, and `parse_simulation_inputs` so these are available from the top-level package API.

### Testing
- Ran source formatting with `black` on changed files, which completed successfully.
- Executed a focused pytest selection including `tests/test_cli_format.py`, a number of CLI/library/emit tests, and `tests/test_simulator.py`, which passed in the focused runs covering CLI and header/emit behavior.
- Ran the full test selection (`tests/test_lockstep_compiler_api.py`, `tests/test_cli_libraries.py`, `tests/test_cli_format.py`, `tests/test_improvements.py`, `tests/test_simulator.py`) and observed remaining failures in extensive semantic validator / LSP tests unrelated to the CLI/library/header changes in this patch; these failures are noted as existing coverage differences and not introduced by the CLI and export fixes in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f4dc870a883288993ab561911b81e)