### PR TITLE
Treat fold routes as optimizer DAG consumers

### DIFF
--- a/lockstep_compiler/optimizer.py
+++ b/lockstep_compiler/optimizer.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 import re
 
-
 _BIND_ROUTE_RE = re.compile(
     r"^\s*(?P<target>[A-Za-z_]\w*)\s*=\s*(?P<callee>[A-Za-z_]\w*)\s*\((?P<args>[^)]*)\)\s*;\s*$"
+)
+_FOLD_BIND_ROUTE_RE = re.compile(
+    r"^\s*uniform\s+(?P<uniform_type>.+?)\s+(?P<target>[A-Za-z_]\w*)"
+    r"\s*=\s*fold\s+(?P<operator>sum|avg|min|max)\s*"
+    r"\((?P<source>[A-Za-z_]\w*)\)\s*;\s*$"
 )
 
 
@@ -15,9 +19,20 @@ class ParsedBindRoute:
     callee: str
     args: tuple[str, ...]
     raw: str
+    kind: str = "kernel"
 
 
 def _parse_bind_route(route: str) -> ParsedBindRoute | None:
+    fold_match = _FOLD_BIND_ROUTE_RE.match(route)
+    if fold_match:
+        return ParsedBindRoute(
+            target=fold_match.group("target"),
+            callee=f"fold:{fold_match.group('operator')}",
+            args=(fold_match.group("source"),),
+            raw=route,
+            kind="fold",
+        )
+
     match = _BIND_ROUTE_RE.match(route)
     if not match:
         return None
@@ -48,6 +63,20 @@ def optimize_bind_routes(
     if bind_routes_ir:
         parsed_routes = []
         for index, route in enumerate(bind_routes_ir):
+            if route.get("kind") == "fold":
+                parsed_routes.append(
+                    ParsedBindRoute(
+                        target=route.get("uniform_name", ""),
+                        callee=f"fold:{route.get('operator', '')}",
+                        args=(route.get("source", ""),),
+                        raw=route.get(
+                            "route",
+                            bind_routes[index] if index < len(bind_routes) else "",
+                        ),
+                        kind="fold",
+                    )
+                )
+                continue
             if route.get("kind") != "kernel":
                 parsed_routes.append(None)
                 continue
@@ -59,6 +88,7 @@ def optimize_bind_routes(
                     raw=route.get(
                         "route", bind_routes[index] if index < len(bind_routes) else ""
                     ),
+                    kind="kernel",
                 )
             )
         if len(parsed_routes) < len(bind_routes):
@@ -91,7 +121,11 @@ def optimize_bind_routes(
     # is never consumed, unless they explicitly read/accumulate their target.
     active_kernel_indices: set[int] = set()
     for idx, parsed in enumerate(parsed_routes):
-        if parsed is None or parsed.callee not in valid_kernel_names:
+        if (
+            parsed is None
+            or parsed.kind != "kernel"
+            or parsed.callee not in valid_kernel_names
+        ):
             continue
         if (
             parsed.target in live_after_route[idx]
@@ -99,19 +133,25 @@ def optimize_bind_routes(
         ):
             active_kernel_indices.add(idx)
 
-    # Build producer/consumer links between active kernels.
+    # Build producer/consumer links. Kernels are the only fusible producers, but
+    # folds are first-class consumers so accumulator reads keep their producer
+    # kernels alive and prevent fusion from hiding values needed by reductions.
     producer_by_symbol: dict[str, int] = {}
     deps: dict[int, set[int]] = {idx: set() for idx in active_kernel_indices}
     consumers: dict[int, set[int]] = {idx: set() for idx in active_kernel_indices}
     for idx, parsed in enumerate(parsed_routes):
-        if idx not in active_kernel_indices or parsed is None:
+        if parsed is None:
             continue
+        is_active_kernel = idx in active_kernel_indices
         for arg in parsed.args:
             producer = producer_by_symbol.get(arg)
-            if producer is not None:
+            if producer is None:
+                continue
+            if is_active_kernel:
                 deps[idx].add(producer)
-                consumers[producer].add(idx)
-        producer_by_symbol[parsed.target] = idx
+            consumers[producer].add(idx)
+        if is_active_kernel:
+            producer_by_symbol[parsed.target] = idx
 
     fused_groups: list[dict[str, object]] = []
     fused_replacement_at: dict[int, str] = {}
@@ -204,6 +244,7 @@ def optimize_bind_routes(
         parsed = parsed_routes[idx]
         if (
             parsed is not None
+            and parsed.kind == "kernel"
             and parsed.callee in valid_kernel_names
             and idx not in active_kernel_indices
         ):

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -99,6 +99,68 @@ def test_optimize_bind_routes_uses_structured_bind_route_ir_when_available():
     assert result["fused_groups"] == []
 
 
+def test_optimize_bind_routes_treats_structured_fold_as_accumulator_consumer():
+    result = optimize_bind_routes(
+        [
+            "energy = Accumulate(src, energy);",
+            "uniform float total = fold sum(energy);",
+            "energy = Reset(seed, scratch);",
+        ],
+        shader_names={"Accumulate", "Reset"},
+        filter_names=set(),
+        bind_routes_ir=[
+            {
+                "kind": "kernel",
+                "target": "energy",
+                "kernel": "Accumulate",
+                "args": ["src", "energy"],
+                "route": "energy = Accumulate(src, energy);",
+            },
+            {
+                "kind": "fold",
+                "uniform_type": "float",
+                "uniform_name": "total",
+                "operator": "sum",
+                "source": "energy",
+                "route": "uniform float total = fold sum(energy);",
+            },
+            {
+                "kind": "kernel",
+                "target": "energy",
+                "kernel": "Reset",
+                "args": ["seed", "scratch"],
+                "route": "energy = Reset(seed, scratch);",
+            },
+        ],
+    )
+
+    assert result["optimized_bind_routes"] == [
+        "energy = Accumulate(src, energy);",
+        "uniform float total = fold sum(energy);",
+        "energy = Reset(seed, scratch);",
+    ]
+    assert result["fused_groups"] == []
+
+
+def test_optimize_bind_routes_parses_textual_fold_as_accumulator_consumer():
+    result = optimize_bind_routes(
+        [
+            "energy = Accumulate(src, energy);",
+            "uniform float total = fold sum(energy);",
+            "energy = Reset(seed, scratch);",
+        ],
+        shader_names={"Accumulate", "Reset"},
+        filter_names=set(),
+    )
+
+    assert result["optimized_bind_routes"] == [
+        "energy = Accumulate(src, energy);",
+        "uniform float total = fold sum(energy);",
+        "energy = Reset(seed, scratch);",
+    ]
+    assert result["fused_groups"] == []
+
+
 def test_optimize_bind_routes_uses_liveness_not_global_use_count():
     result = optimize_bind_routes(
         [


### PR DESCRIPTION
### Motivation
- The optimizer's `optimize_bind_routes` previously ignored `fold` bind routes, so accumulator reads were invisible to the DAG and producer kernels could be incorrectly eliminated as dead. 
- Fold reductions must be treated as first-class consumers so accumulator values act as live dataflow edges between kernels and folds.

### Description
- Parse textual fold routes with a new `_FOLD_BIND_ROUTE_RE` and extend `ParsedBindRoute` with a `kind` field to mark `fold` entries; update `_parse_bind_route` to return fold metadata for textual routes in addition to kernel routes. 
- When `bind_routes_ir` is present, translate structured `fold` IR into `ParsedBindRoute` entries so structured folds are recognized as consumers. 
- Modify liveness and DAG construction inside `optimize_bind_routes` so only `kind == "kernel"` routes are considered fusible/producer candidates while folds contribute consumer links that keep producer kernels live. 
- Add regression tests `test_optimize_bind_routes_treats_structured_fold_as_accumulator_consumer` and `test_optimize_bind_routes_parses_textual_fold_as_accumulator_consumer` to `tests/test_optimizer.py` to cover both structured IR and textual fold parsing. 
- Key files changed: `lockstep_compiler/optimizer.py` and `tests/test_optimizer.py`.

### Testing
- Ran `pytest tests/test_optimizer.py -q` which passed and exercises the new fold-consumer cases. 
- Ran `pytest tests/test_compiler_api.py -q` which passed to verify compiler-level behavior remains intact. 
- Ran a full `pytest -q` which exposed unrelated preexisting failures (missing benchmark fixture plus separate LSP/formatter/CLI issues) that are outside the scope of these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a219978fdd88328a11e72abc256553f)