### PR TITLE
Fix C header sizing for folded array/vector leaves and add static assert

### DIFF
--- a/lockstep_compiler/c_header.py
+++ b/lockstep_compiler/c_header.py
@@ -4,7 +4,12 @@ from collections.abc import Mapping
 from typing import Any
 
 from .ast import AstProgram, ast_to_entities
-from .arena_layout import build_arena_layout
+from .arena_layout import (
+    _parse_type_name,
+    _structural_type_name,
+    build_arena_layout,
+    field_size,
+)
 from .errors import LockstepCompileError
 from .models import LockstepDiagnostic
 from .utils import sanitize_symbol as _sanitize_symbol
@@ -17,6 +22,14 @@ _PRIMITIVE_C_TYPE = {
     "double": "double",
 }
 
+_C_TYPE_SIZE = {
+    "uint8_t": 1,
+    "int32_t": 4,
+    "uint32_t": 4,
+    "float": 4,
+    "double": 8,
+}
+
 _MAX_U64 = (1 << 64) - 1
 
 
@@ -26,6 +39,25 @@ def _c_type(type_name: str, known_structs: set[str]) -> str:
     if type_name in known_structs:
         return f"struct Lockstep_{_sanitize_symbol(type_name)}"
     return "void*"
+
+
+def _structural_c_type(type_name: str, known_structs: set[str]) -> str:
+    parsed = _parse_type_name(type_name)
+    if parsed is None:
+        return _c_type(type_name, known_structs)
+    return _c_type(_structural_type_name(parsed), known_structs)
+
+
+def _sized_field_declaration(
+    c_type_name: str, field_name: str, total_size: int
+) -> str:
+    c_type_size = _C_TYPE_SIZE.get(c_type_name)
+    if c_type_size is None or total_size <= 0 or total_size % c_type_size != 0:
+        return f"uint8_t {field_name}[{max(total_size, 1)}]"
+    item_count = total_size // c_type_size
+    if item_count == 1:
+        return f"{c_type_name} {field_name}"
+    return f"{c_type_name} {field_name}[{item_count}]"
 
 
 def emit_c_header(
@@ -73,9 +105,13 @@ def emit_c_header(
 
         lines.append(f"LOCKSTEP_PACKED_STRUCT(struct {c_struct_name} {{")
         for field in struct_decl.fields:
-            field_type = _c_type(field.type_name, known_structs)
+            field_type = _structural_c_type(field.type_name, known_structs)
             field_name = _sanitize_symbol(field.name)
-            lines.append(f"    {field_type} {field_name};")
+            field_total_size = field_size(field.type_name, layout.struct_sizes)
+            declaration = _sized_field_declaration(
+                field_type, field_name, field_total_size
+            )
+            lines.append(f"    {declaration};")
         lines.append("});")
         lines.append("")
 
@@ -106,17 +142,17 @@ def emit_c_header(
                 source_file=diagnostic.source_file,
             )
         cumulative_layout_total += leaf_allocation_size
-        c_type_name = _c_type(leaf.type_name, known_structs)
+        c_type_name = _structural_c_type(leaf.type_name, known_structs)
         path_suffix = (
             "_".join(_sanitize_symbol(part) for part in leaf.path)
             if leaf.path
             else "value"
         )
         field_name = f"{leaf.kind}_{_sanitize_symbol(leaf.binding_name)}_{path_suffix}"
-        if leaf.element_count > 1:
-            lines.append(f"    {c_type_name} {field_name}[{leaf.element_count}];")
-        else:
-            lines.append(f"    {c_type_name} {field_name};")
+        declaration = _sized_field_declaration(
+            c_type_name, field_name, leaf_allocation_size
+        )
+        lines.append(f"    {declaration};")
     lines.append("});")
     lines.append("")
 
@@ -128,6 +164,11 @@ def emit_c_header(
             'static_assert(LOCKSTEP_ARENA_BYTES <= SIZE_MAX, "LOCKSTEP_ARENA_BYTES must fit in size_t on the target architecture");',
             "#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)",
             '_Static_assert(LOCKSTEP_ARENA_BYTES <= SIZE_MAX, "LOCKSTEP_ARENA_BYTES must fit in size_t on the target architecture");',
+            "#endif",
+            "#if defined(__cplusplus) && (__cplusplus >= 201103L)",
+            'static_assert(sizeof(struct Lockstep_Arena) == LOCKSTEP_ARENA_BYTES, "Lockstep_Arena size must match LOCKSTEP_ARENA_BYTES");',
+            "#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)",
+            '_Static_assert(sizeof(struct Lockstep_Arena) == LOCKSTEP_ARENA_BYTES, "Lockstep_Arena size must match LOCKSTEP_ARENA_BYTES");',
             "#endif",
         ]
     )

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -1816,6 +1816,37 @@ def test_emit_c_header_uses_parallel_soa_blocks_for_stream_capacity():
     assert "#define LOCKSTEP_ARENA_BYTES 32" in header
 
 
+def test_emit_c_header_sizes_folded_array_and_vector_leaves_by_layout_bytes():
+    header = emit_c_header(
+        {
+            "structs": [
+                {
+                    "name": "Vec",
+                    "fields": [
+                        {"type": "float[4]", "name": "xs"},
+                        {"type": "vector<float,4>", "name": "ys"},
+                    ],
+                }
+            ],
+            "streams": [{"name": "values", "type": "Vec", "capacity": "8"}],
+            "accumulators": [],
+            "uniforms": [],
+        }
+    )
+
+    assert "float xs[4];" in header
+    assert "float ys[4];" in header
+    assert "float stream_values_xs[32];" in header
+    assert "float stream_values_ys[32];" in header
+    assert "#define LOCKSTEP_OFFSET_STREAM_VALUES_XS 0" in header
+    assert "#define LOCKSTEP_OFFSET_STREAM_VALUES_YS 128" in header
+    assert "#define LOCKSTEP_ARENA_BYTES 256" in header
+    assert (
+        "_Static_assert(sizeof(struct Lockstep_Arena) == LOCKSTEP_ARENA_BYTES"
+        in header
+    )
+
+
 def test_emit_c_header_includes_optional_saturated_write_debug_helpers():
     header = emit_c_header(
         {


### PR DESCRIPTION
### Motivation
- The C header emitted array/generic-typed leaves from the structural `c_type` multiplied only by `element_count`, which dropped folded array/generic multipliers from the layout and caused `sizeof(struct Lockstep_Arena)` to diverge from `LOCKSTEP_ARENA_BYTES`.

### Description
- Use the parsed structural type when emitting C types via a new `_structural_c_type` helper so generic/array suffixes are reduced to the underlying structural C type before sizing.
- Add `_C_TYPE_SIZE` and `_sized_field_declaration` helpers and use `field_size(...)` to size struct and arena fields from layout byte counts rather than reconstructing multiplicity from `c_type` and `element_count`.
- Replace per-element `type name[element_count]` emission with byte-sized declarations for both `struct Lockstep_*` fields and `struct Lockstep_Arena` leaves.
- Emit C/C++ assertions `static_assert(sizeof(struct Lockstep_Arena) == LOCKSTEP_ARENA_BYTES)` / `_Static_assert(...)` to catch future header/arena layout drift and add a regression test `test_emit_c_header_sizes_folded_array_and_vector_leaves_by_layout_bytes`.

### Testing
- Ran `python -m pytest tests/test_compiler_api.py -q` and the test suite for the compiler API passed.
- Ran `python -m pytest` which failed collection in this environment due to the missing optional dependency `hypothesis` (test collection error, unrelated to this change).
- Generated a header and compiled a small compile-time size check with `cc -std=c11 -Wall -Wextra -c /tmp/lockstep_header_check.c`, which succeeded (there is an existing unused-parameter warning present when `-Werror` is used).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f08ed24848328b552898ac2e1dcf2)