### PR TITLE
Fix compiled filter compaction semantics

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -844,6 +844,10 @@ class _FunctionLowerer:
         if not self.builder.block.is_terminated:
             if isinstance(return_type, ir.VoidType):
                 self.builder.ret_void()
+            elif isinstance(return_type, ir.IntType) and return_type.width == 1:
+                # Filters default to keeping the row when control reaches the end
+                # without an explicit return, matching simulator semantics.
+                self.builder.ret(ir.Constant(return_type, 1))
             elif isinstance(return_type, ir.FloatType):
                 self.builder.ret(ir.Constant(ir.FloatType(), 0.0))
             else:
@@ -1165,7 +1169,7 @@ def emit_llvm_ir(
         ]
         fn = ir.Function(
             module,
-            ir.FunctionType(ir.VoidType(), params),
+            ir.FunctionType(ir.IntType(1), params),
             name=f"filter_{_sanitize_symbol(flt.name)}",
         )
         for idx, param in enumerate(flt.params):
@@ -1202,9 +1206,9 @@ def emit_llvm_ir(
         lowerer.lower_function(
             fn,
             list(flt.body),
-            ir.VoidType(),
+            ir.IntType(1),
             [_kernel_param_type(param) for param in flt.params],
-            None,
+            "bool",
             [param.modifier in {"out", "accum"} for param in flt.params],
         )
 
@@ -1225,6 +1229,7 @@ def emit_llvm_ir(
         shader.name: (shader, shader.params) for shader in shaders
     }
     kernel_signatures.update({flt.name: (flt, flt.params) for flt in filters})
+    filter_names = {flt.name for flt in filters}
 
     def _infer_accumulator_sizes() -> dict[str, int]:
         inferred_sizes = {accum.name: 1 for accum in accumulators}
@@ -1788,21 +1793,32 @@ def emit_llvm_ir(
         current: ir.Value,
         *,
         local_slots: dict[str, ir.AllocaInstr] | None = None,
-    ) -> None:
+        output_index: ir.Value | None = None,
+    ) -> ir.Value | None:
         callee, params = _kernel_function_and_params(route.kernel)
         if callee is None:
-            return
+            return None
+        store_index = output_index if output_index is not None else current
         call_args = []
         copy_out_slots: list[tuple[str, ir.AllocaInstr, str]] = []
         for index, param in enumerate(callee.args):
             arg_name = route.args[index] if index < len(route.args) else ""
             modifier = params[index].modifier if index < len(params) else None
-            call_arg = _route_arg_value(
-                arg_name=arg_name,
-                param=param,
-                modifier=modifier,
-                current=current,
-                local_slots=local_slots,
+            is_filter_output = (
+                route.kernel in filter_names
+                and modifier == "out"
+                and arg_name in stream_slots
+            )
+            call_arg = (
+                None
+                if is_filter_output
+                else _route_arg_value(
+                    arg_name=arg_name,
+                    param=param,
+                    modifier=modifier,
+                    current=current,
+                    local_slots=local_slots,
+                )
             )
             if call_arg is None and modifier == "out" and arg_name in stream_slots:
                 if not hasattr(param.type, "pointee"):
@@ -1817,7 +1833,7 @@ def emit_llvm_ir(
                     name=f"route_{_sanitize_symbol(arg_name)}_out_slot",
                 )
                 initial_value = _load_tick_param(
-                    "stream", arg_name, param.type.pointee, current
+                    "stream", arg_name, param.type.pointee, store_index
                 )
                 tick_builder.store(initial_value, slot)
                 call_arg = slot
@@ -1827,14 +1843,54 @@ def emit_llvm_ir(
                     f"could not lower argument '{arg_name}' for route '{route.route}'"
                 )
             call_args.append(call_arg)
-        tick_builder.call(callee, call_args)
+        result = tick_builder.call(callee, call_args)
+        if route.kernel in filter_names and copy_out_slots:
+            keep_bool = result
+            if not (
+                isinstance(keep_bool.type, ir.IntType) and keep_bool.type.width == 1
+            ):
+                keep_bool = lowerer._coerce_value_to_type(
+                    keep_bool, ir.IntType(1), "bool"
+                )
+            store_block = tick.append_basic_block(
+                f"filter_{_sanitize_symbol(route.kernel)}_store"
+            )
+            skip_block = tick.append_basic_block(
+                f"filter_{_sanitize_symbol(route.kernel)}_skip"
+            )
+            after_block = tick.append_basic_block(
+                f"filter_{_sanitize_symbol(route.kernel)}_after"
+            )
+            tick_builder.cbranch(keep_bool, store_block, skip_block)
+            tick_builder.position_at_end(store_block)
+            for arg_name, slot, declared_type in copy_out_slots:
+                updated_value = tick_builder.load(
+                    slot, name=f"route_{_sanitize_symbol(arg_name)}_out_value"
+                )
+                _store_value(
+                    "stream",
+                    arg_name,
+                    updated_value,
+                    declared_type,
+                    element_index=store_index,
+                )
+            tick_builder.branch(after_block)
+            tick_builder.position_at_end(skip_block)
+            tick_builder.branch(after_block)
+            tick_builder.position_at_end(after_block)
+            return result
         for arg_name, slot, declared_type in copy_out_slots:
             updated_value = tick_builder.load(
                 slot, name=f"route_{_sanitize_symbol(arg_name)}_out_value"
             )
             _store_value(
-                "stream", arg_name, updated_value, declared_type, element_index=current
+                "stream",
+                arg_name,
+                updated_value,
+                declared_type,
+                element_index=store_index,
             )
+        return result
 
     def _lower_kernel_route(route: AstKernelBindRoute):
         trip_count = _kernel_route_trip_count(route)
@@ -1844,6 +1900,12 @@ def emit_llvm_ir(
             ir.IntType(32), name=f"{_sanitize_symbol(kernel_name)}_idx"
         )
         tick_builder.store(ir.Constant(ir.IntType(32), 0), index_ptr)
+        write_index_ptr = None
+        if kernel_name in filter_names:
+            write_index_ptr = tick_builder.alloca(
+                ir.IntType(32), name=f"{_sanitize_symbol(kernel_name)}_write_idx"
+            )
+            tick_builder.store(ir.Constant(ir.IntType(32), 0), write_index_ptr)
 
         loop_cond = tick.append_basic_block(
             f"route_{_sanitize_symbol(kernel_name)}_cond"
@@ -1864,7 +1926,27 @@ def emit_llvm_ir(
         tick_builder.cbranch(cond, loop_body, loop_exit)
 
         tick_builder.position_at_end(loop_body)
-        _emit_kernel_call(route, current)
+        output_index = current
+        if write_index_ptr is not None:
+            output_index = tick_builder.load(write_index_ptr, name="filter_write_idx")
+        keep_value = _emit_kernel_call(route, current, output_index=output_index)
+        if write_index_ptr is not None:
+            keep_bool = keep_value
+            if keep_bool is None:
+                keep_bool = ir.Constant(ir.IntType(1), 1)
+            if not (
+                isinstance(keep_bool.type, ir.IntType) and keep_bool.type.width == 1
+            ):
+                keep_bool = lowerer._coerce_value_to_type(
+                    keep_bool, ir.IntType(1), "bool"
+                )
+            write_next = tick_builder.add(
+                output_index, ir.Constant(ir.IntType(32), 1), name="filter_write_next"
+            )
+            selected_write = tick_builder.select(
+                keep_bool, write_next, output_index, name="filter_write_select"
+            )
+            tick_builder.store(selected_write, write_index_ptr)
         next_index = tick_builder.add(
             current, ir.Constant(ir.IntType(32), 1), name="idx_next"
         )
@@ -2780,6 +2862,10 @@ def emit_llvm_ir(
         eliminated_targets = {route.target for route in routes[:-1]}
         if not eliminated_targets:
             _lower_kernel_route(routes[0])
+            return
+        if any(route.kernel in filter_names for route in routes):
+            for route in routes:
+                _lower_kernel_route(route)
             return
         if not _can_vectorize_fused_group(routes):
             for route in routes:

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -116,7 +116,10 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
     assert result.entities["fused_bind_groups"] == []
 
     assert result.llvm_ir.startswith('; ModuleID = "lockstep"\n')
-    assert 'define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")' in result.llvm_ir
+    assert (
+        'define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")'
+        in result.llvm_ir
+    )
 
 
 def test_codegen_logical_and_short_circuits_rhs_division():
@@ -126,9 +129,7 @@ def test_codegen_logical_and_short_circuits_rhs_division():
                 name="guarded",
                 return_type=AstType("bool"),
                 params=(
-                    AstKernelParam(
-                        modifier="", declared_type=AstType("int"), name="x"
-                    ),
+                    AstKernelParam(modifier="", declared_type=AstType("int"), name="x"),
                 ),
                 body=(
                     AstReturnStmt(
@@ -158,9 +159,9 @@ def test_codegen_logical_and_short_circuits_rhs_division():
     ir_text = emit_llvm_ir(program)
 
     assert 'br i1 %".4", label %"logic_and_rhs", label %"logic_and_merge"' in ir_text
-    assert 'logic_and_rhs:' in ir_text
-    assert 'sdiv i32 100' in ir_text
-    assert 'logic_and_merge:' in ir_text
+    assert "logic_and_rhs:" in ir_text
+    assert "sdiv i32 100" in ir_text
+    assert "logic_and_merge:" in ir_text
     assert '[0, %"entry"], [%".7", %"logic_and_rhs"]' in ir_text
 
 
@@ -195,11 +196,14 @@ def test_codegen_logical_or_short_circuits_rhs_call():
 
     ir_text = emit_llvm_ir(program)
 
-    assert 'br i1 %"ready_val", label %"logic_or_merge", label %"logic_or_rhs"' in ir_text
-    assert 'logic_or_rhs:' in ir_text
+    assert (
+        'br i1 %"ready_val", label %"logic_or_merge", label %"logic_or_rhs"' in ir_text
+    )
+    assert "logic_or_rhs:" in ir_text
     assert 'call i1 @"pure_expensive"()' in ir_text
-    assert 'logic_or_merge:' in ir_text
+    assert "logic_or_merge:" in ir_text
     assert '[1, %"entry"], [%"call_expensive", %"logic_or_rhs"]' in ir_text
+
 
 def test_compile_lockstep_surfaces_typed_ast_type_error_without_legacy_fallback(
     monkeypatch,
@@ -430,11 +434,8 @@ def test_emit_llvm_ir_generates_expected_declarations():
     assert '%"struct.Vec3" = type {float, float, float}' in llvm_ir
     assert 'define float @"pure_demo"()' in llvm_ir
     assert 'define void @"shader_ApplyGravity"()' in llvm_ir
-    assert 'define void @"filter_Cull"()' in llvm_ir
-    assert (
-        'define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")'
-        in llvm_ir
-    )
+    assert 'define i1 @"filter_Cull"()' in llvm_ir
+    assert 'define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")' in llvm_ir
     assert "; bind: out = ApplyGravity(inp, out, energy, dt);" in llvm_ir
     assert 'declare float @"llvm.maxnum.f32"(float %".1", float %".2")' in llvm_ir
     assert 'declare float @"llvm.minnum.f32"(float %".1", float %".2")' in llvm_ir
@@ -839,14 +840,29 @@ def test_emit_llvm_ir_accepts_ast_program_input():
 
     assert "route_ApplyGravity_cond" in llvm_ir
     assert 'icmp slt i32 %"idx", 2' in llvm_ir
-    assert '%"stream_inp_arena_bytes" = bitcast %"struct.Lockstep_Arena"* %"arena" to i8*' in llvm_ir
-    assert '%"stream_inp_value_byte_ptr" = getelementptr i8, i8* %"stream_inp_arena_bytes", i32 %"stream_inp_byte_offset"' in llvm_ir
+    assert (
+        '%"stream_inp_arena_bytes" = bitcast %"struct.Lockstep_Arena"* %"arena" to i8*'
+        in llvm_ir
+    )
+    assert (
+        '%"stream_inp_value_byte_ptr" = getelementptr i8, i8* %"stream_inp_arena_bytes", i32 %"stream_inp_byte_offset"'
+        in llvm_ir
+    )
     assert 'bitcast i8* %"stream_inp_value_byte_ptr" to float*' in llvm_ir
     assert '%"stream_out_byte_offset" = add i32 8, %"stream_out_byte_index"' in llvm_ir
-    assert '%"stream_out_value_byte_ptr" = getelementptr i8, i8* %"stream_out_arena_bytes", i32 %"stream_out_byte_offset"' in llvm_ir
+    assert (
+        '%"stream_out_value_byte_ptr" = getelementptr i8, i8* %"stream_out_arena_bytes", i32 %"stream_out_byte_offset"'
+        in llvm_ir
+    )
     assert 'bitcast i8* %"stream_out_value_byte_ptr" to float*' in llvm_ir
-    assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 0' not in llvm_ir
-    assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 1' not in llvm_ir
+    assert (
+        'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 0'
+        not in llvm_ir
+    )
+    assert (
+        'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 1'
+        not in llvm_ir
+    )
 
 
 def test_emit_llvm_ir_uses_array_field_for_single_capacity_streams():
@@ -998,9 +1014,17 @@ def test_emit_llvm_ir_lowers_kernel_bind_routes_into_counted_loops():
     assert "route_ApplyGravity_cond" in llvm_ir
     assert 'icmp slt i32 %"idx", 4' in llvm_ir
     assert 'call void @"shader_ApplyGravity"(float' in llvm_ir
-    assert '%"struct.Lockstep_Arena" = type {[4 x float], [4 x float], float}' in llvm_ir
-    assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 0, i32 %"route_i32_lane0.1"' in llvm_ir
-    assert 'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 1, i32 %"route_i32_lane0.3"' in llvm_ir
+    assert (
+        '%"struct.Lockstep_Arena" = type {[4 x float], [4 x float], float}' in llvm_ir
+    )
+    assert (
+        'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 0, i32 %"route_i32_lane0.1"'
+        in llvm_ir
+    )
+    assert (
+        'getelementptr %"struct.Lockstep_Arena", %"struct.Lockstep_Arena"* %"arena", i32 0, i32 1, i32 %"route_i32_lane0.3"'
+        in llvm_ir
+    )
 
 
 def test_emit_llvm_ir_keeps_integer_arithmetic_in_integer_domain():
@@ -1123,9 +1147,7 @@ def test_emit_llvm_ir_promotes_mixed_numeric_operands_in_fused_vectors():
                         {"modifier": "out", "type": "double", "name": "out"},
                     ],
                     "body_ast": [
-                        AstAssignStmt(
-                            target=("out",), value=AstExprVar(path=("inp",))
-                        )
+                        AstAssignStmt(target=("out",), value=AstExprVar(path=("inp",)))
                     ],
                 },
             ],
@@ -1170,6 +1192,7 @@ def test_emit_llvm_ir_promotes_mixed_numeric_operands_in_fused_vectors():
     assert "uitofp <8 x i32>" in llvm_ir
     assert "fmul <8 x double>" in llvm_ir
     assert "fadd <8 x double>" in llvm_ir
+
 
 def test_emit_llvm_ir_lowers_select_builtin_for_integers():
     llvm_ir = emit_llvm_ir(
@@ -1254,7 +1277,12 @@ def test_emit_llvm_ir_lowers_select_builtin_for_structs():
         }
     )
 
-    assert 'i1 %"condition_val", %"struct.Pair" %"a_val", %"struct.Pair" %"b_val"' in llvm_ir
+    assert (
+        'i1 %"condition_val", %"struct.Pair" %"a_val", %"struct.Pair" %"b_val"'
+        in llvm_ir
+    )
+
+
 def test_emit_llvm_ir_defaults_target_triple_and_simd_width_for_fold_reduce():
     llvm_ir = emit_llvm_ir(
         {
@@ -1338,8 +1366,11 @@ def test_emit_llvm_ir_lowers_fold_routes_to_vector_reduce_intrinsics():
 
     assert 'call fast float @"llvm.vector.reduce.fadd.v8f32"' in llvm_ir
     assert '%"struct.Lockstep_Arena" = type {float, float}' in llvm_ir
-    assert '%"uniform_total_value_byte_ptr" = getelementptr i8, i8* %"uniform_total_arena_bytes", i32 4' in llvm_ir
-    assert 'i32 0, i32 0, i32 4' not in llvm_ir
+    assert (
+        '%"uniform_total_value_byte_ptr" = getelementptr i8, i8* %"uniform_total_arena_bytes", i32 4'
+        in llvm_ir
+    )
+    assert "i32 0, i32 0, i32 4" not in llvm_ir
 
 
 def test_emit_llvm_ir_strip_mines_fold_larger_than_target_width():
@@ -1407,8 +1438,7 @@ def test_emit_llvm_ir_strip_mines_large_fold_without_truncating_to_target_width(
     assert (
         '%"fold_chunk_ptr" = phi  <8 x float>* '
         '[%"fold_energy_chunk_ptr", %"entry"], '
-        '[%"fold_chunk_ptr_next", %"fold_energy_strip_body"]'
-        in llvm_ir
+        '[%"fold_chunk_ptr_next", %"fold_energy_strip_body"]' in llvm_ir
     )
     assert (
         '%"fold_energy_chunk" = load <8 x float>, <8 x float>* %"fold_chunk_ptr"'
@@ -1416,8 +1446,7 @@ def test_emit_llvm_ir_strip_mines_large_fold_without_truncating_to_target_width(
     )
     assert (
         '%"fold_chunk_ptr_next" = getelementptr <8 x float>, '
-        '<8 x float>* %"fold_chunk_ptr", i32 1'
-        in llvm_ir
+        '<8 x float>* %"fold_chunk_ptr", i32 1' in llvm_ir
     )
     assert '%"accum_energy_byte_index" = mul i32 %"fold_index", 4' not in llvm_ir
     assert '%"fold_elem_7" = add i32 %"fold_index", 7' not in llvm_ir
@@ -1450,26 +1479,19 @@ def test_compile_lockstep_strip_mines_fold_across_accumulator_route_width():
         in result.llvm_ir
     )
     assert 'br label %"fold_energy_strip_cond"' in result.llvm_ir
-    assert (
-        '%"fold_has_full_chunk" = icmp ult i32 %"fold_index", 16'
-        in result.llvm_ir
-    )
+    assert '%"fold_has_full_chunk" = icmp ult i32 %"fold_index", 16' in result.llvm_ir
     assert '%"fold_index_next" = add i32 %"fold_index", 8' in result.llvm_ir
     assert 'mul i32 %"idx", 4' in result.llvm_ir
-    assert 'mul i32 16, 4' in result.llvm_ir
+    assert "mul i32 16, 4" in result.llvm_ir
     assert (
         '%"fold_chunk_ptr_next" = getelementptr <8 x float>, '
-        '<8 x float>* %"fold_chunk_ptr", i32 1'
-        in result.llvm_ir
+        '<8 x float>* %"fold_chunk_ptr", i32 1' in result.llvm_ir
     )
+    assert '%"accum_energy_byte_index" = mul i32 %"fold_index", 4' not in result.llvm_ir
     assert (
-        '%"accum_energy_byte_index" = mul i32 %"fold_index", 4'
-        not in result.llvm_ir
+        '%"fold_avg" = fdiv float %"fold_reduce", 0x4031000000000000' in result.llvm_ir
     )
-    assert (
-        '%"fold_avg" = fdiv float %"fold_reduce", 0x4031000000000000'
-        in result.llvm_ir
-    )
+
 
 def test_emit_llvm_ir_honors_explicit_target_width_override():
     llvm_ir = emit_llvm_ir(
@@ -1754,7 +1776,9 @@ def test_emit_c_header_generates_structs_offsets_and_tick_signature():
 
 
 def test_emit_c_header_honors_target_width_override_macro():
-    header = emit_c_header({"streams": [], "accumulators": [], "uniforms": []}, target_width=16)
+    header = emit_c_header(
+        {"streams": [], "accumulators": [], "uniforms": []}, target_width=16
+    )
     assert "#define LOCKSTEP_SIMD_WIDTH 16" in header
 
 
@@ -2083,7 +2107,9 @@ def test_compile_lockstep_enforces_parse_timeout(monkeypatch):
         lambda: (StubLexer, StubParser, StubVisitor),
     )
     monotonic_values = iter([0.0, 0.002])
-    monkeypatch.setattr(compiler_module.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(
+        compiler_module.time, "monotonic", lambda: next(monotonic_values)
+    )
 
     with pytest.raises(lockstep_compiler.LockstepCompileError) as exc_info:
         lockstep_compiler.compile_lockstep(
@@ -2093,6 +2119,7 @@ def test_compile_lockstep_enforces_parse_timeout(monkeypatch):
 
     assert exc_info.value.phase == "parse"
     assert exc_info.value.errors[0].code == "LCK004"
+
 
 def test_codegen_uses_unsigned_ops_for_uint_math():
     source = """
@@ -2188,3 +2215,60 @@ def test_codegen_uses_unsigned_ops_for_uint_struct_fields():
     assert "udiv i32" in llvm_ir
     assert "urem i32" in llvm_ir
     assert "icmp ult i32" in llvm_ir
+
+
+def test_emit_llvm_ir_compacts_filter_outputs_with_return_predicate():
+    from lockstep_compiler.ast import (
+        AstKernelBindRoute,
+        AstKernelDecl,
+        AstKernelParam,
+        AstPipelineDecl,
+        AstStreamDecl,
+    )
+
+    program = AstProgram(
+        filters=(
+            AstKernelDecl(
+                name="KeepPositive",
+                params=(
+                    AstKernelParam(modifier="in", declared_type="float", name="src"),
+                    AstKernelParam(modifier="out", declared_type="float", name="dst"),
+                ),
+                body=(
+                    AstAssignStmt(target=("dst",), value=AstExprVar(path=("src",))),
+                    AstReturnStmt(
+                        value=AstExprBinary(
+                            op=">",
+                            left=AstExprVar(path=("src",)),
+                            right=AstExprLiteral(kind="float", value="0.0"),
+                        )
+                    ),
+                ),
+            ),
+        ),
+        pipelines=(
+            AstPipelineDecl(
+                name="Main",
+                streams=(
+                    AstStreamDecl(name="inp", declared_type="float", capacity="4"),
+                    AstStreamDecl(name="out", declared_type="float", capacity="4"),
+                ),
+                bind_routes=(
+                    AstKernelBindRoute(
+                        target="out",
+                        kernel="KeepPositive",
+                        args=("inp", "out"),
+                        route="out = KeepPositive(inp, out);",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    llvm_ir = emit_llvm_ir(program)
+
+    assert 'define i1 @"filter_KeepPositive"' in llvm_ir
+    assert '"KeepPositive_write_idx"' in llvm_ir
+    assert '"filter_write_select"' in llvm_ir
+    assert '"filter_KeepPositive_store"' in llvm_ir
+    assert '"filter_KeepPositive_skip"' in llvm_ir


### PR DESCRIPTION
### Motivation
- Filters were lowered as `void` functions so `return` predicates were discarded by codegen, causing compiled kernels to always produce one output per input and overwrite compacted slots.
- The compiled path needed to observe filter boolean predicates and compact outputs (advance write index only for kept rows) to match simulator semantics.

### Description
- Lower filters to boolean-returning LLVM functions by emitting `filter_*` as `i1` functions and treating their return type as `bool` in the lowerer (`emit_llvm_ir` and `_FunctionLowerer`).
- Make `_FunctionLowerer` default fall-through return for `i1` functions to `1` so filters that reach end-of-body without `return` keep the row.
- Capture filter call results and implement conditional commit of `copy_out_slots`: write outputs into temporaries and emit conditional blocks to `store` them only when the keep predicate is true, returning the predicate from `_emit_kernel_call`.
- Add a per-filter `write_index` and update loop lowering so the write index advances only for kept rows, and avoid vector-fusing groups that include filters to preserve compaction semantics.
- Update tests to expect `i1` filter declarations and add `test_emit_llvm_ir_compacts_filter_outputs_with_return_predicate` to cover write-index and conditional-store codegen.

### Testing
- Ran `pytest -q tests/test_compiler_api.py::test_emit_llvm_ir_compacts_filter_outputs_with_return_predicate tests/test_compiler_api.py::test_emit_llvm_ir_generates_expected_declarations tests/test_simulator.py::test_simulate_pipeline_entities_executes_filter_return_predicate_and_struct_fields` and all selected tests passed.
- Ran `pytest -q tests/test_optimizer.py tests/test_compiler_api.py tests/test_simulator.py` and the suite passed.
- Attempted full `pytest -q` but collection was blocked by a missing environment dependency (`hypothesis`), so full test collection did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f090883988328b0c236f85dca7fab)