### PR TITLE
Bound default dependency file limit to 128

### DIFF
--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -34,6 +34,7 @@ DEFAULT_SOURCE_FILE = "<stdin>"
 DEFAULT_MAX_SOURCE_BYTES = 1_048_576
 DEFAULT_PARSE_TIMEOUT_MS = 2_000
 DEFAULT_MAX_EXPRESSION_NESTING = 128
+DEFAULT_MAX_DEPENDENCY_FILES = 128
 DEFAULT_INVALID_FRONTEND_LIMIT_CODE = "LCK006"
 DEFAULT_DEPENDENCY_ROOT_VIOLATION_CODE = "LCK007"
 _DEPENDENCY_DECL_PATTERN = re.compile(
@@ -47,7 +48,7 @@ class FrontendLimits:
     max_source_bytes: int | None = DEFAULT_MAX_SOURCE_BYTES
     parse_timeout_ms: int | None = DEFAULT_PARSE_TIMEOUT_MS
     max_expression_nesting: int | None = DEFAULT_MAX_EXPRESSION_NESTING
-    max_dependency_files: int | None = DEFAULT_MAX_SOURCE_BYTES
+    max_dependency_files: int | None = DEFAULT_MAX_DEPENDENCY_FILES
     max_dependency_total_bytes: int | None = DEFAULT_MAX_SOURCE_BYTES
     max_dependency_depth: int | None = DEFAULT_MAX_EXPRESSION_NESTING
 

--- a/tests/test_improvements.py
+++ b/tests/test_improvements.py
@@ -367,6 +367,10 @@ def test_compile_lockstep_rejects_negative_frontend_limits(limit_name, value):
     assert limit_name in exc_info.value.errors[0].message
 
 
+def test_frontend_limits_default_dependency_file_limit_is_bounded():
+    assert FrontendLimits().max_dependency_files == 128
+
+
 def test_compile_lockstep_zero_disables_source_size_limit():
     compile_lockstep(
         _LIMIT_SOURCE,


### PR DESCRIPTION
### Motivation
- The `FrontendLimits.max_dependency_files` default was mistakenly set to `DEFAULT_MAX_SOURCE_BYTES` (1,048,576), making the file-count limit effectively inert and far larger than intended; the change bounds that default to a reasonable fixed value in the 64–256 range.

### Description
- Add a dedicated `DEFAULT_MAX_DEPENDENCY_FILES = 128` constant and use it as the default for `FrontendLimits.max_dependency_files` in `lockstep_compiler/compiler.py`.
- Add a regression test `test_frontend_limits_default_dependency_file_limit_is_bounded` in `tests/test_improvements.py` that asserts `FrontendLimits().max_dependency_files == 128`.

### Testing
- Ran the targeted tests `pytest tests/test_improvements.py::test_frontend_limits_default_dependency_file_limit_is_bounded tests/test_type_syntax.py::test_dependency_file_count_limit_is_enforced` and they passed (`2 passed`).
- Running a larger subset `pytest tests/test_improvements.py tests/test_type_syntax.py::test_dependency_file_count_limit_is_enforced` exposed unrelated failures in hover/type-analysis (4 failed, 40 passed) which are not caused by the dependency-limit default change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f0949c96883288d080402f65e4494)