### PR TITLE
Simplify CLI compiler invocation

### DIFF
--- a/lockstep_compiler/cli.py
+++ b/lockstep_compiler/cli.py
@@ -1,5 +1,4 @@
 import argparse
-import inspect
 import json
 import sys
 import traceback
@@ -260,98 +259,31 @@ def run_cli(
         )
         return 1
 
-    supports_verbose = False
-    supports_library_sources = False
-    supports_source_file = False
-    supports_library_source_files = False
-    supports_frontend_limits = False
-    supports_target_width = False
-    supports_dependency_root = False
-    supports_unsafe_allow_external_dependencies = False
-    try:
-        signature = inspect.signature(compiler)
-    except (TypeError, ValueError):
-        signature = None
+    from .compiler import FrontendLimits
 
-    if signature is not None:
-        supports_verbose = any(
-            parameter.kind is inspect.Parameter.VAR_KEYWORD
-            or parameter.name == "verbose"
-            for parameter in signature.parameters.values()
-        )
-        supports_library_sources = any(
-            parameter.kind is inspect.Parameter.VAR_KEYWORD
-            or parameter.name == "library_sources"
-            for parameter in signature.parameters.values()
-        )
-        supports_source_file = any(
-            parameter.kind is inspect.Parameter.VAR_KEYWORD
-            or parameter.name == "source_file"
-            for parameter in signature.parameters.values()
-        )
-        supports_library_source_files = any(
-            parameter.kind is inspect.Parameter.VAR_KEYWORD
-            or parameter.name == "library_source_files"
-            for parameter in signature.parameters.values()
-        )
-        supports_frontend_limits = any(
-            parameter.kind is inspect.Parameter.VAR_KEYWORD
-            or parameter.name == "frontend_limits"
-            for parameter in signature.parameters.values()
-        )
-        supports_target_width = any(
-            parameter.kind is inspect.Parameter.VAR_KEYWORD
-            or parameter.name == "target_width"
-            for parameter in signature.parameters.values()
-        )
-        supports_dependency_root = any(
-            parameter.kind is inspect.Parameter.VAR_KEYWORD
-            or parameter.name == "dependency_root"
-            for parameter in signature.parameters.values()
-        )
-        supports_unsafe_allow_external_dependencies = any(
-            parameter.kind is inspect.Parameter.VAR_KEYWORD
-            or parameter.name == "unsafe_allow_external_dependencies"
-            for parameter in signature.parameters.values()
-        )
-
-    compile_kwargs: dict[str, Any] = {}
-    if supports_verbose:
-        compile_kwargs["verbose"] = False
-    if supports_library_sources:
-        compile_kwargs["library_sources"] = library_sources
-    if supports_source_file:
-        compile_kwargs["source_file"] = str(source_path) if args.path else "<stdin>"
-    if supports_library_source_files:
-        compile_kwargs["library_source_files"] = library_source_files
-    if supports_frontend_limits:
-        from .compiler import FrontendLimits
-
-        compile_kwargs["frontend_limits"] = FrontendLimits(
-            max_source_bytes=args.max_source_bytes,
-            parse_timeout_ms=args.parse_timeout_ms,
-            max_expression_nesting=args.max_expr_nesting,
-            max_dependency_files=args.max_dependency_files,
-            max_dependency_total_bytes=args.max_dependency_total_bytes,
-            max_dependency_depth=args.max_dependency_depth,
-        )
-    if supports_target_width:
-        compile_kwargs["target_width"] = args.target_width
-    if supports_dependency_root:
-        dependency_root: Path | None = None
-        if args.path and not args.unsafe_allow_external_dependencies:
-            dependency_root = source_path.resolve().parent
-        compile_kwargs["dependency_root"] = dependency_root
-    if supports_unsafe_allow_external_dependencies:
-        compile_kwargs["unsafe_allow_external_dependencies"] = (
-            args.unsafe_allow_external_dependencies
-        )
+    dependency_root: Path | None = None
+    if args.path and not args.unsafe_allow_external_dependencies:
+        dependency_root = source_path.resolve().parent
 
     try:
-        if compile_kwargs:
-            result = compiler(source, **compile_kwargs)
-        else:
-            result = compiler(source)
+        result = compiler(
+            source,
+            verbose=False,
+            library_sources=library_sources,
+            source_file=str(source_path) if args.path else "<stdin>",
+            library_source_files=library_source_files,
+            frontend_limits=FrontendLimits(
+                max_source_bytes=args.max_source_bytes,
+                parse_timeout_ms=args.parse_timeout_ms,
+                max_expression_nesting=args.max_expr_nesting,
+                max_dependency_files=args.max_dependency_files,
+                max_dependency_total_bytes=args.max_dependency_total_bytes,
+                max_dependency_depth=args.max_dependency_depth,
+            ),
+            target_width=args.target_width,
+            dependency_root=dependency_root,
+            unsafe_allow_external_dependencies=args.unsafe_allow_external_dependencies,
+        )
     except LockstepCompileError as err:
         count = len(err.errors)
         suffix = "" if count == 1 else "s"

--- a/tests/test_cli_format.py
+++ b/tests/test_cli_format.py
@@ -6,7 +6,7 @@ from lockstep_compiler.cli import run_cli
 def test_run_cli_format_outputs_formatted_source_without_compiling():
     called = {"compiler": False}
 
-    def fake_compiler(_source):
+    def fake_compiler(_source, **_kwargs):
         called["compiler"] = True
 
     stdout = io.StringIO()

--- a/tests/test_cli_libraries.py
+++ b/tests/test_cli_libraries.py
@@ -15,7 +15,7 @@ def test_run_cli_passes_library_sources_to_compiler(tmp_path):
 
     captured = {}
 
-    def fake_compiler(source, *, verbose=False, library_sources=None):
+    def fake_compiler(source, *, verbose=False, library_sources=None, **_kwargs):
         captured["source"] = source
         captured["verbose"] = verbose
         captured["library_sources"] = library_sources
@@ -50,7 +50,7 @@ def test_run_cli_reports_missing_library_file(tmp_path):
         stdin=io.StringIO("pipeline Main { bind { } }"),
         stdout=io.StringIO(),
         stderr=stderr,
-        compiler=lambda source: source,
+        compiler=lambda source, **_kwargs: source,
     )
 
     assert exit_code == 1
@@ -92,7 +92,7 @@ def test_run_cli_reports_stdin_file_in_diagnostics(tmp_path):
 def test_run_cli_passes_frontend_limits_to_compiler():
     captured = {}
 
-    def fake_compiler(source, *, frontend_limits=None):
+    def fake_compiler(source, *, frontend_limits=None, **_kwargs):
         captured["source"] = source
         captured["frontend_limits"] = frontend_limits
         return {
@@ -130,6 +130,9 @@ def test_run_cli_passes_frontend_limits_to_compiler():
     assert captured["frontend_limits"].max_source_bytes == 64
     assert captured["frontend_limits"].parse_timeout_ms == 50
     assert captured["frontend_limits"].max_expression_nesting == 16
+    assert captured["frontend_limits"].max_dependency_files == 4
+    assert captured["frontend_limits"].max_dependency_total_bytes == 512
+    assert captured["frontend_limits"].max_dependency_depth == 2
 
 
 def test_run_cli_defaults_dependency_root_to_source_directory(tmp_path):
@@ -137,7 +140,7 @@ def test_run_cli_defaults_dependency_root_to_source_directory(tmp_path):
     source_path.write_text("pipeline Main { bind { } }", encoding="utf-8")
     captured = {}
 
-    def fake_compiler(source, *, dependency_root=None):
+    def fake_compiler(source, *, dependency_root=None, **_kwargs):
         captured["dependency_root"] = dependency_root
         return {"streams": [], "accumulators": [], "uniforms": [], "shaders": [], "filters": [], "bind_routes": []}
 
@@ -151,8 +154,15 @@ def test_run_cli_can_disable_dependency_root_with_unsafe_flag(tmp_path):
     source_path.write_text("pipeline Main { bind { } }", encoding="utf-8")
     captured = {}
 
-    def fake_compiler(source, *, dependency_root=None):
+    def fake_compiler(
+        source,
+        *,
+        dependency_root=None,
+        unsafe_allow_external_dependencies=False,
+        **_kwargs,
+    ):
         captured["dependency_root"] = dependency_root
+        captured["unsafe_allow_external_dependencies"] = unsafe_allow_external_dependencies
         return {"streams": [], "accumulators": [], "uniforms": [], "shaders": [], "filters": [], "bind_routes": []}
 
     exit_code = run_cli(
@@ -162,6 +172,4 @@ def test_run_cli_can_disable_dependency_root_with_unsafe_flag(tmp_path):
     )
     assert exit_code == 0
     assert captured["dependency_root"] is None
-    assert captured["frontend_limits"].max_dependency_files == 4
-    assert captured["frontend_limits"].max_dependency_total_bytes == 512
-    assert captured["frontend_limits"].max_dependency_depth == 2
+    assert captured["unsafe_allow_external_dependencies"] is True

--- a/tests/test_lockstep_compiler_api.py
+++ b/tests/test_lockstep_compiler_api.py
@@ -470,7 +470,7 @@ def test_module_main_error_path_exits_with_stderr(monkeypatch, capsys):
 def test_run_cli_reads_source_from_stdin_when_path_omitted():
     captured = {}
 
-    def fake_compiler(source):
+    def fake_compiler(source, **_kwargs):
         captured["source"] = source
 
     exit_code = run_cli(
@@ -488,7 +488,7 @@ def test_run_cli_reads_source_from_path(tmp_path):
     source_file.write_text("pipeline FromFile { }", encoding="utf-8")
     captured = {}
 
-    def fake_compiler(source):
+    def fake_compiler(source, **_kwargs):
         captured["source"] = source
 
     exit_code = run_cli(
@@ -500,7 +500,7 @@ def test_run_cli_reads_source_from_path(tmp_path):
 
 
 def test_run_cli_dump_prints_compiled_entities():
-    def fake_compiler(_source):
+    def fake_compiler(_source, **_kwargs):
         return LockstepCompileResult(
             parse_tree=None,
             entities={
@@ -535,7 +535,7 @@ def test_run_cli_dump_prints_compiled_entities():
 
 
 def test_run_cli_dump_falls_back_to_compiler_result():
-    def fake_compiler(_source):
+    def fake_compiler(_source, **_kwargs):
         return {"nodes": ["a", "b"]}
 
     stdout = io.StringIO()
@@ -558,7 +558,7 @@ def test_run_cli_dump_falls_back_to_compiler_result():
 
 
 def test_run_cli_returns_non_zero_and_writes_errors():
-    def failing_compiler(_source):
+    def failing_compiler(_source, **_kwargs):
         raise LockstepCompileError(
             [
                 LockstepDiagnostic(
@@ -588,7 +588,7 @@ def test_run_cli_returns_non_zero_and_writes_errors():
 
 
 def test_run_cli_internal_error_default_mode_keeps_generic_message():
-    def failing_compiler(_source):
+    def failing_compiler(_source, **_kwargs):
         raise RuntimeError("kaboom")
 
     stderr = io.StringIO()
@@ -606,7 +606,7 @@ def test_run_cli_internal_error_default_mode_keeps_generic_message():
 
 
 def test_run_cli_debug_mode_emits_exception_details_and_traceback():
-    def failing_compiler(_source):
+    def failing_compiler(_source, **_kwargs):
         raise LockstepCompileError(
             [
                 LockstepDiagnostic(
@@ -653,7 +653,7 @@ def test_run_cli_returns_non_zero_for_missing_path(tmp_path):
     stderr = io.StringIO()
     called = {"compiler": False}
 
-    def fake_compiler(_source):
+    def fake_compiler(_source, **_kwargs):
         called["compiler"] = True
 
     exit_code = run_cli(
@@ -671,7 +671,7 @@ def test_run_cli_returns_non_zero_for_unreadable_path(monkeypatch):
     stderr = io.StringIO()
     called = {"compiler": False}
 
-    def fake_compiler(_source):
+    def fake_compiler(_source, **_kwargs):
         called["compiler"] = True
 
     def raise_permission_error(_self, encoding):
@@ -696,7 +696,7 @@ def test_run_cli_returns_non_zero_for_invalid_utf8(tmp_path):
     stderr = io.StringIO()
     called = {"compiler": False}
 
-    def fake_compiler(_source):
+    def fake_compiler(_source, **_kwargs):
         called["compiler"] = True
 
     exit_code = run_cli(
@@ -713,7 +713,7 @@ def test_run_cli_returns_non_zero_for_invalid_utf8(tmp_path):
 def test_run_cli_uses_default_compiler_when_compiler_missing(monkeypatch):
     captured = {}
 
-    def fake_compiler(source, *, verbose=True):
+    def fake_compiler(source, *, verbose=True, **_kwargs):
         captured["source"] = source
         captured["verbose"] = verbose
 
@@ -734,11 +734,14 @@ def test_run_cli_uses_default_compiler_when_compiler_missing(monkeypatch):
     }
 
 
-def test_run_cli_preserves_injected_compiler_without_verbose_parameter():
+def test_run_cli_passes_standard_options_to_injected_compiler():
     captured = {}
 
-    def fake_compiler(source):
+    def fake_compiler(source, **kwargs):
         captured["source"] = source
+        captured["verbose"] = kwargs["verbose"]
+        captured["source_file"] = kwargs["source_file"]
+        captured["target_width"] = kwargs["target_width"]
 
     exit_code = run_cli(
         [],
@@ -747,13 +750,18 @@ def test_run_cli_preserves_injected_compiler_without_verbose_parameter():
     )
 
     assert exit_code == 0
-    assert captured == {"source": "pipeline CustomCompiler { }"}
+    assert captured == {
+        "source": "pipeline CustomCompiler { }",
+        "verbose": False,
+        "source_file": "<stdin>",
+        "target_width": 8,
+    }
 
 
 def test_run_cli_default_execution_suppresses_verbose_visitor_logs(monkeypatch):
     stderr = io.StringIO()
 
-    def fake_compiler(_source, *, verbose=True):
+    def fake_compiler(_source, *, verbose=True, **_kwargs):
         if verbose:
             print("Visiting node: pipeline", file=stderr)
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -515,7 +515,7 @@ def test_simulate_pipeline_entities_executes_filter_return_predicate_and_struct_
 
 
 def test_run_cli_simulate_prints_json_for_compiler_result():
-    def fake_compiler(_source):
+    def fake_compiler(_source, **_kwargs):
         return {
             "streams": [{"name": "s", "type": "int", "capacity": "4"}],
             "accumulators": [],
@@ -542,7 +542,7 @@ def test_run_cli_simulate_reads_input_file(tmp_path):
     input_file = tmp_path / "sim-input.json"
     input_file.write_text('{"streams": {"s": [1, 2, 3]}}', encoding="utf-8")
 
-    def fake_compiler(_source):
+    def fake_compiler(_source, **_kwargs):
         return {
             "streams": [{"name": "s", "type": "int", "capacity": "4"}],
             "accumulators": [],
@@ -575,7 +575,7 @@ def test_run_cli_rejects_simulate_input_without_simulate(tmp_path):
         stdin=io.StringIO("pipeline P { }"),
         stdout=io.StringIO(),
         stderr=stderr,
-        compiler=lambda _source: {},
+        compiler=lambda _source, **_kwargs: {},
     )
 
     assert exit_code == 2
@@ -586,7 +586,7 @@ def test_run_cli_report_accepts_simulate_input_file(tmp_path):
     input_file = tmp_path / "sim-input.json"
     input_file.write_text('{"streams": {"s": [10, 20]}}', encoding="utf-8")
 
-    def fake_compiler(_source):
+    def fake_compiler(_source, **_kwargs):
         return {
             "streams": [{"name": "s", "type": "int", "capacity": "4"}],
             "accumulators": [],
@@ -610,7 +610,7 @@ def test_run_cli_report_accepts_simulate_input_file(tmp_path):
 
 
 def test_run_cli_report_prints_single_json_payload_with_entities_and_simulation():
-    def fake_compiler(_source):
+    def fake_compiler(_source, **_kwargs):
         return {
             "streams": [{"name": "s", "type": "int", "capacity": "4"}],
             "accumulators": [],
@@ -644,7 +644,7 @@ def test_run_cli_rejects_combined_dump_and_simulate_modes():
             stdin=io.StringIO("pipeline P { }"),
             stdout=io.StringIO(),
             stderr=io.StringIO(),
-            compiler=lambda source: source,
+            compiler=lambda source, **_kwargs: source,
         )
     except SystemExit as err:
         assert err.code == 2
@@ -725,7 +725,7 @@ def test_run_cli_simulate_reports_invalid_simulation_shape(tmp_path):
     input_file = tmp_path / "sim-input.json"
     input_file.write_text('{"streams": {"s": 1}}', encoding="utf-8")
 
-    def fake_compiler(_source):
+    def fake_compiler(_source, **_kwargs):
         return {
             "streams": [{"name": "s", "type": "int", "capacity": "4"}],
             "accumulators": [],


### PR DESCRIPTION
### Motivation
- The CLI was performing runtime feature-detection of an injected compiler via `inspect.signature` to support many optional kwargs, which increases maintenance surface for an in-repo compiler that owns both sides. 
- For the in-repo compiler we always control the API, so calling it directly with the standard keyword arguments simplifies the CLI and clarifies the contract.

### Description
- Remove `inspect.signature`-based detection and always invoke the compiler with the full standard keyword set including `verbose`, `library_sources`, `source_file`, `library_source_files`, `frontend_limits`, `target_width`, `dependency_root`, and `unsafe_allow_external_dependencies` (`lockstep_compiler/cli.py`).
- Add an explicit `dependency_root` calculation and pass `FrontendLimits` directly when invoking the compiler (`lockstep_compiler/cli.py`).
- Update test doubles and unit tests to accept the direct-call contract by adding `**_kwargs` or explicit parameters where appropriate, and change assertions to validate the CLI now passes the standard options (`tests/test_lockstep_compiler_api.py`, `tests/test_cli_libraries.py`, `tests/test_simulator.py`, `tests/test_cli_format.py`).
- Adjust tests to verify `unsafe_allow_external_dependencies` behavior and that frontend dependency limit fields are present on the passed `frontend_limits` object where relevant (`tests/test_cli_libraries.py`).

### Testing
- Ran the focused test subset with `pytest -q tests/test_lockstep_compiler_api.py tests/test_cli_libraries.py tests/test_cli_format.py tests/test_simulator.py`, which completed successfully after test updates. 
- Verified Python compilation of modified files with `python3 -m py_compile lockstep_compiler/cli.py tests/...`, which succeeded. 
- Ran `git diff --check` (local check) which reported no issues. 
- Full `pytest -q` collection was attempted but is blocked in this environment because the `hypothesis` test dependency is not installed, so the full suite could not be collected here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f09598628832894a1425153f8adb5)