### PR TITLE
Fix LSP crash when indexing struct field types

### DIFF
--- a/lockstep_compiler/type_analysis.py
+++ b/lockstep_compiler/type_analysis.py
@@ -117,11 +117,22 @@ def validate_type_name(
 
 
 def build_struct_field_type_index(
-    structs: dict[str, dict[str, SemanticStructField]],
+    structs: dict[str, dict[str, SemanticStructField | str]],
 ) -> dict[str, dict[str, str]]:
+    """Normalize per-struct field maps to plain ``field_name -> type`` strings.
+
+    Callers pass either :class:`SemanticStructField` values (from the semantic
+    validator) or already-resolved type strings (from LSP entity extraction), so
+    both shapes are accepted and reduced to type-name strings.
+    """
     return {
         struct_name: {
-            field_name: field.declared_type for field_name, field in fields.items()
+            field_name: (
+                field.declared_type
+                if isinstance(field, SemanticStructField)
+                else field
+            )
+            for field_name, field in fields.items()
         }
         for struct_name, fields in structs.items()
     }

--- a/tests/test_type_analysis_shared.py
+++ b/tests/test_type_analysis_shared.py
@@ -1,6 +1,21 @@
 from lockstep_compiler import compile_lockstep
 from lockstep_compiler.lsp import build_analysis_context, provide_hover_info
-from lockstep_compiler.type_analysis import parse_type_name, validate_type_name
+from lockstep_compiler.models import SemanticStructField
+from lockstep_compiler.type_analysis import (
+    build_struct_field_type_index,
+    parse_type_name,
+    validate_type_name,
+)
+
+
+def test_build_struct_field_type_index_accepts_strings_and_field_objects():
+    from_strings = build_struct_field_type_index({"Vec": {"x": "float"}})
+    from_fields = build_struct_field_type_index(
+        {"Vec": {"x": SemanticStructField(name="x", declared_type="float")}}
+    )
+
+    assert from_strings == {"Vec": {"x": "float"}}
+    assert from_fields == {"Vec": {"x": "float"}}
 
 
 def test_parse_and_validate_type_name_shared_helpers():


### PR DESCRIPTION
## Problem

`build_struct_field_type_index` in `lockstep_compiler/type_analysis.py` accessed `field.declared_type` on every field value. Its only caller, `_build_struct_field_type_index_from_entities` in `lsp.py`, builds its struct map from extracted entities where each field value is already a plain **type-name string**, not a `SemanticStructField` object.

The result was an `AttributeError: 'str' object has no attribute 'declared_type'` that fired on every LSP analysis path routed through `build_analysis_context`:

- `textDocument/hover`
- go-to-definition for struct members
- bind-route / kernel completion

This was reproducible via the repo's own (failing) tests in `test_lsp.py`, `test_improvements.py`, `test_lsp_cache.py`, and `test_type_analysis_shared.py`.

## Fix

Accept both shapes — `SemanticStructField` values (from the semantic validator) and plain type strings (from LSP entity extraction) — and reduce either to type-name strings. Added a direct regression test covering both input shapes.

## Verification

```
python -m pytest tests/test_lsp.py tests/test_improvements.py tests/test_lsp_cache.py tests/test_type_analysis_shared.py
```
all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYneka66BR2Ue7d4jb1xoC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYneka66BR2Ue7d4jb1xoC)_