### PR TITLE
Fix formatter crash on import/include declarations

### DIFF
--- a/lockstep_compiler/formatter.py
+++ b/lockstep_compiler/formatter.py
@@ -145,6 +145,15 @@ class _FormattingVisitor(LockstepVisitor):
         return self.visitChildren(ctx)
 
     def visitDependencyDecl(self, ctx: LockstepParser.DependencyDeclContext):
+        return self.visitChildren(ctx)
+
+    def visitImportDecl(self, ctx: LockstepParser.ImportDeclContext):
+        self._append_dependency(ctx)
+
+    def visitIncludeDecl(self, ctx: LockstepParser.IncludeDeclContext):
+        self._append_dependency(ctx)
+
+    def _append_dependency(self, ctx):
         keyword = ctx.getChild(0).getText()
         path = ctx.STRING().getText()
         self._append(f"{keyword} {path};")


### PR DESCRIPTION
## Problem

The grammar defines `dependencyDecl : importDecl | includeDecl`, and only `importDecl`/`includeDecl` expose a `STRING` token — a `DependencyDeclContext` does not. The formatter's `visitDependencyDecl` still called `ctx.STRING()`, so:

```
lockstepc <file> --format
```

crashed with `AttributeError: 'DependencyDeclContext' object has no attribute 'STRING'` on any source containing an `import` or `#include` directive. The documented `--format` feature was unusable for programs with dependencies.

## Fix

`visitDependencyDecl` now recurses into the wrapped `importDecl`/`includeDecl` rule, and dedicated `visitImportDecl`/`visitIncludeDecl` methods read the keyword and `STRING` literal from the correct context.

## Verification

```
python -m pytest tests/test_formatter.py
```
passes (including the previously-failing `test_format_lockstep_source_formats_dependencies_and_composite_types`), and `lockstepc <file> --format` now formats `import`/`#include` directives correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYneka66BR2Ue7d4jb1xoC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYneka66BR2Ue7d4jb1xoC)_