### PR TITLE
Fix compiler crash on raw backslashes in string literals

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -33,6 +33,7 @@ from .ast import (
 )
 from .arena_layout import build_ast_arena_layout
 from .optimizer import _parse_bind_route, optimize_bind_routes
+from .utils import decode_escape_sequences
 from .utils import sanitize_symbol as _sanitize_symbol
 
 _PRIMITIVE_TYPE_MAP: dict[str, ir.Type] = {
@@ -409,7 +410,7 @@ class _FunctionLowerer:
     def _decode_string_literal(token_text: str) -> str:
         if len(token_text) >= 2 and token_text[0] == '"' and token_text[-1] == '"':
             token_text = token_text[1:-1]
-        return bytes(token_text, "utf-8").decode("unicode_escape")
+        return decode_escape_sequences(token_text)
 
     def _lower_string_literal(self, token_text: str) -> ir.Value:
         decoded = self._decode_string_literal(token_text)

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -28,6 +28,7 @@ from .models import (
 )
 from .optimizer import optimize_bind_routes
 from .prelude import load_intrinsics
+from .utils import decode_escape_sequences
 from .visitors import validate_semantics as _validate_semantics
 
 DEFAULT_SOURCE_FILE = "<stdin>"
@@ -349,15 +350,7 @@ def _build_combined_source(
 
 
 def _decode_dependency_path(path_literal: str) -> str:
-    try:
-        return bytes(path_literal, "utf-8").decode("unicode_escape")
-    except UnicodeDecodeError:
-        # Path literals that contain raw backslashes (for example, absolute
-        # Windows paths such as ``C:\\Users\\...``) are not valid
-        # ``unicode_escape`` sequences. Fall back to the literal text so the
-        # dependency resolver can still validate and reject it instead of the
-        # compiler crashing with an uncaught decode error.
-        return path_literal
+    return decode_escape_sequences(path_literal)
 
 
 def _dependency_parse_error(

--- a/lockstep_compiler/utils.py
+++ b/lockstep_compiler/utils.py
@@ -1,3 +1,22 @@
 def sanitize_symbol(name: str) -> str:
     """Replace non-alphanumeric, non-underscore characters with underscores."""
     return "".join(ch if (ch.isalnum() or ch == "_") else "_" for ch in name)
+
+
+def decode_escape_sequences(literal: str) -> str:
+    """Decode C-style escape sequences in a string or path literal.
+
+    Uses Python's ``unicode_escape`` codec, which understands the common
+    escapes the grammar allows (``\\n``, ``\\t``, ``\\"``, ``\\\\`` and so on).
+
+    Literals that contain raw backslashes which do not form a valid escape
+    sequence -- most commonly absolute Windows paths such as ``C:\\Users\\...``
+    -- are not valid ``unicode_escape`` input and would otherwise raise
+    ``UnicodeDecodeError``. In that case the literal text is returned unchanged
+    so callers keep processing (and can validate or reject the value) instead of
+    the compiler crashing with an uncaught decode error.
+    """
+    try:
+        return bytes(literal, "utf-8").decode("unicode_escape")
+    except UnicodeDecodeError:
+        return literal

--- a/tests/test_escape_decoding.py
+++ b/tests/test_escape_decoding.py
@@ -1,0 +1,31 @@
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from lockstep_compiler.codegen import _FunctionLowerer
+from lockstep_compiler.utils import decode_escape_sequences
+
+
+def test_decode_escape_sequences_decodes_valid_escapes():
+    assert decode_escape_sequences(r"line\nbreak") == "line\nbreak"
+    assert decode_escape_sequences(r"tab\tafter") == "tab\tafter"
+    assert decode_escape_sequences(r"back\\slash") == "back\\slash"
+
+
+def test_decode_escape_sequences_tolerates_raw_backslashes():
+    # Raw Windows paths contain backslash sequences (``\U``, ``\A``) that are not
+    # valid ``unicode_escape`` input; decoding must not raise.
+    windows_path = r"C:\Users\runner\AppData\outside.lock"
+    assert decode_escape_sequences(windows_path) == windows_path
+    assert decode_escape_sequences(r"\U0") == r"\U0"
+
+
+def test_string_literal_lowering_tolerates_raw_backslashes():
+    # A source string literal such as ``"C:\Users"`` previously crashed codegen
+    # with an uncaught UnicodeDecodeError. The quotes are stripped and the raw
+    # text is returned instead of raising.
+    assert _FunctionLowerer._decode_string_literal(r'"C:\Users"') == r"C:\Users"
+    assert _FunctionLowerer._decode_string_literal(r'"ok\ttab"') == "ok\ttab"


### PR DESCRIPTION
## Summary
`_FunctionLowerer._decode_string_literal` decoded string-literal escape sequences with `bytes(...).decode("unicode_escape")`, which raises an uncaught `UnicodeDecodeError` on raw backslashes that do not form a valid escape sequence — for example a source string literal `"C:\Users"` or `"\U0"`. This is the same class of bug as the dependency-path crash fixed in #281, in the parallel code path.

## Changes
- Extract the tolerant decoder into a shared `decode_escape_sequences` helper in `lockstep_compiler/utils.py`. Valid escapes (`\n`, `\t`, `\\`, `\"`, …) still decode; input that isn't a valid `unicode_escape` sequence falls through as literal text instead of crashing.
- Use the helper from both `codegen._decode_string_literal` and `compiler._decode_dependency_path`, removing the duplicated try/except.
- Add `tests/test_escape_decoding.py` covering the shared helper, the codegen string-literal path, and valid-escape decoding.

## Verification
- New tests pass; full suite: 239 passed, 4 skipped.
- `python -m compileall lockstep_compiler tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012f32MBWEnDXEd7gAwNMdqd)_