### PR TITLE
Bump GitHub Actions to Node 24 releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,10 @@ jobs:
         timeout-minutes: 15
         steps:
           - name: Checkout
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
 
           - name: Setup Python
-            uses: actions/setup-python@v5
+            uses: actions/setup-python@v6
             with:
               python-version: "3.12"
 
@@ -49,10 +49,10 @@ jobs:
         timeout-minutes: 15
         steps:
           - name: Checkout
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
 
           - name: Setup Python
-            uses: actions/setup-python@v5
+            uses: actions/setup-python@v6
             with:
               python-version: "3.12"
 
@@ -67,10 +67,10 @@ jobs:
         timeout-minutes: 15
         steps:
           - name: Checkout
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
 
           - name: Setup Python
-            uses: actions/setup-python@v5
+            uses: actions/setup-python@v6
             with:
               python-version: "3.12"
 
@@ -84,10 +84,10 @@ jobs:
         timeout-minutes: 15
         steps:
           - name: Checkout
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
 
           - name: Setup Python
-            uses: actions/setup-python@v5
+            uses: actions/setup-python@v6
             with:
               python-version: "3.12"
               cache: "pip"
@@ -113,10 +113,10 @@ jobs:
             
         steps:
           - name: Checkout
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
 
           - name: Setup Python
-            uses: actions/setup-python@v5
+            uses: actions/setup-python@v6
             with:
               python-version: ${{ matrix.python-version }}
               cache: "pip"
@@ -132,7 +132,7 @@ jobs:
 
           - name: Upload coverage artifacts
             if: always()
-            uses: actions/upload-artifact@v4
+            uses: actions/upload-artifact@v6
             with:
                 name: reports-${{ matrix.os }}-py${{ matrix.python-version }}
                 path: |
@@ -148,10 +148,10 @@ jobs:
         timeout-minutes: 20
         steps:
           - name: Checkout
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
 
           - name: Setup Python
-            uses: actions/setup-python@v5
+            uses: actions/setup-python@v6
             with:
               python-version: "3.12"
               cache: "pip"
@@ -167,7 +167,7 @@ jobs:
 
           - name: Upload benchmark JSON
             if: always()
-            uses: actions/upload-artifact@v4
+            uses: actions/upload-artifact@v6
             with:
                 name: benchmark-results-pr-${{ github.run_id }}
                 path: benchmark-results.json


### PR DESCRIPTION
## Summary
Every CI run logs `Node.js 20 is deprecated … forced to run on Node.js 24` because the pinned action majors still bundle the Node 20 runtime. Node 20 is scheduled for removal from the runners on 2026-09-16, so these will hard-fail after that date.

## Changes
Bump to the first majors that ship the Node 24 runtime:
- `actions/checkout` v4 → v5
- `actions/setup-python` v5 → v6
- `actions/upload-artifact` v4 → v6

GitHub-hosted runners (`ubuntu-latest`, `macos-latest`, `windows-latest`) already meet the runner version these require, and the inputs used here (`python-version`, `cache`, `name`, `path`, `if-no-files-found`) are unchanged across these majors.

## Sources
- [actions/checkout Node 24 PR](https://github.com/actions/checkout/pull/2226)
- [setup-python v6 / Node 24 discussion](https://github.com/pypa/cibuildwheel/discussions/2829)
- [upload-artifact releases (v6 → Node 24)](https://github.com/actions/upload-artifact/releases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012f32MBWEnDXEd7gAwNMdqd)_