### PR TITLE
Size fold accumulators to stream capacity, not scalar

### DIFF
--- a/lockstep_compiler/arena_layout.py
+++ b/lockstep_compiler/arena_layout.py
@@ -382,17 +382,70 @@ def _build_layout_from_bindings(
     )
 
 
+def infer_accumulator_sizes(entities: dict[str, Any]) -> dict[str, int]:
+    """Infer per-accumulator element counts from the pipeline's bind routes.
+
+    A fold accumulator is lowered as one slot per stream row processed by the
+    kernel that writes it (the "parallel reduction tree" the reduction pass then
+    folds), so its arena footprint is the trip count of that kernel route -- not
+    a single scalar. This mirrors the inference the LLVM backend performs so the
+    C header, IR arena type, and generated kernel all agree on the ABI.
+    """
+
+    accumulator_names = {
+        accumulator["name"] for accumulator in entities.get("accumulators", [])
+    }
+    inferred: dict[str, int] = {name: 1 for name in accumulator_names}
+    if not inferred:
+        return inferred
+
+    stream_capacities = {
+        stream["name"]: max(int(stream.get("capacity", 1) or 1), 1)
+        for stream in entities.get("streams", [])
+    }
+    kernel_params: dict[str, list[dict[str, Any]]] = {}
+    for kernel in list(entities.get("shaders", [])) + list(entities.get("filters", [])):
+        kernel_params[kernel["name"]] = list(kernel.get("params", []))
+
+    for route in entities.get("bind_routes_ir", []):
+        if route.get("kind") not in {"kernel", "shader", "filter"}:
+            continue
+        params = kernel_params.get(route.get("kernel"))
+        if params is None:
+            continue
+        args = route.get("args", [])
+        trip_count = 0
+        for index, arg_name in enumerate(args):
+            if index >= len(params):
+                break
+            if params[index].get("modifier") == "in" and arg_name in stream_capacities:
+                trip_count = max(trip_count, stream_capacities[arg_name])
+        target = route.get("target")
+        if target in stream_capacities:
+            trip_count = max(trip_count, stream_capacities[target])
+        trip_count = max(trip_count, 1)
+        for index, arg_name in enumerate(args):
+            if index >= len(params):
+                break
+            if params[index].get("modifier") == "accum" and arg_name in inferred:
+                inferred[arg_name] = max(inferred[arg_name], trip_count)
+    return inferred
+
+
 def build_arena_layout(entities: dict[str, Any]) -> ArenaLayout:
     normalized_structs = normalize_structs(entities.get("structs", []))
+    inferred_accumulator_sizes = infer_accumulator_sizes(entities)
     bindings: list[tuple[str, str, str, int]] = []
     for stream in entities.get("streams", []):
         capacity = int(stream.get("capacity", 1))
         bindings.append(("stream", stream["name"], stream["type"], max(capacity, 1)))
     for accumulator in entities.get("accumulators", []):
-        element_count = (
-            int(accumulator.get("size", 1))
-            if accumulator.get("size") is not None
-            else 1
+        explicit_size = (
+            int(accumulator["size"]) if accumulator.get("size") is not None else 1
+        )
+        element_count = max(
+            explicit_size,
+            inferred_accumulator_sizes.get(accumulator["name"], 1),
         )
         bindings.append(
             ("accum", accumulator["name"], accumulator["type"], max(element_count, 1))

--- a/tests/test_accumulator_arena_abi.py
+++ b/tests/test_accumulator_arena_abi.py
@@ -1,0 +1,134 @@
+"""ABI agreement between the generated C header and the LLVM IR arena.
+
+A fold accumulator is lowered by the backend as one slot per stream row (the
+per-row partials the reduction pass folds), so the arena reserves ``capacity``
+elements for it. The C header must reserve the same footprint: a host that
+follows the documented flow -- allocate ``LOCKSTEP_ARENA_BYTES``, call
+``Lockstep_Tick`` -- otherwise under-allocates and the kernel writes past the
+end of the arena.
+
+These tests pin that the header and IR agree on the arena size and that the
+accumulator leaf is sized to the stream capacity rather than a lone scalar.
+"""
+
+from __future__ import annotations
+
+import re
+
+from lockstep_compiler.arena_layout import infer_accumulator_sizes
+from lockstep_compiler.compiler import compile_lockstep
+
+_LLVM_ELEMENT_BYTES = {
+    "i1": 1,
+    "i8": 1,
+    "i16": 2,
+    "i32": 4,
+    "i64": 8,
+    "float": 4,
+    "double": 8,
+}
+
+FOLD_PROGRAM = """
+struct Particle {
+    int id;
+    float vx;
+    float vy;
+    float mass;
+};
+
+shader IntegrateAndAccumulate(
+    in Particle src,
+    out Particle dst,
+    accum float energy
+) {
+    float speed2 = (src.vx * src.vx) + (src.vy * src.vy);
+    energy = energy + (0.5 * src.mass * speed2);
+    dst.id = src.id;
+    dst.vx = src.vx;
+    dst.vy = src.vy;
+    dst.mass = src.mass;
+}
+
+pipeline Sim {
+    stream<Particle, 4096> particlesIn;
+    stream<Particle, 4096> particlesOut;
+    accumulator<float> energy;
+    bind {
+        particlesOut = IntegrateAndAccumulate(particlesIn, particlesOut, energy);
+        uniform float total = fold sum(energy);
+    }
+}
+"""
+
+
+def _ir_arena_bytes(ir_text: str) -> int:
+    match = re.search(
+        r'%"struct\.Lockstep_Arena"\s*=\s*type\s*\{(.+?)\}', ir_text, re.S
+    )
+    assert match is not None, "arena struct type missing from IR"
+    total = 0
+    for array in re.finditer(r"\[(\d+)\s*x\s*(\w+)\]", match.group(1)):
+        total += int(array.group(1)) * _LLVM_ELEMENT_BYTES[array.group(2)]
+    return total
+
+
+def _header_arena_bytes(header_text: str) -> int:
+    match = re.search(r"#define LOCKSTEP_ARENA_BYTES (\d+)", header_text)
+    assert match is not None, "LOCKSTEP_ARENA_BYTES missing from header"
+    return int(match.group(1))
+
+
+def test_infer_accumulator_sizes_uses_route_trip_count():
+    entities = {
+        "accumulators": [{"name": "energy", "type": "float"}],
+        "streams": [
+            {"name": "pin", "type": "P", "capacity": "4096"},
+            {"name": "pout", "type": "P", "capacity": "4096"},
+        ],
+        "shaders": [
+            {
+                "name": "K",
+                "params": [
+                    {"modifier": "in", "type": "P", "name": "src"},
+                    {"modifier": "out", "type": "P", "name": "dst"},
+                    {"modifier": "accum", "type": "float", "name": "energy"},
+                ],
+            }
+        ],
+        "filters": [],
+        "bind_routes_ir": [
+            {
+                "kind": "kernel",
+                "kernel": "K",
+                "target": "pout",
+                "args": ["pin", "pout", "energy"],
+            }
+        ],
+    }
+    assert infer_accumulator_sizes(entities) == {"energy": 4096}
+
+
+def test_infer_accumulator_sizes_defaults_to_scalar_without_routes():
+    entities = {
+        "accumulators": [{"name": "loose", "type": "float"}],
+        "streams": [],
+        "shaders": [],
+        "filters": [],
+        "bind_routes_ir": [],
+    }
+    assert infer_accumulator_sizes(entities) == {"loose": 1}
+
+
+def test_header_and_ir_agree_on_fold_arena_size():
+    result = compile_lockstep(FOLD_PROGRAM, verbose=False)
+    header_bytes = _header_arena_bytes(result.c_header)
+    ir_bytes = _ir_arena_bytes(result.llvm_ir)
+    assert header_bytes == ir_bytes
+
+
+def test_header_sizes_accumulator_leaf_to_stream_capacity():
+    result = compile_lockstep(FOLD_PROGRAM, verbose=False)
+    # The accumulator leaf must be a capacity-sized array, not a lone scalar,
+    # or a documented allocate-LOCKSTEP_ARENA_BYTES host would corrupt memory.
+    assert "float accum_energy_value[4096];" in result.c_header
+    assert "float accum_energy_value;" not in result.c_header


### PR DESCRIPTION
## Summary
Fix a critical ABI mismatch between the C header and LLVM IR arena layout for fold accumulators. Accumulators used in fold operations are now correctly sized to the stream capacity (one slot per row processed) rather than as a single scalar, preventing memory corruption when hosts allocate the documented `LOCKSTEP_ARENA_BYTES`.

## Key Changes
- **Added `infer_accumulator_sizes()` function** in `arena_layout.py` that infers per-accumulator element counts from pipeline bind routes by analyzing kernel trip counts (determined by input stream capacities and output targets)
- **Updated `build_arena_layout()`** to use inferred accumulator sizes, taking the maximum of explicit size declarations and inferred capacity-based sizes
- **Added comprehensive test suite** (`test_accumulator_arena_abi.py`) that validates:
  - Accumulator size inference correctly uses route trip counts
  - Accumulators default to scalar (size 1) when not used in routes
  - C header and LLVM IR arena sizes agree
  - Accumulator arrays are sized to stream capacity in the generated header

## Implementation Details
The fix mirrors the inference logic the LLVM backend performs: a fold accumulator lowered as a parallel reduction tree requires one slot per stream row processed by the kernel writing it. The trip count is determined by examining bind routes to find the maximum capacity among input streams and output targets for each kernel. This ensures the C header, IR arena type, and generated kernel all agree on the ABI footprint.

https://claude.ai/code/session_01AKTSk4J6VHyQJxnYbeDcRX