### PR TITLE
Gate native benchmark invariants in CI with a committed baseline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -183,3 +183,48 @@ jobs:
             if: steps.benchmark_regression.outcome == 'failure'
             run: |
               echo "::warning::Benchmark regression threshold exceeded (advisory mode)."
+
+    native-benchmark:
+        name: Native benchmarks (compiled code)
+        if: github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        steps:
+          - name: Checkout
+            uses: actions/checkout@v5
+
+          - name: Setup Python
+            uses: actions/setup-python@v6
+            with:
+              python-version: "3.12"
+              cache: "pip"
+
+          - name: Install dependencies
+            run: |
+              python -m pip install --upgrade pip
+              python -m pip install --require-hashes -r requirements-test.lock
+
+          - name: Show clang version
+            run: clang --version
+
+          - name: Run native execution benchmarks
+            run: |
+              python benchmarks/native/run_native.py --output native-results.json
+
+          - name: Upload native benchmark JSON
+            if: always()
+            uses: actions/upload-artifact@v6
+            with:
+                name: native-results-pr-${{ github.run_id }}
+                path: native-results.json
+                if-no-files-found: error
+
+          # Deterministic gate: arena ABI + output checksums are hardware-
+          # independent, so a drift here is a real codegen regression and fails
+          # the job. Throughput is not gated -- it is host-dependent and noisy on
+          # shared runners; the JSON artifact above carries it for trend tracking.
+          - name: Check native benchmark invariants
+            run: |
+              python scripts/check_native_benchmark.py \
+                --baseline benchmarks/baselines/native.json \
+                --current native-results.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: verify verify-parser-toolchain generate-parser check-generated-parser build test test-cov mypy lock-deps check-lock-deps bench bench-check bench-native bench-soa bench-fusion
+.PHONY: verify verify-parser-toolchain generate-parser check-generated-parser build test test-cov mypy lock-deps check-lock-deps bench bench-check bench-native bench-native-check bench-soa bench-fusion
 
 verify: test mypy
 
@@ -56,6 +56,15 @@ bench-check:
 # LLVM/clang toolchain on PATH.
 bench-native:
 	python benchmarks/native/run_native.py --output native-results.json
+
+# Gate the deterministic native invariants (arena ABI + output checksums) against
+# the checked-in baseline. Throughput is intentionally not gated -- it is
+# hardware-dependent and too noisy on shared CI runners. Regenerate the baseline
+# after an intentional codegen change with:
+#   python scripts/check_native_benchmark.py --current native-results.json --update
+bench-native-check: bench-native
+	python scripts/check_native_benchmark.py \
+		--baseline benchmarks/baselines/native.json --current native-results.json
 
 # SoA-vs-AoS layout micro-benchmark: quantifies the Struct-of-Arrays throughput
 # win over Array-of-Structs for the same kernel. Requires clang on PATH.

--- a/README.md
+++ b/README.md
@@ -241,6 +241,13 @@ python benchmarks/native/run_native.py --workload particle_energy --iterations 5
 
 Reported metrics are per-tick latency (`per_tick_us`), stream throughput (`mrows_per_sec`), arena bandwidth (`arena_gib_per_sec`), and a deterministic output `checksum`. This requires an LLVM/clang toolchain on `PATH`; the harness exits with a clear message if `clang` is unavailable. See [`benchmarks/native/README.md`](benchmarks/native/README.md) for details. Absolute numbers are host-dependent, so treat them as relative/regression signals.
 
+On pull requests, the `native-benchmark` CI job runs the harness and then gates its **deterministic** invariants — arena ABI (`arena_bytes`, `rows_per_tick`) and output `checksum` — against the checked-in baseline `benchmarks/baselines/native.json` via `make bench-native-check`. These are hardware-independent, so a drift is a real codegen ABI/correctness regression and fails the job (unlike the frontend throughput gate, which is advisory). Throughput is *not* gated — it is host-dependent and too noisy on shared runners — but the full JSON report is uploaded as a CI artifact for trend tracking. When a codegen change intentionally moves the invariants, regenerate the baseline and review the diff:
+
+```bash
+python benchmarks/native/run_native.py --output native-results.json
+python scripts/check_native_benchmark.py --current native-results.json --update
+```
+
 To quantify *why* Lockstep uses a Struct-of-Arrays memory layout, `make bench-soa` (or `python benchmarks/native/soa_vs_aos.py`) runs the same branchless particle kernel over identical data in SoA and Array-of-Structs layouts across a range of sizes and reports the throughput ratio. Both layouts compute identical results, so the difference is purely layout: SoA wins on vectorization (contiguous SIMD loads) and, for kernels that read a subset of fields, on bandwidth.
 
 To measure the throughput lost when a multi-stage pipeline is not fused, `make bench-fusion` (or `python benchmarks/native/fusion_probe.py`) compares the per-stage loops against a single fused loop over the same computation. Codegen now fuses accumulator stages (the `accum` restriction on fusion has been lifted); the remaining case codegen still lowers per stage is a group containing a **filter** — see [`benchmarks/native/README.md`](benchmarks/native/README.md).

--- a/benchmarks/baselines/native.json
+++ b/benchmarks/baselines/native.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "kind": "native_execution_invariants",
+  "description": "Deterministic, hardware-independent invariants of the native execution benchmarks (ABI + output checksums). Throughput is not gated. Regenerate with scripts/check_native_benchmark.py --update.",
+  "workloads": {
+    "multi_stage_pipeline": {
+      "rows_per_tick": 131072,
+      "arena_bytes": 5767168,
+      "checksum": 13105.6002
+    },
+    "particle_energy": {
+      "rows_per_tick": 32768,
+      "arena_bytes": 1703936,
+      "checksum": 65528.0
+    },
+    "telemetry_filter_aggregation": {
+      "rows_per_tick": 65536,
+      "arena_bytes": 2293760,
+      "checksum": 65528.0
+    }
+  }
+}

--- a/scripts/check_native_benchmark.py
+++ b/scripts/check_native_benchmark.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Gate the deterministic invariants of the native execution benchmarks.
+
+``benchmarks/native/run_native.py`` reports two very different kinds of number:
+
+* **Deterministic, hardware-independent** — ``rows_per_tick`` and ``arena_bytes``
+  are pure ABI (fixed by the arena layout), and ``checksum`` is an exact
+  reduction over an output leaf that the branchless kernel computes identically
+  on any CPU. These must not change unless codegen intentionally changes; a drift
+  is a real correctness/ABI regression.
+
+* **Hardware-dependent** — ``per_tick_us``, ``mrows_per_sec`` and
+  ``arena_gib_per_sec`` depend on the CPU the benchmark ran on (and, with
+  ``-march=native``, on the exact microarchitecture). On shared CI runners these
+  are far too noisy to gate on, so they are treated as advisory and only
+  published as an artifact.
+
+This script gates the first group and ignores the second. It compares a current
+``run_native.py`` JSON report against a checked-in baseline
+(``benchmarks/baselines/native.json``) and fails if the workload set changed, if
+any ABI field differs, or if a checksum drifts beyond floating-point noise.
+
+The baseline is a tracked reference, like the golden-IR snapshots: when a codegen
+change intentionally moves it, regenerate with ``--update`` and review the diff.
+
+    python scripts/check_native_benchmark.py --current native-results.json
+    python scripts/check_native_benchmark.py --current native-results.json --update
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+# Relative tolerance for the checksum comparison. The checksum is a deterministic
+# IEEE float computation, but allow a hair of slack against cross-toolchain
+# floating-point noise; the ABI fields below are matched exactly.
+_CHECKSUM_REL_TOL = 1e-6
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _results_by_workload(payload: dict) -> dict[str, dict]:
+    results = payload.get("results", [])
+    if not isinstance(results, list):
+        return {}
+    by_name: dict[str, dict] = {}
+    for row in results:
+        if isinstance(row, dict) and isinstance(row.get("workload"), str):
+            by_name[row["workload"]] = row
+    return by_name
+
+
+def _baseline_from_results(payload: dict) -> dict:
+    """Project a full run_native.py report down to its gated invariants."""
+    workloads = {
+        name: {
+            "rows_per_tick": int(row["rows_per_tick"]),
+            "arena_bytes": int(row["arena_bytes"]),
+            "checksum": float(row["checksum"]),
+        }
+        for name, row in sorted(_results_by_workload(payload).items())
+    }
+    return {
+        "schema_version": 1,
+        "kind": "native_execution_invariants",
+        "description": (
+            "Deterministic, hardware-independent invariants of the native "
+            "execution benchmarks (ABI + output checksums). Throughput is not "
+            "gated. Regenerate with scripts/check_native_benchmark.py --update."
+        ),
+        "workloads": workloads,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=Path("benchmarks/baselines/native.json"),
+        help="Checked-in native invariants baseline JSON.",
+    )
+    parser.add_argument(
+        "--current",
+        type=Path,
+        default=Path("native-results.json"),
+        help="Current run_native.py JSON report.",
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Rewrite the baseline from --current instead of checking.",
+    )
+    args = parser.parse_args()
+
+    current = _load(args.current)
+
+    if args.update:
+        baseline = _baseline_from_results(current)
+        args.baseline.parent.mkdir(parents=True, exist_ok=True)
+        args.baseline.write_text(
+            json.dumps(baseline, indent=2) + "\n", encoding="utf-8"
+        )
+        print(f"Wrote native baseline for {len(baseline['workloads'])} workload(s) to {args.baseline}")
+        return 0
+
+    baseline = _load(args.baseline)
+    baseline_workloads = baseline.get("workloads", {})
+    current_workloads = _results_by_workload(current)
+
+    if not isinstance(baseline_workloads, dict) or not baseline_workloads:
+        print("Invalid baseline: expected a non-empty 'workloads' object.", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+
+    missing = sorted(set(baseline_workloads) - set(current_workloads))
+    extra = sorted(set(current_workloads) - set(baseline_workloads))
+    for name in missing:
+        failures.append(f"{name}: present in baseline but missing from current results")
+    for name in extra:
+        failures.append(f"{name}: present in current results but not in baseline")
+
+    for name in sorted(set(baseline_workloads) & set(current_workloads)):
+        expected = baseline_workloads[name]
+        actual = current_workloads[name]
+
+        for field in ("rows_per_tick", "arena_bytes"):
+            exp = int(expected[field])
+            act = int(actual[field])
+            if exp != act:
+                failures.append(
+                    f"{name}.{field}: ABI drift (baseline={exp}, current={act})"
+                )
+
+        exp_ck = float(expected["checksum"])
+        act_ck = float(actual["checksum"])
+        if not math.isclose(exp_ck, act_ck, rel_tol=_CHECKSUM_REL_TOL, abs_tol=1e-6):
+            failures.append(
+                f"{name}.checksum: correctness drift (baseline={exp_ck}, current={act_ck})"
+            )
+
+    if failures:
+        print("Native benchmark invariant check FAILED:")
+        for failure in failures:
+            print(f"  - {failure}")
+        print(
+            "\nIf this change is intentional, regenerate the baseline with\n"
+            "  python scripts/check_native_benchmark.py --current <report> --update\n"
+            "and review the diff.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"Native benchmark invariants OK for {len(baseline_workloads)} workload(s) "
+        "(ABI + checksums; throughput not gated)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_native_benchmark.py
+++ b/tests/test_check_native_benchmark.py
@@ -1,0 +1,134 @@
+"""Unit tests for the native benchmark invariant gate.
+
+``scripts/check_native_benchmark.py`` is a CI gate, so its pass/fail logic is
+worth pinning directly rather than only exercising it through the workflow. These
+tests drive the module in-process with synthetic reports (no clang, no compiled
+benchmark run), covering: a clean pass, ABI drift, checksum drift beyond
+tolerance, checksum noise within tolerance, a dropped workload, and the
+round-trip that the shipped baseline matches its own projection.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_SPEC = importlib.util.spec_from_file_location(
+    "check_native_benchmark", REPO_ROOT / "scripts" / "check_native_benchmark.py"
+)
+assert _SPEC and _SPEC.loader
+check_native_benchmark = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(check_native_benchmark)
+
+BASELINE_PATH = REPO_ROOT / "benchmarks" / "baselines" / "native.json"
+
+
+def _report(**overrides: dict) -> dict:
+    """A minimal run_native.py-shaped report for two workloads."""
+    rows = {
+        "alpha": {"workload": "alpha", "rows_per_tick": 1024, "arena_bytes": 4096, "checksum": 10.0, "mrows_per_sec": 500.0},
+        "beta": {"workload": "beta", "rows_per_tick": 2048, "arena_bytes": 8192, "checksum": 20.0, "mrows_per_sec": 600.0},
+    }
+    for name, patch in overrides.items():
+        rows[name] = {**rows[name], **patch}
+    return {"kind": "native_execution", "results": list(rows.values())}
+
+
+def _invoke(baseline_path: Path, current_path: Path, update: bool = False) -> int:
+    import sys
+
+    argv = [
+        "check_native_benchmark.py",
+        "--baseline",
+        str(baseline_path),
+        "--current",
+        str(current_path),
+    ]
+    if update:
+        argv.append("--update")
+    old = sys.argv
+    sys.argv = argv
+    try:
+        return check_native_benchmark.main()
+    finally:
+        sys.argv = old
+
+
+def _baseline_of(report: dict) -> dict:
+    return check_native_benchmark._baseline_from_results(report)
+
+
+def test_matching_report_passes(tmp_path: Path) -> None:
+    report = _report()
+    baseline = _baseline_of(report)
+    b = tmp_path / "b.json"
+    c = tmp_path / "c.json"
+    b.write_text(json.dumps(baseline), encoding="utf-8")
+    c.write_text(json.dumps(report), encoding="utf-8")
+    assert _invoke(b, c) == 0
+
+
+def test_checksum_within_tolerance_passes(tmp_path: Path) -> None:
+    baseline = _baseline_of(_report())
+    # A sub-1e-6 relative wobble must not trip the gate.
+    current = _report(alpha={"checksum": 10.0 * (1 + 1e-7)})
+    b = tmp_path / "b.json"
+    c = tmp_path / "c.json"
+    b.write_text(json.dumps(baseline), encoding="utf-8")
+    c.write_text(json.dumps(current), encoding="utf-8")
+    assert _invoke(b, c) == 0
+
+
+def test_checksum_drift_fails(tmp_path: Path) -> None:
+    baseline = _baseline_of(_report())
+    current = _report(alpha={"checksum": 11.0})
+    b = tmp_path / "b.json"
+    c = tmp_path / "c.json"
+    b.write_text(json.dumps(baseline), encoding="utf-8")
+    c.write_text(json.dumps(current), encoding="utf-8")
+    assert _invoke(b, c) == 1
+
+
+def test_abi_drift_fails(tmp_path: Path) -> None:
+    baseline = _baseline_of(_report())
+    current = _report(beta={"arena_bytes": 8192 + 64})
+    b = tmp_path / "b.json"
+    c = tmp_path / "c.json"
+    b.write_text(json.dumps(baseline), encoding="utf-8")
+    c.write_text(json.dumps(current), encoding="utf-8")
+    assert _invoke(b, c) == 1
+
+
+def test_missing_workload_fails(tmp_path: Path) -> None:
+    baseline = _baseline_of(_report())
+    current = {"results": [_report()["results"][0]]}  # drop 'beta'
+    b = tmp_path / "b.json"
+    c = tmp_path / "c.json"
+    b.write_text(json.dumps(baseline), encoding="utf-8")
+    c.write_text(json.dumps(current), encoding="utf-8")
+    assert _invoke(b, c) == 1
+
+
+def test_update_writes_projection(tmp_path: Path) -> None:
+    report = _report()
+    b = tmp_path / "b.json"
+    c = tmp_path / "c.json"
+    c.write_text(json.dumps(report), encoding="utf-8")
+    assert _invoke(b, c, update=True) == 0
+    written = json.loads(b.read_text(encoding="utf-8"))
+    assert set(written["workloads"]) == {"alpha", "beta"}
+    assert written["workloads"]["alpha"]["arena_bytes"] == 4096
+    # Throughput is intentionally not part of the gated baseline.
+    assert "mrows_per_sec" not in written["workloads"]["alpha"]
+
+
+def test_shipped_baseline_is_self_consistent() -> None:
+    """The committed baseline must be a valid, non-empty invariants file."""
+    baseline = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    assert baseline["workloads"], "shipped native baseline has no workloads"
+    for name, fields in baseline["workloads"].items():
+        assert set(fields) == {"rows_per_tick", "arena_bytes", "checksum"}, name


### PR DESCRIPTION
## Summary

The native execution benchmarks were runnable but nothing guarded their output — a codegen change could alter the arena ABI or silently break a workload's compiled result and no check would notice. The frontend regression gate is advisory and covers only the two Python KPIs.

This adds a **deterministic** gate over the native benchmarks' hardware-independent invariants:

| gated (deterministic) | not gated (host-dependent) |
| --- | --- |
| `arena_bytes`, `rows_per_tick` (pure ABI, exact match) | `per_tick_us` |
| `checksum` (output correctness, FP-tolerant) | `mrows_per_sec`, `arena_gib_per_sec` |

`scripts/check_native_benchmark.py` compares a `run_native.py` report to a checked-in baseline (`benchmarks/baselines/native.json`), matching ABI fields exactly and the checksum within floating-point tolerance, and **failing** on any drift, a dropped workload, or an added one. It regenerates the baseline with `--update`, the same pattern as the golden-IR snapshots.

**Throughput is intentionally not gated** — it is host-dependent and far too noisy on shared CI runners. The full JSON report is uploaded as a CI artifact so the numbers are still tracked for trends.

## Why a committed baseline, not a CI push

My earlier suggestion was "a CI step that appends to a committed history file." A committed baseline updated via PR is deliberately chosen instead: pushing a history file back from CI needs write permissions and creates bot-push loops, and CI hardware noise would pollute any committed *throughput* history anyway. The baseline captures exactly the values that *should* be stable, and moves visibly (in a reviewed diff) only when codegen intends it to.

## Contents

- `scripts/check_native_benchmark.py` — the gate, with `--update`.
- `benchmarks/baselines/native.json` — the tracked invariants baseline.
- `.github/workflows/tests.yml` — a `native-benchmark` PR job that runs the harness, uploads the JSON artifact, and runs the hard invariant gate.
- `Makefile` — `bench-native-check` target (`bench-native` + the gate).
- `tests/test_check_native_benchmark.py` — unit tests for the gate logic (pass, ABI drift, checksum drift, in-tolerance noise, dropped workload, `--update` projection, shipped-baseline shape) — no clang required, so they run in the normal suite.

Full suite (261 passed, 4 ANTLR skips) + `make mypy` pass; workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtpsuN82fUuZMvSpPL9JmM)_