### PR TITLE
security: resource-limit the simulator execution subprocess

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,6 +61,7 @@ The `--simulate` flag executes a lightweight simulation of the pipeline's bind r
 - **Native-code execution still occurs, but out-of-process.** The simulator no longer executes generated native code in the compiler process address space. This removes the highest-severity in-process memory-corruption risk from MCJIT execution. However, a subprocess still executes generated code and therefore still carries host-level execution risk if used on untrusted input.
 - **Toolchain dependency and fallback behavior.** Subprocess execution depends on `clang` or `lli` being present at runtime. If neither is available (or subprocess compilation/execution fails), the simulator falls back to Python `sum` semantics for numeric folds to preserve simulator availability.
 - **Timeout-bounded subprocesses.** Compilation and execution subprocess calls are timeout-bounded to reduce runaway execution risk, but they are not cgroup/namespace isolated by Lockstep itself.
+- **Resource-limited execution subprocess (POSIX).** The subprocess that executes generated native code is launched with clamped POSIX resource limits (`RLIMIT_CPU`, `RLIMIT_AS`, `RLIMIT_FSIZE`, and `RLIMIT_CORE` set to `0`) via a `preexec_fn`. This bounds CPU time, address space, output file size, and core dumps so that a pathological or malicious generated program cannot spin, exhaust memory, or fill the disk beyond these ceilings — a stronger guarantee than the wall-clock timeout alone, which does not cap memory or output. The limits are lowered from the inherited hard limits only (never raised) and degrade gracefully where a limit is unsupported. On platforms without `rlimit` support (Windows), the subprocess falls back to the wall-clock timeout.
 
 ### LSP server
 
@@ -113,7 +114,6 @@ Verification in CI:
 
 The following improvements are planned for future releases:
 
-- **Input size and complexity limits** for the parser frontend (maximum file size, maximum nesting depth, parse timeout).
-- **Stronger process isolation** for simulator subprocesses (for example, optional namespace/cgroup sandboxing when available).
+- **Stronger process isolation** for simulator subprocesses. POSIX resource limits (CPU, address space, file size, core dumps) are now applied to the execution subprocess; deeper isolation (namespace/cgroup sandboxing when available) remains future work.
 - **Formal verification** of arena aliasing and offset correctness invariants, confirming that generated accesses are sound across all valid Lockstep programs.
 - **Automated dependency vulnerability scanning** via Dependabot or similar tooling in CI.

--- a/lockstep_compiler/simulator.py
+++ b/lockstep_compiler/simulator.py
@@ -1,11 +1,15 @@
 import json
 import os
+import sys
 from dataclasses import dataclass
 from functools import lru_cache
 import shutil
 import subprocess
 import tempfile
-from typing import Any, cast
+from typing import Any, Callable, cast
+
+if sys.platform != "win32":
+    import resource
 
 from llvmlite import ir
 
@@ -186,6 +190,50 @@ def _simulator_runtime_command() -> tuple[str, ...] | None:
     return None
 
 
+# Resource ceilings applied to the subprocess that executes generated native
+# code (the fold-reduction program, or `lli` interpreting the generated IR).
+# They are generous enough never to trip on a real reduction but bound a
+# pathological or malicious generated program: a CPU spin, an allocation blow-up,
+# or an attempt to fill the disk. This is defense in depth on top of the
+# wall-clock timeout, which alone does not cap memory or output size. POSIX only;
+# where rlimits are unavailable (Windows) the subprocess falls back to the
+# wall-clock timeout.
+_SUBPROCESS_CPU_SECONDS = 10
+_SUBPROCESS_ADDRESS_SPACE_BYTES = 512 * 1024 * 1024
+_SUBPROCESS_FILE_SIZE_BYTES = 64 * 1024 * 1024
+
+
+def _clamp_rlimit(which: int, soft: int) -> None:  # pragma: no cover - child
+    """Lower the soft limit of a resource, never raising above the inherited
+    hard limit and never failing the launch if the platform rejects it."""
+    try:
+        _, hard = resource.getrlimit(which)
+    except (ValueError, OSError):
+        return
+    limit = soft
+    if hard != resource.RLIM_INFINITY:
+        limit = min(soft, hard)
+    try:
+        resource.setrlimit(which, (limit, hard))
+    except (ValueError, OSError):
+        pass
+
+
+def _subprocess_resource_limits() -> Callable[[], None] | None:
+    """Return a ``preexec_fn`` that clamps CPU time, address space, output file
+    size, and core dumps for a child process, or ``None`` where unsupported."""
+    if sys.platform == "win32":
+        return None
+
+    def _apply() -> None:  # pragma: no cover - executed in the forked child
+        _clamp_rlimit(resource.RLIMIT_CPU, _SUBPROCESS_CPU_SECONDS)
+        _clamp_rlimit(resource.RLIMIT_AS, _SUBPROCESS_ADDRESS_SPACE_BYTES)
+        _clamp_rlimit(resource.RLIMIT_FSIZE, _SUBPROCESS_FILE_SIZE_BYTES)
+        _clamp_rlimit(resource.RLIMIT_CORE, 0)
+
+    return _apply
+
+
 def _run_reduce_subprocess(values: list[float]) -> float:
     command = _simulator_runtime_command()
     if command is None:
@@ -215,6 +263,7 @@ def _run_reduce_subprocess(values: list[float]) -> float:
             capture_output=True,
             text=True,
             timeout=5,
+            preexec_fn=_subprocess_resource_limits(),
         )
 
     return float(completed.stdout.strip())

--- a/tests/test_simulator_subprocess_limits.py
+++ b/tests/test_simulator_subprocess_limits.py
@@ -1,0 +1,58 @@
+"""Tests for the resource limits applied to the simulator's reduction
+subprocess (the boundary where generated native code executes)."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from lockstep_compiler import simulator
+
+
+posix_only = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX resource limits are unavailable on Windows"
+)
+
+
+@posix_only
+def test_resource_limits_returns_callable_on_posix() -> None:
+    preexec = simulator._subprocess_resource_limits()
+    assert callable(preexec)
+
+
+@posix_only
+def test_clamp_rlimit_lowers_soft_limit() -> None:
+    import resource
+
+    # RLIMIT_CORE is safe to mutate in-process: 0 just disables core dumps and
+    # never terminates the interpreter (unlike RLIMIT_CPU / RLIMIT_AS).
+    original_soft, hard = resource.getrlimit(resource.RLIMIT_CORE)
+    try:
+        simulator._clamp_rlimit(resource.RLIMIT_CORE, 0)
+        new_soft, new_hard = resource.getrlimit(resource.RLIMIT_CORE)
+        assert new_soft == 0
+        assert new_hard == hard
+    finally:
+        resource.setrlimit(resource.RLIMIT_CORE, (original_soft, hard))
+
+
+@posix_only
+def test_clamp_rlimit_never_raises_above_hard_limit() -> None:
+    import resource
+
+    original_soft, hard = resource.getrlimit(resource.RLIMIT_CORE)
+    try:
+        # Ask for more than the hard limit; the soft limit must not exceed it.
+        requested = (
+            hard + 1 if hard != resource.RLIM_INFINITY else _SOME_LARGE_VALUE
+        )
+        simulator._clamp_rlimit(resource.RLIMIT_CORE, requested)
+        new_soft, _ = resource.getrlimit(resource.RLIMIT_CORE)
+        if hard != resource.RLIM_INFINITY:
+            assert new_soft <= hard
+    finally:
+        resource.setrlimit(resource.RLIMIT_CORE, (original_soft, hard))
+
+
+_SOME_LARGE_VALUE = 1 << 40


### PR DESCRIPTION
## Summary

The simulator's fold-reduction path (`--simulate` with the opt-in LLVM runtime) executes generated native code out of process — either a `clang`-compiled executable or `lli` interpreting the generated IR. Until now the only bound on that subprocess was a **5s wall-clock timeout**, which does not cap memory, CPU time, or output size. A pathological or malicious generated program could allocate without bound or fill the disk within the timeout window.

This PR launches the execution subprocess with clamped **POSIX resource limits** via a `preexec_fn`:

| Limit | Ceiling | Bounds |
| --- | --- | --- |
| `RLIMIT_CPU` | 10s | busy-loops (precise CPU cap on top of the wall timeout) |
| `RLIMIT_AS` | 512 MiB | address-space / allocation blow-ups |
| `RLIMIT_FSIZE` | 64 MiB | output / temp-file growth |
| `RLIMIT_CORE` | 0 | core dumps |

This is the "stronger process isolation" item from the `SECURITY.md` hardening roadmap.

## Design notes

- Limits are **lowered from the inherited hard limits only** (never raised), and `_clamp_rlimit` **fails open** if a platform rejects a specific limit — a supported ceiling is always applied without ever breaking the launch.
- Applied to the **execution** subprocess (the untrusted-code boundary), not the `clang` compile step (trusted toolchain that legitimately needs memory).
- **Windows** has no `rlimit` support: `_subprocess_resource_limits()` returns `None` and the subprocess keeps the existing wall-clock timeout. The `resource` import is guarded by `sys.platform`.

## Tests

New `tests/test_simulator_subprocess_limits.py` (POSIX-guarded):
- `_subprocess_resource_limits()` returns a callable on POSIX.
- `_clamp_rlimit` lowers a soft limit and never raises above the hard limit (exercised with `RLIMIT_CORE`, which is safe to mutate in-process).

mypy (strict, includes `simulator.py`) passes; full suite green.

## Docs

`SECURITY.md`: documents the new resource-limited execution subprocess and updates the hardening roadmap (also drops the already-delivered parser input-limits bullet).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHd6rPoCoz2gez6kEzje9B)_