### PR TITLE
refactor: extract scalar intrinsic lowering into codegen_intrinsics

### DIFF
--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -32,6 +32,7 @@ from .ast import (
     _normalize_type,
 )
 from .arena_layout import build_ast_arena_layout
+from .codegen_intrinsics import lower_intrinsic_call
 from .optimizer import _parse_bind_route, optimize_bind_routes
 from .utils import decode_escape_sequences
 from .utils import sanitize_symbol as _sanitize_symbol
@@ -79,130 +80,12 @@ class _FunctionLowerer:
     def _compiler_error(self, message: str) -> None:
         raise CodegenError(message)
 
-    def _declare_llvm_intrinsic(
-        self, intrinsic_name: str, arg_type: ir.Type
-    ) -> ir.Function:
-        if isinstance(arg_type, ir.FloatType):
-            suffix = "f32"
-        elif isinstance(arg_type, ir.DoubleType):
-            suffix = "f64"
-        else:
-            self._compiler_error(
-                f"intrinsic '{intrinsic_name}' expects float or double arguments"
-            )
-        llvm_name = f"llvm.{intrinsic_name}.{suffix}"
-        intrinsic = self.module.globals.get(llvm_name)
-        if intrinsic is not None:
-            return intrinsic
-        fn_type = ir.FunctionType(arg_type, [arg_type, arg_type])
-        return ir.Function(self.module, fn_type, name=llvm_name)
-
-    def _float_intrinsic_type(self, name: str, args: list[ir.Value]) -> ir.Type:
-        if not args or not all(
-            isinstance(arg.type, (ir.FloatType, ir.DoubleType)) for arg in args
-        ):
-            self._compiler_error(f"intrinsic '{name}' expects float arguments")
-        first_type = args[0].type
-        if not all(arg.type == first_type for arg in args):
-            self._compiler_error(f"intrinsic '{name}' expects matching float arguments")
-        return first_type
-
-    def _declare_unary_llvm_intrinsic(
-        self, intrinsic_name: str, arg_type: ir.Type
-    ) -> ir.Function:
-        if isinstance(arg_type, ir.FloatType):
-            suffix = "f32"
-        elif isinstance(arg_type, ir.DoubleType):
-            suffix = "f64"
-        else:
-            self._compiler_error(
-                f"intrinsic '{intrinsic_name}' expects float or double arguments"
-            )
-        llvm_name = f"llvm.{intrinsic_name}.{suffix}"
-        intrinsic = self.module.globals.get(llvm_name)
-        if intrinsic is not None:
-            return intrinsic
-        fn_type = ir.FunctionType(arg_type, [arg_type])
-        return ir.Function(self.module, fn_type, name=llvm_name)
-
     def _lower_intrinsic_call(self, name: str, args: list[ir.Value]) -> ir.Value | None:
-        if name == "step" and len(args) == 2:
-            arg_type = self._float_intrinsic_type(name, args)
-            edge, x_val = args
-            cmp_result = self.builder.fcmp_ordered(">=", x_val, edge, name="step_cmp")
-            return self.builder.uitofp(cmp_result, arg_type, name="step")
-
-        if name == "mix" and len(args) == 3:
-            arg_type = self._float_intrinsic_type(name, args)
-            a, b, t = args
-            one_minus_t = self.builder.fsub(
-                ir.Constant(arg_type, 1.0), t, name="mix_one_minus_t"
-            )
-            return self.builder.fadd(
-                self.builder.fmul(a, one_minus_t),
-                self.builder.fmul(b, t),
-                name="mix",
-            )
-
-        if name == "max" and len(args) == 2:
-            arg_type = self._float_intrinsic_type(name, args)
-            maxnum = self._declare_llvm_intrinsic("maxnum", arg_type)
-            return self.builder.call(maxnum, args, name="max")
-
-        if name == "min" and len(args) == 2:
-            arg_type = self._float_intrinsic_type(name, args)
-            minnum = self._declare_llvm_intrinsic("minnum", arg_type)
-            return self.builder.call(minnum, args, name="min")
-
-        if name == "clamp" and len(args) == 3:
-            arg_type = self._float_intrinsic_type(name, args)
-            x_val, min_value, max_value = args
-            maxnum = self._declare_llvm_intrinsic("maxnum", arg_type)
-            minnum = self._declare_llvm_intrinsic("minnum", arg_type)
-            clamped_min = self.builder.call(
-                maxnum, [x_val, min_value], name="clamp_min"
-            )
-            return self.builder.call(minnum, [clamped_min, max_value], name="clamp")
-
-        if name == "abs" and len(args) == 1:
-            arg_type = self._float_intrinsic_type(name, args)
-            fabs = self._declare_unary_llvm_intrinsic("fabs", arg_type)
-            return self.builder.call(fabs, args, name="abs")
-
-        if name == "sign" and len(args) == 1:
-            arg_type = self._float_intrinsic_type(name, args)
-            x = args[0]
-            zero = ir.Constant(arg_type, 0.0)
-            pos = self.builder.fcmp_ordered(">", x, zero, name="sign_pos")
-            neg = self.builder.fcmp_ordered("<", x, zero, name="sign_neg")
-            pos_f = self.builder.uitofp(pos, arg_type, name="sign_pos_f")
-            neg_f = self.builder.uitofp(neg, arg_type, name="sign_neg_f")
-            return self.builder.fsub(pos_f, neg_f, name="sign")
-
-        if name == "smoothstep" and len(args) == 3:
-            arg_type = self._float_intrinsic_type(name, args)
-            edge0, edge1, x = args
-            # t = clamp((x - edge0) / (edge1 - edge0), 0, 1)
-            diff = self.builder.fsub(x, edge0, name="ss_diff")
-            range_val = self.builder.fsub(edge1, edge0, name="ss_range")
-            t_raw = self.builder.fdiv(diff, range_val, name="ss_t_raw")
-            maxnum = self._declare_llvm_intrinsic("maxnum", arg_type)
-            minnum = self._declare_llvm_intrinsic("minnum", arg_type)
-            t_clamped = self.builder.call(
-                maxnum, [t_raw, ir.Constant(arg_type, 0.0)], name="ss_clamp_lo"
-            )
-            t = self.builder.call(
-                minnum, [t_clamped, ir.Constant(arg_type, 1.0)], name="ss_t"
-            )
-            # result = t * t * (3 - 2 * t)
-            two_t = self.builder.fmul(ir.Constant(arg_type, 2.0), t, name="ss_2t")
-            three_minus_2t = self.builder.fsub(
-                ir.Constant(arg_type, 3.0), two_t, name="ss_3m2t"
-            )
-            t_sq = self.builder.fmul(t, t, name="ss_tsq")
-            return self.builder.fmul(t_sq, three_minus_2t, name="smoothstep")
-
-        return None
+        # Scalar builtin-intrinsic lowering lives in `codegen_intrinsics`; this
+        # method just supplies the current builder/module and error callback.
+        return lower_intrinsic_call(
+            self.builder, self.module, name, args, self._compiler_error
+        )
 
     def _struct_name_for_type(self, llvm_type: ir.Type) -> str | None:
         for name, known_ty in self.known_structs.items():

--- a/lockstep_compiler/codegen_intrinsics.py
+++ b/lockstep_compiler/codegen_intrinsics.py
@@ -1,0 +1,154 @@
+"""Scalar builtin-intrinsic lowering for the LLVM backend.
+
+This module owns the semantics of Lockstep's straight-line scalar intrinsics
+(`step`, `mix`, `min`, `max`, `clamp`, `abs`, `sign`, `smoothstep`): how each one
+is expanded into LLVM IR and how the supporting `llvm.*` declarations are
+materialized. It is intentionally free of any `_FunctionLowerer` state — every
+function takes the LLVM `builder`/`module` and an ``error`` callback explicitly —
+so the intrinsic contract lives in one small, directly testable place rather than
+threaded through the 3k-line code generator.
+
+The lowering is byte-for-byte identical to the previous in-class implementation;
+`tests/test_golden_ir.py` pins the emitted IR.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from llvmlite import ir
+
+# Raises a codegen error with the given message (never returns).
+ErrorFn = Callable[[str], None]
+
+
+def declare_binary_llvm_intrinsic(
+    module: ir.Module, intrinsic_name: str, arg_type: ir.Type, error: ErrorFn
+) -> ir.Function:
+    """Declare (or reuse) a two-operand `llvm.<name>.<suffix>` intrinsic."""
+    if isinstance(arg_type, ir.FloatType):
+        suffix = "f32"
+    elif isinstance(arg_type, ir.DoubleType):
+        suffix = "f64"
+    else:
+        error(f"intrinsic '{intrinsic_name}' expects float or double arguments")
+    llvm_name = f"llvm.{intrinsic_name}.{suffix}"
+    intrinsic = module.globals.get(llvm_name)
+    if intrinsic is not None:
+        return intrinsic
+    fn_type = ir.FunctionType(arg_type, [arg_type, arg_type])
+    return ir.Function(module, fn_type, name=llvm_name)
+
+
+def declare_unary_llvm_intrinsic(
+    module: ir.Module, intrinsic_name: str, arg_type: ir.Type, error: ErrorFn
+) -> ir.Function:
+    """Declare (or reuse) a one-operand `llvm.<name>.<suffix>` intrinsic."""
+    if isinstance(arg_type, ir.FloatType):
+        suffix = "f32"
+    elif isinstance(arg_type, ir.DoubleType):
+        suffix = "f64"
+    else:
+        error(f"intrinsic '{intrinsic_name}' expects float or double arguments")
+    llvm_name = f"llvm.{intrinsic_name}.{suffix}"
+    intrinsic = module.globals.get(llvm_name)
+    if intrinsic is not None:
+        return intrinsic
+    fn_type = ir.FunctionType(arg_type, [arg_type])
+    return ir.Function(module, fn_type, name=llvm_name)
+
+
+def float_intrinsic_type(name: str, args: list[ir.Value], error: ErrorFn) -> ir.Type:
+    """Validate that every argument is the same float/double type and return it."""
+    if not args or not all(
+        isinstance(arg.type, (ir.FloatType, ir.DoubleType)) for arg in args
+    ):
+        error(f"intrinsic '{name}' expects float arguments")
+    first_type = args[0].type
+    if not all(arg.type == first_type for arg in args):
+        error(f"intrinsic '{name}' expects matching float arguments")
+    return first_type
+
+
+def lower_intrinsic_call(
+    builder: ir.IRBuilder,
+    module: ir.Module,
+    name: str,
+    args: list[ir.Value],
+    error: ErrorFn,
+) -> ir.Value | None:
+    """Lower a scalar builtin intrinsic call, or return ``None`` if ``name`` is
+    not a recognized intrinsic (so the caller can fall through to user calls)."""
+    if name == "step" and len(args) == 2:
+        arg_type = float_intrinsic_type(name, args, error)
+        edge, x_val = args
+        cmp_result = builder.fcmp_ordered(">=", x_val, edge, name="step_cmp")
+        return builder.uitofp(cmp_result, arg_type, name="step")
+
+    if name == "mix" and len(args) == 3:
+        arg_type = float_intrinsic_type(name, args, error)
+        a, b, t = args
+        one_minus_t = builder.fsub(
+            ir.Constant(arg_type, 1.0), t, name="mix_one_minus_t"
+        )
+        return builder.fadd(
+            builder.fmul(a, one_minus_t),
+            builder.fmul(b, t),
+            name="mix",
+        )
+
+    if name == "max" and len(args) == 2:
+        arg_type = float_intrinsic_type(name, args, error)
+        maxnum = declare_binary_llvm_intrinsic(module, "maxnum", arg_type, error)
+        return builder.call(maxnum, args, name="max")
+
+    if name == "min" and len(args) == 2:
+        arg_type = float_intrinsic_type(name, args, error)
+        minnum = declare_binary_llvm_intrinsic(module, "minnum", arg_type, error)
+        return builder.call(minnum, args, name="min")
+
+    if name == "clamp" and len(args) == 3:
+        arg_type = float_intrinsic_type(name, args, error)
+        x_val, min_value, max_value = args
+        maxnum = declare_binary_llvm_intrinsic(module, "maxnum", arg_type, error)
+        minnum = declare_binary_llvm_intrinsic(module, "minnum", arg_type, error)
+        clamped_min = builder.call(maxnum, [x_val, min_value], name="clamp_min")
+        return builder.call(minnum, [clamped_min, max_value], name="clamp")
+
+    if name == "abs" and len(args) == 1:
+        arg_type = float_intrinsic_type(name, args, error)
+        fabs = declare_unary_llvm_intrinsic(module, "fabs", arg_type, error)
+        return builder.call(fabs, args, name="abs")
+
+    if name == "sign" and len(args) == 1:
+        arg_type = float_intrinsic_type(name, args, error)
+        x = args[0]
+        zero = ir.Constant(arg_type, 0.0)
+        pos = builder.fcmp_ordered(">", x, zero, name="sign_pos")
+        neg = builder.fcmp_ordered("<", x, zero, name="sign_neg")
+        pos_f = builder.uitofp(pos, arg_type, name="sign_pos_f")
+        neg_f = builder.uitofp(neg, arg_type, name="sign_neg_f")
+        return builder.fsub(pos_f, neg_f, name="sign")
+
+    if name == "smoothstep" and len(args) == 3:
+        arg_type = float_intrinsic_type(name, args, error)
+        edge0, edge1, x = args
+        # t = clamp((x - edge0) / (edge1 - edge0), 0, 1)
+        diff = builder.fsub(x, edge0, name="ss_diff")
+        range_val = builder.fsub(edge1, edge0, name="ss_range")
+        t_raw = builder.fdiv(diff, range_val, name="ss_t_raw")
+        maxnum = declare_binary_llvm_intrinsic(module, "maxnum", arg_type, error)
+        minnum = declare_binary_llvm_intrinsic(module, "minnum", arg_type, error)
+        t_clamped = builder.call(
+            maxnum, [t_raw, ir.Constant(arg_type, 0.0)], name="ss_clamp_lo"
+        )
+        t = builder.call(minnum, [t_clamped, ir.Constant(arg_type, 1.0)], name="ss_t")
+        # result = t * t * (3 - 2 * t)
+        two_t = builder.fmul(ir.Constant(arg_type, 2.0), t, name="ss_2t")
+        three_minus_2t = builder.fsub(
+            ir.Constant(arg_type, 3.0), two_t, name="ss_3m2t"
+        )
+        t_sq = builder.fmul(t, t, name="ss_tsq")
+        return builder.fmul(t_sq, three_minus_2t, name="smoothstep")
+
+    return None


### PR DESCRIPTION
## Summary

`codegen.py` is a 3.1k-line monolith — 3× the next-largest module — which makes the higher-impact backend work (e.g. `noalias`, further SoA lowering) hard to land safely. This PR is a **first, deliberately output-neutral** step toward breaking it up.

It moves the scalar builtin-intrinsic lowering — `step`, `mix`, `min`, `max`, `clamp`, `abs`, `sign`, `smoothstep`, plus the `llvm.*` declaration helpers — out of `_FunctionLowerer` and into a new `codegen_intrinsics` module of **stateless free functions**. Each takes the LLVM `builder`/`module` and an `error` callback explicitly, so the intrinsic contract now lives in one small, directly testable place instead of being threaded through the code generator.

`_FunctionLowerer._lower_intrinsic_call` becomes a three-line delegator.

## Why it's safe

The emitted IR is **byte-for-byte identical**: the moved code is verbatim (only `self.builder`→`builder`, `self.module`→`module`, `self._compiler_error`→`error`). `tests/test_golden_ir.py` pins the exact IR for the shader/accumulator/filter/fusion corpus and passes unchanged, and the four extracted helpers had a single internal call site.

## Result

- `codegen.py`: 3,124 → 3,007 lines
- `codegen_intrinsics.py`: +154 lines (new, cohesive, documented)
- Golden-IR snapshots: unchanged · full suite green · mypy (strict) clean

## Scope

Pure refactor — no behavior or output change. Establishes the extraction pattern for subsequent slices (expression lowering, arena/GEP addressing, the fused-vector pass, reductions).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHd6rPoCoz2gez6kEzje9B)_