### PR TITLE
ci: add ruff lint and a coverage floor

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,15 @@ jobs:
             run: |
               python -m compileall debug_compiler.py lockstep_compiler tests
 
+          - name: Install ruff
+            run: |
+              # Pinned so lint results are reproducible; bump deliberately.
+              python -m pip install "ruff==0.15.8"
+
+          - name: Run ruff
+            run: |
+              make lint
+
     typecheck:
         name: Type checks (mypy)
         runs-on: ubuntu-latest
@@ -100,6 +109,37 @@ jobs:
           - name: Run mypy
             run: |
               make mypy
+
+    coverage:
+        name: Coverage floor
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+          - name: Checkout
+            uses: actions/checkout@v5
+
+          - name: Setup Python
+            uses: actions/setup-python@v6
+            with:
+              python-version: "3.12"
+              cache: "pip"
+
+          - name: Install dependencies
+            run: |
+              python -m pip install --upgrade pip
+              python -m pip install --require-hashes -r requirements-test.lock
+
+          - name: Run tests with coverage floor
+            run: |
+              make test-cov
+
+          - name: Upload coverage report
+            if: always()
+            uses: actions/upload-artifact@v6
+            with:
+                name: coverage-report
+                path: coverage.xml
+                if-no-files-found: warn
 
     test:
         name: Tests (${{ matrix.os }} / py${{ matrix.python-version }})

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
-.PHONY: verify verify-parser-toolchain generate-parser check-generated-parser build test test-cov mypy lock-deps check-lock-deps bench bench-check bench-native bench-native-check bench-soa bench-fusion
+.PHONY: verify verify-parser-toolchain generate-parser check-generated-parser build test test-cov lint mypy lock-deps check-lock-deps bench bench-check bench-native bench-native-check bench-soa bench-fusion
 
-verify: test mypy
+verify: lint test mypy
+
+# Minimum overall statement+branch coverage for the shipped package. Kept a few
+# points below the current level so ordinary variation never fails CI; ratchet
+# it upward as coverage improves.
+COV_FAIL_UNDER = 70
+
+lint:
+	ruff check lockstep_compiler
 
 verify-parser-toolchain:
 	python scripts/generate_parser.py --verify-toolchain
@@ -39,7 +47,8 @@ test:
 	pytest
 
 test-cov:
-	pytest --cov=. --cov-branch --cov-report=term-missing --cov-report=xml:coverage.xml
+	pytest --cov=lockstep_compiler --cov-branch --cov-report=term-missing \
+		--cov-report=xml:coverage.xml --cov-fail-under=$(COV_FAIL_UNDER)
 
 mypy:
 	python -m mypy

--- a/lockstep_compiler/compiler.py
+++ b/lockstep_compiler/compiler.py
@@ -809,7 +809,7 @@ def _compile_lockstep_with_dependencies(
         if "target_width" in emit_signature.parameters:
             emit_kwargs["target_width"] = target_width
         if "bind_optimization" in emit_signature.parameters:
-            emit_kwargs["bind_optimization"] = bind_optimization        
+            emit_kwargs["bind_optimization"] = bind_optimization
         try:
             llvm_ir = emit_llvm_ir(
                 typed_ast,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,19 @@ target-version = ["py311"]
 include = "\\.pyi?$"
 extend-exclude = "generated/"
 
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+# Generated parser code is not hand-maintained; never lint it.
+extend-exclude = ["generated"]
+
+[tool.ruff.lint]
+# pycodestyle errors (E) + pyflakes (F) + pycodestyle warnings (W). E501
+# (line-too-long) is intentionally disabled: Black owns line length, and
+# enabling it here would only produce noise that fights the formatter.
+select = ["E", "F", "W"]
+ignore = ["E501"]
+
 [tool.coverage.run]
 branch = true
 source = ["."]


### PR DESCRIPTION
## Summary

For a project this disciplined (matrix tests, strict mypy, hashed lockfiles, golden-IR snapshots, four benchmark harnesses), two CI gaps stood out:

1. **No linter.** Static checks were `compileall` + mypy. `[tool.black]` config existed but nothing caught unused imports, undefined names, or other pyflakes-class issues.
2. **Coverage collected but never enforced.** `pytest-cov` is installed and the matrix job uploads `coverage.xml`, but no threshold is applied — coverage could silently regress to zero.

This PR closes both.

## Changes

**Ruff**
- `[tool.ruff]` config: rules `E`/`F`/`W`, with `E501` (line-too-long) disabled because Black owns line length (per ruff's own guidance — enabling it just fights the formatter). `generated/` excluded.
- Scoped to the shipped `lockstep_compiler/` package — the highest-signal target. The package is already clean under this rule set; the only fix needed was one stray trailing-whitespace line.
- `make lint` target + a ruff step in the CI `lint` job (ruff pinned for reproducible results). *(Tests/benchmarks/one-off scripts are left out of the initial scope — they carry benign `sys.path` bootstrap and API-surface-import patterns that would need `# noqa` noise; expanding lint to them can be a follow-up.)*

**Coverage floor**
- New `coverage` CI job runs `make test-cov` with `--cov-fail-under=70`.
- Current package coverage is **~77%**, so the floor has a deliberate ~7-point margin to avoid flaking on platform-conditional code; ratchet it up as coverage grows.
- `make test-cov` is scoped to the package and now emits `coverage.xml` + enforces the floor. `make verify` gains `lint`.

## Notes

No dependency changes — the hashed lockfiles are untouched, so `check-lock-deps` is unaffected (ruff is installed directly in the lint job rather than added to the test extras).

Verified locally: `ruff check lockstep_compiler` clean; full suite passes `--cov-fail-under=70`; mypy unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHd6rPoCoz2gez6kEzje9B)_