### PR TITLE
formatter: preserve comments instead of skipping reformat

### DIFF
--- a/lockstep_compiler/formatter.py
+++ b/lockstep_compiler/formatter.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import bisect
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from antlr4 import CommonTokenStream, InputStream
@@ -18,6 +20,53 @@ except ModuleNotFoundError:
     from generated.parser.LockstepVisitor import LockstepVisitor
 
 from .errors import ParseErrorCollector
+
+
+@dataclass(frozen=True)
+class _Comment:
+    """A single line comment recovered from the HIDDEN token channel."""
+
+    line: int  # 1-based source line the comment appears on
+    text: str  # comment text including the leading `//`, trailing space stripped
+    trailing: bool  # True if code precedes it on the same source line
+
+
+def _extract_comments(stream: CommonTokenStream) -> list[_Comment]:
+    """Recover line comments (dropped to the HIDDEN channel) in source order.
+
+    A comment is classified as *trailing* when a real (default-channel) token
+    occurs earlier on the same line, and *own-line* otherwise. This is enough to
+    place `//` comments correctly because they always run to end-of-line, so a
+    comment is either the whole line's content or the tail of a code line.
+    """
+    comments: list[_Comment] = []
+    last_default_line: int | None = None
+    for token in stream.tokens:
+        if token.type == LockstepLexer.COMMENT:
+            comments.append(
+                _Comment(
+                    line=token.line,
+                    text=token.text.rstrip(),
+                    trailing=last_default_line == token.line,
+                )
+            )
+        elif (
+            token.type != -1
+            and token.channel == LockstepLexer.DEFAULT_TOKEN_CHANNEL
+        ):
+            last_default_line = token.line
+    return comments
+
+
+@dataclass
+class _OutputLine:
+    """One rendered line of code plus the source line it originated from, so
+    comments can be re-attached to the right place after reformatting."""
+
+    depth: int
+    src_line: int
+    text: str
+    is_close: bool = False
 
 
 def _lex_tokens(source: str) -> list[str]:
@@ -102,18 +151,64 @@ class _FormattingVisitor(LockstepVisitor):
         super().__init__()
         self._indent = indent
         self._depth = 0
-        self._lines: list[str] = []
+        self._lines: list[_OutputLine] = []
 
-    def _append(self, text: str):
-        self._lines.append(f"{self._indent * self._depth}{text}")
+    def _append(self, text: str, ctx):
+        self._lines.append(_OutputLine(self._depth, ctx.start.line, text))
 
-    def _open_block(self, prefix: str):
-        self._append(f"{prefix} {{")
+    def _open_block(self, prefix: str, ctx):
+        self._lines.append(_OutputLine(self._depth, ctx.start.line, f"{prefix} {{"))
         self._depth += 1
 
-    def _close_block(self, suffix: str = ""):
+    def _close_block(self, ctx, suffix: str = ""):
         self._depth = max(self._depth - 1, 0)
-        self._append(f"}}{suffix}")
+        self._lines.append(
+            _OutputLine(self._depth, ctx.stop.line, f"}}{suffix}", is_close=True)
+        )
+
+    def render(self, comments: list[_Comment]) -> str:
+        """Render the recorded lines, re-interleaving `comments` by source line.
+
+        Own-line comments are emitted as their own line, indented to match the
+        code that follows them; trailing comments are appended to the code line
+        they sat on. When there are no comments this is identical to a plain
+        indent-and-join of the recorded lines, so comment-free output is
+        unchanged.
+        """
+        own_line = [comment for comment in comments if not comment.trailing]
+        src_lines = [line.src_line for line in self._lines]
+
+        # Attach each trailing comment to the last code line at or before it.
+        trailing: dict[int, list[str]] = {}
+        unplaced: list[str] = []
+        for comment in comments:
+            if not comment.trailing:
+                continue
+            index = bisect.bisect_right(src_lines, comment.line) - 1
+            if index >= 0:
+                trailing.setdefault(index, []).append(comment.text)
+            else:
+                unplaced.append(comment.text)
+
+        out: list[str] = []
+        own_index = 0
+        for record_index, record in enumerate(self._lines):
+            while own_index < len(own_line) and own_line[own_index].line < record.src_line:
+                # A comment sitting just before a closing brace belongs inside
+                # the block that is about to close, so indent one level deeper.
+                comment_depth = record.depth + 1 if record.is_close else record.depth
+                out.append(f"{self._indent * comment_depth}{own_line[own_index].text}")
+                own_index += 1
+            line_text = f"{self._indent * record.depth}{record.text}"
+            if record_index in trailing:
+                line_text = f"{line_text}  {' '.join(trailing[record_index])}"
+            out.append(line_text)
+
+        # Comments after the final construct (or an all-comments file).
+        for comment in own_line[own_index:]:
+            out.append(comment.text)
+        out.extend(unplaced)
+        return "\n".join(out) + "\n"
 
     def _format_context_tokens(self, ctx) -> str:
         stream = ctx.parser.getTokenStream()
@@ -139,7 +234,7 @@ class _FormattingVisitor(LockstepVisitor):
     def visitProgram(self, ctx: LockstepParser.ProgramContext):
         for declaration in ctx.declaration():
             self.visit(declaration)
-        return "\n".join(self._lines) + "\n"
+        return None
 
     def visitDeclaration(self, ctx: LockstepParser.DeclarationContext):
         return self.visitChildren(ctx)
@@ -156,27 +251,27 @@ class _FormattingVisitor(LockstepVisitor):
     def _append_dependency(self, ctx):
         keyword = ctx.getChild(0).getText()
         path = ctx.STRING().getText()
-        self._append(f"{keyword} {path};")
+        self._append(f"{keyword} {path};", ctx)
 
     def visitStructDecl(self, ctx: LockstepParser.StructDeclContext):
-        self._open_block(f"struct {ctx.ID().getText()}")
+        self._open_block(f"struct {ctx.ID().getText()}", ctx)
         for member in ctx.structMember():
             self.visit(member)
-        self._close_block(";")
+        self._close_block(ctx, ";")
 
     def visitStructMember(self, ctx: LockstepParser.StructMemberContext):
-        self._append(f"{self.visit(ctx.typeName())} {ctx.ID().getText()};")
+        self._append(f"{self.visit(ctx.typeName())} {ctx.ID().getText()};", ctx)
 
     def visitPureDecl(self, ctx: LockstepParser.PureDeclContext):
         params = ""
         if ctx.pureParamList() is not None:
             params = self.visit(ctx.pureParamList())
         self._open_block(
-            f"pure {self.visit(ctx.typeName())} {ctx.ID().getText()}({params})"
+            f"pure {self.visit(ctx.typeName())} {ctx.ID().getText()}({params})", ctx
         )
         for statement in ctx.statement():
             self.visit(statement)
-        self._close_block()
+        self._close_block(ctx)
 
     def visitPureParamList(self, ctx: LockstepParser.PureParamListContext):
         params = []
@@ -188,63 +283,68 @@ class _FormattingVisitor(LockstepVisitor):
 
     def visitShaderDecl(self, ctx: LockstepParser.ShaderDeclContext):
         params = self._format_params(ctx.paramList())
-        self._open_block(f"shader {ctx.ID().getText()}({params})")
+        self._open_block(f"shader {ctx.ID().getText()}({params})", ctx)
         for statement in ctx.statement():
             self.visit(statement)
-        self._close_block()
+        self._close_block(ctx)
 
     def visitFilterDecl(self, ctx: LockstepParser.FilterDeclContext):
         params = self._format_params(ctx.paramList())
-        self._open_block(f"filter {ctx.ID().getText()}({params})")
+        self._open_block(f"filter {ctx.ID().getText()}({params})", ctx)
         for statement in ctx.statement():
             self.visit(statement)
-        self._close_block()
+        self._close_block(ctx)
 
     def visitParam(self, ctx: LockstepParser.ParamContext):
         qualifier = ctx.getChild(0).getText()
         return f"{qualifier} {self.visit(ctx.typeName())} {ctx.ID().getText()}"
 
     def visitPipelineDecl(self, ctx: LockstepParser.PipelineDeclContext):
-        self._open_block(f"pipeline {ctx.ID().getText()}")
+        self._open_block(f"pipeline {ctx.ID().getText()}", ctx)
         for member in ctx.pipelineMember():
             self.visit(member)
         self.visit(ctx.bindBlock())
-        self._close_block()
+        self._close_block(ctx)
 
     def visitPipelineMember(self, ctx: LockstepParser.PipelineMemberContext):
         return self.visitChildren(ctx)
 
     def visitStreamDecl(self, ctx: LockstepParser.StreamDeclContext):
         self._append(
-            f"stream<{self.visit(ctx.typeName())},{ctx.INT().getText()}> {ctx.ID().getText()};"
+            f"stream<{self.visit(ctx.typeName())},{ctx.INT().getText()}> {ctx.ID().getText()};",
+            ctx,
         )
 
     def visitAccumDecl(self, ctx: LockstepParser.AccumDeclContext):
-        self._append(f"accumulator<{self.visit(ctx.typeName())}> {ctx.ID().getText()};")
+        self._append(
+            f"accumulator<{self.visit(ctx.typeName())}> {ctx.ID().getText()};", ctx
+        )
 
     def visitUniformDecl(self, ctx: LockstepParser.UniformDeclContext):
         prefix = f"uniform {self.visit(ctx.typeName())} {ctx.ID().getText()}"
         if ctx.expr() is not None:
             prefix = f"{prefix}={self.visit(ctx.expr())}"
-        self._append(f"{prefix};")
+        self._append(f"{prefix};", ctx)
 
     def visitBindBlock(self, ctx: LockstepParser.BindBlockContext):
-        self._open_block("bind")
+        self._open_block("bind", ctx)
         for bind_stmt in ctx.bindStmt():
             self.visit(bind_stmt)
-        self._close_block()
+        self._close_block(ctx)
 
     def visitBindStmt(self, ctx: LockstepParser.BindStmtContext):
         if ctx.foldOperator() is not None:
             self._append(
                 "uniform "
                 f"{self.visit(ctx.typeName())} {ctx.ID(0).getText()}="
-                f"fold {self.visit(ctx.foldOperator())}({ctx.ID(1).getText()});"
+                f"fold {self.visit(ctx.foldOperator())}({ctx.ID(1).getText()});",
+                ctx,
             )
             return
 
         self._append(
-            f"{ctx.ID(0).getText()}={ctx.ID(1).getText()}({self.visit(ctx.argList())});"
+            f"{ctx.ID(0).getText()}={ctx.ID(1).getText()}({self.visit(ctx.argList())});",
+            ctx,
         )
 
     def visitFoldOperator(self, ctx: LockstepParser.FoldOperatorContext):
@@ -264,13 +364,13 @@ class _FormattingVisitor(LockstepVisitor):
         body = " ".join(segments)
         if ctx.expr() is not None:
             body = f"{body}={self.visit(ctx.expr())}"
-        self._append(f"{body};")
+        self._append(f"{body};", ctx)
 
     def visitAssignStmt(self, ctx: LockstepParser.AssignStmtContext):
-        self._append(f"{self.visit(ctx.lvalue())}={self.visit(ctx.expr())};")
+        self._append(f"{self.visit(ctx.lvalue())}={self.visit(ctx.expr())};", ctx)
 
     def visitReturnStmt(self, ctx: LockstepParser.ReturnStmtContext):
-        self._append(f"return {self.visit(ctx.expr())};")
+        self._append(f"return {self.visit(ctx.expr())};", ctx)
 
     def visitExpr(self, ctx: LockstepParser.ExprContext):
         return self.visit(ctx.logicalExpr())
@@ -336,8 +436,7 @@ def format_lockstep_source(source, *, indent="    "):
 
     stream = CommonTokenStream(lexer)
     stream.fill()
-    if any(token.type == LockstepLexer.COMMENT for token in stream.tokens):
-        return source
+    comments = _extract_comments(stream)
 
     parser = LockstepParser(stream)
     parser.removeErrorListeners()
@@ -345,6 +444,14 @@ def format_lockstep_source(source, *, indent="    "):
     tree = parser.program()
 
     if error_listener.errors:
+        # The token-stream fallback cannot safely re-place comments around a
+        # broken parse, so leave a comment-bearing source untouched rather than
+        # dropping its comments; comment-free sources still get best-effort
+        # reformatting.
+        if comments:
+            return source
         return _format_token_stream(source, indent=indent)
 
-    return _FormattingVisitor(indent=indent).visit(tree)
+    visitor = _FormattingVisitor(indent=indent)
+    visitor.visit(tree)
+    return visitor.render(comments)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -51,7 +51,58 @@ def test_lexer_preserves_line_comments_in_token_stream():
     assert comments == ["// keep me"]
 
 
-def test_format_lockstep_source_preserves_comments_by_skipping_reformat():
+def test_format_lockstep_source_preserves_trailing_and_own_line_comments():
+    source = (
+        "// header note\n"
+        "struct Particle{\n"
+        "float pos; // position\n"
+        "float vel;\n"
+        "};\n"
+    )
+
+    assert format_lockstep_source(source) == (
+        "// header note\n"
+        "struct Particle {\n"
+        "    float pos;  // position\n"
+        "    float vel;\n"
+        "};\n"
+    )
+
+
+def test_format_lockstep_source_indents_comment_before_closing_brace():
+    source = "pipeline Main{stream<float,4> s;bind{\n// nothing yet\n}}\n"
+
+    assert format_lockstep_source(source) == (
+        "pipeline Main {\n"
+        "    stream<float,4> s;\n"
+        "    bind {\n"
+        "        // nothing yet\n"
+        "    }\n"
+        "}\n"
+    )
+
+
+def test_format_lockstep_source_is_idempotent_with_comments():
+    source = (
+        "// header note\n"
+        "struct P{\n"
+        "float pos; // position\n"
+        "};\n"
+    )
+
+    once = format_lockstep_source(source)
+    assert format_lockstep_source(once) == once
+
+
+def test_format_lockstep_source_preserves_comment_only_file():
+    source = "// just a comment\n// another\n"
+
+    assert format_lockstep_source(source) == source
+
+
+def test_format_lockstep_source_leaves_invalid_source_with_comments_untouched():
+    # Missing bind block -> parse error; comments can't be safely re-placed, so
+    # the source is returned verbatim rather than dropping the comment.
     source = "pipeline Main{ // keep me\nstream<float,4> s;\n}\n"
 
     assert format_lockstep_source(source) == source


### PR DESCRIPTION
## Summary

`--format` previously **returned the source unchanged whenever a comment was present** (`formatter.py`: `if any(... COMMENT ...): return source`). Both formatting passes drop the HIDDEN-channel comment tokens, so bailing out was the only way to avoid deleting comments — correct, but it meant any file with a single `//` comment got no formatting at all. This is the "comment-preserving formatter" item from `ROADMAP.md` v0.7.0.

This PR makes the AST formatter comment-aware.

## How it works

- Each rendered line now records the **source line** it originated from (`_OutputLine`).
- Comments are recovered from the token stream (`_extract_comments`) and classified as **trailing** (a real token precedes them on the same line) or **own-line**. Since `//` comments always run to end-of-line, those are the only two cases.
- At render time comments are re-interleaved: trailing comments are appended to their code line (`code;  // note`); own-line comments become their own line, indented to match the construct that follows — one level deeper when they sit just before a closing brace, so a comment inside an empty `bind { }` stays inside it.

### Example

```
// header note
struct Particle {
    float pos;  // position
    float vel;
};
pipeline Demo {
    uniform float dt=0.5;  // timestep
    bind {
        // nothing yet
    }
}
```

## Safety

- **Comment-free output is byte-identical** to before (`render` with no comments is a plain indent-and-join), so existing formatter snapshots are unchanged.
- Formatting is **idempotent** with comments (covered by a test).
- On a **parse error**, comments still can't be safely re-placed, so a comment-bearing invalid file is returned verbatim rather than dropping its comments; comment-free invalid files keep the existing best-effort token fallback.

## Tests

Replaced the old "skip reformat" assertion with focused tests: trailing + own-line + leading comments, comment indentation before a closing brace, idempotence, a comment-only file, and the invalid-source passthrough. Full suite + mypy pass; the module is clean under ruff (E/F/W).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHd6rPoCoz2gez6kEzje9B)_