### PR TITLE
docs: apply concise, accurate ROADMAP and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,80 @@
 # Lockstep (Shader-C)
 ![logo.png](logo.png)
 
-**Lockstep** is a data-oriented systems programming language designed for high-throughput, deterministic compute pipelines. It bridges the gap between the productivity of C and the brutal execution efficiency of GPU compute shaders.
+**Lockstep** is a data-oriented systems programming language for high-throughput,
+deterministic compute pipelines — bridging the productivity of C and the
+execution model of GPU compute shaders.
 
-By enforcing a strict **Straight-Line SIMD** execution model and **Static Memory Topology**, Lockstep allows the compiler to generate machine code that is mathematically guaranteed to saturate CPU vector units without the overhead of branch misprediction or cache contention.
+By enforcing **Straight-Line SIMD** execution and a **Static Memory Topology**,
+Lockstep lets the compiler generate machine code built to saturate CPU vector
+units without branch misprediction or cache contention.
 
 ## 1. Core Philosophy
 
-* **Data-Oriented by Design:** Logic is secondary to data flow. Programs are modeled as physical circuits (pipelines) rather than sequences of instructions.
-* **Zero Branching:** Standard control flow (`if`, `for`, `while`) is banned inside compute kernels. Branching is replaced by hardware-native masking and stream-splitting.
-* **Predictable Performance:** No `malloc`, no hidden threads, and no garbage collection. Memory is a static arena provided by the Host.
-* **Deterministic Parallelism:** Race conditions are impossible by construction. State updates are strictly isolated to `out` streams or linear `accumulator` types.
+* **Data-oriented by design.** Programs are modeled as physical circuits
+  (pipelines), not sequences of instructions.
+* **Zero branching.** `if`/`for`/`while` are banned inside kernels; branching is
+  replaced by hardware-native masking and stream-splitting.
+* **Predictable performance.** No `malloc`, no hidden threads, no GC. Memory is a
+  static arena provided by the host.
+* **Deterministic parallelism.** Race conditions are impossible by construction:
+  state updates are isolated to `out` streams or linear `accumulator` types.
 
 ---
 
 ## 2. Language Architecture
 
-### The Pipeline Topology
+### Pipeline topology
 
-A Lockstep program is a Directed Acyclic Graph (DAG) of compute nodes.
+A Lockstep program is a Directed Acyclic Graph (DAG) of compute nodes:
 
-* **`shader`**: A 1-to-1 mapping. Processes one input element and produces one output element.
-* **`filter`**: A 1-to-0/1 mapping. Conditionally passes data to downstream nodes.
-* **`pure`**: A side-effect-free mathematical transform. Strictly inlined.
-* **`pipeline`**: The "circuit board" that binds streams and uniforms to kernels.
+* **`shader`** — 1-to-1: one input element produces one output element.
+* **`filter`** — 1-to-0/1: conditionally passes data downstream.
+* **`pure`** — a side-effect-free transform, strictly inlined.
+* **`pipeline`** — the "circuit board" binding streams and uniforms to kernels.
 
-### The Memory Model
+### Memory model
 
-Lockstep uses a **Host-Owned Static Arena**. The compiler calculates the exact byte-offset for every Struct-of-Arrays (SoA) member at compile-time.
+Lockstep uses a **host-owned static arena**; the compiler computes every
+member's byte offset at compile time.
 
-* **SoA by Default:** Structs are automatically decomposed into parallel primitive arrays to maximize cache line utilization and SIMD width.
-* **Saturated Writes:** To eliminate boundary checks, stream indices use saturation arithmetic. If a stream capacity is exceeded, the final element acts as a "trash can," absorbing further writes without memory corruption or branching.
+* **SoA by default.** Structs are decomposed into parallel primitive arrays (one
+  contiguous array per field) to maximize cache-line and SIMD utilization.
+* **Saturated writes.** Stream indices use saturation arithmetic instead of
+  bounds checks: past capacity, the final element acts as a "trash can" that
+  absorbs writes without corruption or branching.
 
 ---
 
 ## 3. Syntax Guide
 
-### Straight-Line Shaders
+### Straight-line shaders
 
-Since `if/else` is banned, conditional logic is performed using branchless intrinsics like `step`, `mix`, `clamp`, `min`, `max`, `abs`, `sign`, and `smoothstep`.
+With `if`/`else` banned, conditionals use branchless intrinsics —
+`step`, `mix`, `select`, `clamp`, `min`, `max`, `abs`, `sign`, `smoothstep`:
 
 ```c
 shader ApplyPhysics(in Entity ent, out Entity updated, uniform float dt) {
-    // Standard math
     float fall_vy = ent.vy - (9.81 * dt);
     float bounce_vy = -ent.vy * 0.8;
-    
-    // Branchless Branching: step returns 1.0 if ent.y <= 0.0, else 0.0
+
+    // step returns 1.0 if ent.y <= 0.0, else 0.0
     float is_grounded = step(0.0, -ent.y);
-    
+
     // mix(a, b, t) acts as a hardware-level selector
     updated.vy = mix(fall_vy, bounce_vy, is_grounded);
     updated.y = max(ent.y + (updated.vy * dt), 0.0);
 }
-
 ```
 
-### Linear Accumulators
+`select(cond, a, b)` is a branchless typed mux (a `bool` condition and matching
+branch types), complementing the float-interpolating `mix`.
 
-Global reductions (e.g., Total Energy, Max Bounds) are handled via **Linear Types**. Accumulators must be "consumed" by a fold operation, which the compiler lowers into a lock-free parallel reduction tree.
+### Linear accumulators
+
+Global reductions (total energy, bounds, …) use **linear types**. An accumulator
+must be consumed by a `fold`, which the compiler lowers into a parallel reduction
+tree:
 
 ```c
 pipeline Simulation {
@@ -67,297 +83,206 @@ pipeline Simulation {
 
     bind {
         particles = Calculate(particles, energy_sum);
-        // fold sum consumes the linear type and produces a global scalar
+        // fold consumes the linear type and produces a global scalar
         uniform float total_e = fold sum(energy_sum);
     }
 }
-
 ```
 
-### Type System (User-Facing Rules)
+### Type system
 
-Lockstep's semantic validator enforces a strict type system with **no implicit coercions**.
+The semantic validator enforces a **strict type system with no implicit
+coercions**.
 
-#### Primitive types
-
-The currently supported primitive declared types are:
-
-* `int`
-* `uint`
-* `float`
-* `double`
-* `bool`
-* `string`
-
-`uint` uses unsigned integer semantics in code generation; `double` maps to 64-bit floating point. Unknown declared types still produce `LCK310`.
-
-#### Composite/struct type composition
-
-Struct members may use:
-
-* primitives,
-* previously declared struct names, and
-* array suffixes (`T[4]`).
-
-The parser and semantic validator also accept generic-wrapper spelling (`Ctor<T>` / `Ctor<T,4>`, including nested forms) so declarations such as `vector<float,4>` can participate in type checking and arena/header layout. In generated LLVM IR, however, generic-wrapper values are currently lowered as opaque pointers rather than first-class aggregate/vector values. Treat generic wrappers as ABI/layout placeholders, not as kernel-value types for arithmetic, field access, or SIMD computation.
-
-Examples that are supported as declared/layout types:
-
-* `Particle[4]`
-* `vector<float,4>`
-* `matrix<vector<Particle,4>,4>`
-
-Type identity is name-based and exact. Field access chains (`a.b.c`) are valid only when each link resolves to a concrete struct type and an existing field.
-
-#### Type matching and coercion policy
-
-Type checking is strict and explicit:
-
-* No implicit widening or narrowing.
-* No implicit `int`⇄`float` promotion.
-* Assignment, variable initialization, pure-function arguments, pure-function returns, and bind argument/target checks all require exact type equality.
-* Mixed numeric operators (`int` with `float`) without an explicit cast are rejected with `LCK424` (`implicit_numeric_widening`).
-
-When conversion is desired, use an explicit cast.
+* **Primitives:** `int`, `uint`, `float`, `double`, `bool`, `string`. `uint` has
+  unsigned semantics; `double` is 64-bit float. Unknown types produce `LCK310`.
+* **Composites:** struct members may be primitives, previously declared structs,
+  or array suffixes (`T[4]`). Generic-wrapper spellings (`vector<float,4>`,
+  nested `matrix<vector<Particle,4>,4>`) are accepted for type checking and
+  arena/header layout, but are lowered as **opaque pointers** in IR — treat them
+  as ABI/layout placeholders, not as kernel value types for arithmetic, field
+  access, or SIMD. Type identity is name-based and exact; field chains (`a.b.c`)
+  resolve only through concrete struct types.
+* **Coercion:** none implicit — no widening/narrowing, no `int`⇄`float`
+  promotion. Assignments, initializers, `pure` arguments/returns, and bind
+  arguments require exact type equality. Mixed `int`/`float` arithmetic without a
+  cast is rejected with `LCK424`. Use an explicit cast when conversion is wanted.
 
 ---
 
 ## 4. Compiler & Backend
 
-Lockstep targets **LLVM IR** directly to leverage industrial-grade optimization passes.
+Lockstep targets **LLVM IR** directly.
 
-* **Single-arena ABI:** Generated kernels receive a `struct Lockstep_Arena*` and compute byte offsets into that arena. The backend does not currently emit blanket `noalias` decorations for arena-derived pointers, so alias-disambiguation-sensitive optimizations should not be assumed from the arena representation alone.
-* **SSA locals for concrete values:** Local scalar and concrete-struct values are lowered through SSA-friendly LLVM values where possible; arena loads and stores still use byte-addressed offsets for ABI stability.
-* **Manual SIMD lowering:** Stream fusion is vectorized by the backend's fused-vector lowering pass, which strip-mines contiguous stream elements and emits vector loads, stores, arithmetic, and reductions directly. This is separate from relying on LLVM to auto-vectorize scalar loops over the arena.
-* **Fast-Math Reductions:** Reduction loops are emitted with `fast` math flags, permitting LLVM to reassociate floating-point operations into horizontal SIMD shuffles.
+* **Single-arena ABI.** Kernels receive a `struct Lockstep_Arena*` and compute
+  byte offsets into it. The backend does not yet emit blanket `noalias` on
+  arena-derived pointers, so do not assume alias-based optimizations from the
+  arena representation alone (see [ROADMAP.md](ROADMAP.md)).
+* **SSA locals.** Scalar and concrete-struct locals are lowered through
+  SSA-friendly values where possible; arena loads/stores stay byte-addressed for
+  ABI stability.
+* **Manual SIMD lowering.** The fused-vector pass strip-mines contiguous stream
+  elements and emits vector loads, stores, arithmetic, and reductions directly,
+  rather than relying on LLVM auto-vectorization.
+* **Fast-math reductions.** Reduction loops carry `fast` flags so LLVM can
+  reassociate into horizontal SIMD shuffles.
 
 ---
 
 ## 5. Host Integration
 
-The compiler generates a C-compatible header for the Host application (C/C++, Rust, or Zig).
+The compiler emits a C-compatible header for the host (C/C++, Rust, Zig):
 
-1. **Allocate:** Host allocates a `struct Lockstep_Arena` object or a suitably aligned contiguous block of at least `LOCKSTEP_ARENA_BYTES` bytes.
-2. **Prime:** Host writes initial data into the SoA fields and byte offsets provided by the header.
-3. **Tick:** Host calls `Lockstep_Tick(arena)` with a pointer to that arena. There is no separate `Lockstep_BindMemory` entry point.
+1. **Allocate** a `struct Lockstep_Arena` (or an aligned block of at least
+   `LOCKSTEP_ARENA_BYTES`).
+2. **Prime** initial data into the SoA fields at the header's byte offsets.
+3. **Tick** by calling `Lockstep_Tick(arena)`. There is no separate
+   `Lockstep_BindMemory` entry point.
 
-See [`examples/`](examples/) for a minimal end-to-end host app in C (`examples/minimal_host.c`) that includes a generated header, allocates arena memory, primes initial data, and calls `Lockstep_Tick`.
+See [`examples/minimal_host.c`](examples/) for a complete end-to-end host app.
 
 ---
 
-## 6. Compiler Frontend Usage
+## 6. CLI Usage
 
-Install in editable mode to enable the packaged CLI entrypoint:
+Install in editable mode to get the `lockstepc` entry point:
 
 ```bash
 pip install -e .
-lockstepc path/to/program.lock
-# or read source from stdin
-cat path/to/program.lock | lockstepc --dump
-# canonical straight-line formatting
-lockstepc path/to/program.lock --format
-# emit LLVM IR
-lockstepc path/to/program.lock --emit-ir
-# emit C host header
-lockstepc path/to/program.lock --emit-header
-# print compiler version
+
+lockstepc program.lock                 # compile
+cat program.lock | lockstepc --dump    # read stdin, dump entities as JSON
+lockstepc program.lock --format        # canonical straight-line formatting
+lockstepc program.lock --emit-ir       # emit LLVM IR
+lockstepc program.lock --emit-header   # emit C host header
+lockstepc program.lock --simulate      # validate wiring/cardinality
 lockstepc --version
 ```
 
-### Reproducible dependency installs (locked + hashed)
+### Pipeline simulation
 
-Lockstep now tracks pinned lockfiles generated from `pyproject.toml` using `pip-tools`:
+`--simulate` validates pipeline wiring and cardinality before backend
+generation. Provide inputs with `--simulate-input path.json`:
 
-* `requirements.lock` (runtime dependencies)
-* `requirements-test.lock` (runtime + `test` optional group)
-* `requirements-lsp.lock` (runtime + `lsp` optional group)
-
-Install using hash verification:
-
-```bash
-python -m pip install --require-hashes -r requirements.lock
-python -m pip install --require-hashes -r requirements-test.lock
-python -m pip install --require-hashes -r requirements-lsp.lock
+```json
+{
+  "streams": { "raw_positions": [{"id": 1}, {"id": 2, "_keep": false}] },
+  "accumulators": { "energy": [0.5, 1.5] }
+}
 ```
 
-Refresh lockfiles after dependency changes:
+Output includes per-route `input_count`/`output_count`, updated stream
+snapshots, accumulator contents, and folded uniforms. Folds (`sum`/`avg`) run in
+deterministic pure-Python mode by default (including mixed `int`/`float`/`bool`
+accumulators). An opt-in LLVM-backed reduction runs when `LOCKSTEP_SIM_USE_LLVM=1`
+(or `use_llvm_runtime=True`); it executes out of process under POSIX resource
+limits and reports an explicit error if `clang`/`lli` is missing rather than
+silently falling back.
 
-```bash
-python -m pip install --upgrade pip pip-tools
-make lock-deps
-```
-
-CI enforces lockfile freshness (`make check-lock-deps`) and uses `--require-hashes` during installation so builds fail if hashes do not match.
-
-### Codegen snapshot tests
-
-`tests/test_golden_ir.py` pins the exact LLVM IR and generated C header for a curated corpus (`tests/golden/programs/*.lock`) that exercises the main lowering paths — plain shaders, accumulators with `fold`, filters, and fused accumulator pipelines. Any codegen change that alters the output fails the test with a unified diff, so ABI or lowering changes are reviewed deliberately. The snapshots are deterministic and target-pinned, so they are stable across the CI matrix. When a change is intentional, regenerate and review the diff:
-
-```bash
-LOCKSTEP_UPDATE_GOLDEN=1 pytest tests/test_golden_ir.py
-# or:
-python tests/golden/regenerate.py
-```
-
-### Benchmarking and regression checks
-
-Real measured results from every harness below — captured on a documented host — are published in [`benchmarks/RESULTS.md`](benchmarks/RESULTS.md).
-
-Generate benchmark output locally:
-
-```bash
-make bench
-```
-
-This writes `benchmark-results.json` in the repository root. The CI workflow uploads this file as an artifact for every pull-request benchmark run.
-
-Compare current results against the checked-in baseline with a 10% slowdown threshold:
-
-```bash
-make bench-check
-```
-
-Baseline files live under `benchmarks/baselines/`. The default CI gate uses `benchmarks/baselines/default.json` and tracks KPI metrics listed in that file's `kpis` array.
-
-To update the baseline:
-
-1. Run `make bench` on a representative machine/state.
-2. Review `benchmark-results.json` for outliers.
-3. Copy accepted values into `benchmarks/baselines/default.json`.
-4. Re-run `make bench-check` and commit both the baseline update and rationale in your PR.
-
-The regression check currently runs in **advisory mode** on pull requests (warning-only via `continue-on-error`). Once enough benchmark history is collected, switch it to required by removing `continue-on-error: true` in `.github/workflows/tests.yml` and enabling branch protection for the benchmark job.
-### Benchmarking compiler and simulation latency
-
-Install test dependencies (includes `pytest-benchmark`) and run:
-
-```bash
-python -m pip install --require-hashes -r requirements-test.lock
-make bench
-```
-
-`make bench` executes `pytest tests/benchmarks -q --benchmark-only` and prints a benchmark summary table with per-test timing statistics (for example `min`, `max`, `mean`, and iteration counts). The benchmark suite uses fixed seeds and deterministic row counts (`1k`, `10k`, `100k`) so historical comparisons remain stable across runs.
-
-### Native execution benchmarks (compiled code throughput)
-
-The harnesses above all time the Python frontend (parse + in-Python simulate). To measure the code Lockstep actually ships, `benchmarks/native/` compiles each workload's generated LLVM IR with `clang -O3 -march=native`, links a generated host driver that calls `Lockstep_Tick` in a timed loop over a full arena, and reports real execution throughput:
-
-```bash
-make bench-native
-# or, directly:
-python benchmarks/native/run_native.py
-python benchmarks/native/run_native.py --workload particle_energy --iterations 5000 --json
-```
-
-Reported metrics are per-tick latency (`per_tick_us`), stream throughput (`mrows_per_sec`), arena bandwidth (`arena_gib_per_sec`), and a deterministic output `checksum`. This requires an LLVM/clang toolchain on `PATH`; the harness exits with a clear message if `clang` is unavailable. See [`benchmarks/native/README.md`](benchmarks/native/README.md) for details. Absolute numbers are host-dependent, so treat them as relative/regression signals.
-
-On pull requests, the `native-benchmark` CI job runs the harness and then gates its **deterministic** invariants — arena ABI (`arena_bytes`, `rows_per_tick`) and output `checksum` — against the checked-in baseline `benchmarks/baselines/native.json` via `make bench-native-check`. These are hardware-independent, so a drift is a real codegen ABI/correctness regression and fails the job (unlike the frontend throughput gate, which is advisory). Throughput is *not* gated — it is host-dependent and too noisy on shared runners — but the full JSON report is uploaded as a CI artifact for trend tracking. When a codegen change intentionally moves the invariants, regenerate the baseline and review the diff:
-
-```bash
-python benchmarks/native/run_native.py --output native-results.json
-python scripts/check_native_benchmark.py --current native-results.json --update
-```
-
-To quantify *why* Lockstep uses a Struct-of-Arrays memory layout, `make bench-soa` (or `python benchmarks/native/soa_vs_aos.py`) runs the same branchless particle kernel over identical data in SoA and Array-of-Structs layouts across a range of sizes and reports the throughput ratio. Both layouts compute identical results, so the difference is purely layout: SoA wins on vectorization (contiguous SIMD loads) and, for kernels that read a subset of fields, on bandwidth.
-
-To measure the throughput lost when a multi-stage pipeline is not fused, `make bench-fusion` (or `python benchmarks/native/fusion_probe.py`) compares the per-stage loops against a single fused loop over the same computation. Codegen now fuses accumulator stages (the `accum` restriction on fusion has been lifted); the remaining case codegen still lowers per stage is a group containing a **filter** — see [`benchmarks/native/README.md`](benchmarks/native/README.md).
-
-Programmatic frontend usage is available from `lockstep_compiler`:
+### Programmatic API
 
 ```python
 from lockstep_compiler import LockstepCompileResult, compile_lockstep
 
 result: LockstepCompileResult = compile_lockstep(source_code, verbose=True)
+# result.parse_tree, result.entities, result.diagnostics
 ```
-
-`compile_lockstep(...)` returns a `LockstepCompileResult` containing:
-
-* `parse_tree`: ANTLR parse tree for the source.
-* `entities`: extracted frontend entities (`structs`, `shaders`, `streams`, `accumulators`).
-* `diagnostics`: first-class compiler diagnostics (`LockstepDiagnostic`) for non-fatal observations.
-
-### Pipeline Simulation (small datasets)
-
-Use the CLI simulator to validate pipeline wiring/cardinality before LLVM backend generation:
-
-```bash
-lockstepc path/to/program.lock --simulate
-lockstepc path/to/program.lock --simulate --simulate-input path/to/input.json
-```
-
-`--simulate-input` expects JSON with optional `streams` and `accumulators` maps, for example:
-
-```json
-{
-  "streams": {
-    "raw_positions": [{"id": 1}, {"id": 2, "_keep": false}]
-  },
-  "accumulators": {
-    "energy": [0.5, 1.5]
-  }
-}
-```
-
-Simulation output includes per-route `input_count`/`output_count`, updated stream snapshots, accumulator contents, and folded uniform values.
-
-By default, fold reductions (`sum` / `avg`) run in deterministic pure-Python mode, including mixed numeric accumulators (`int`, `float`, `bool`) with stable coercion behavior. Optional LLVM-backed reduction remains available as an opt-in for experimentation/perf checks by setting `LOCKSTEP_SIM_USE_LLVM=1` (or passing `use_llvm_runtime=True` in API calls). If opt-in LLVM execution fails (for example missing `clang`/`lli`), simulation reports an explicit runtime error instead of silently falling back.
-
-Generated C headers include `Lockstep_SaturatedWriteIndex(...)` plus per-stream `LOCKSTEP_CAPACITY_STREAM_<NAME>` macros. Define `LOCKSTEP_DEBUG_SATURATED_WRITES` before including the header to log whenever a saturated write falls back to the final index. Override `LOCKSTEP_SATURATED_WRITE_LOG(...)` to integrate with custom telemetry.
-
-### Diagnostic Shape
-
-Each diagnostic includes:
-
-* `severity` (`"info"`, `"warning"`, or `"error"`)
-* `code` (stable diagnostic identifier such as `LCK101`, `LCK201`)
-* `message`
-* `line`
-* `column`
-* optional `hint`
-
-### Behavior
-
-* **Non-fatal observations** (for example empty `bind` blocks, duplicate declarations, or unreachable statements after a pure-function return) are returned in `LockstepCompileResult.diagnostics` and compilation still succeeds.
-* **Pure function return enforcement** is semantic and strict:
-  * `LCK413` (`error`) is emitted when a `pure` function body has no `return` statement.
-  * `LCK414` (`warning`) is emitted when a `pure` function body contains multiple `return` statements.
-  * `LCK415` (`warning`) is emitted for statements that appear after the first `return` in a `pure` function body.
-  * `LCK418` (`error`) is emitted when a pure `return` expression type does not match the declared return type.
-* **Type-check mismatches** each have distinct diagnostic codes:
-  * `LCK412` (`error`) is emitted for pure-function argument type mismatches.
-  * `LCK416` (`error`) is emitted for variable initializer type mismatches during AST semantic validation.
-  * `LCK417` (`error`) is emitted for assignment type mismatches during AST semantic validation.
-  * `LCK424` (`error`) is emitted when arithmetic mixes `int` and `float` operands without an explicit cast.
-* **Fatal parse errors** still raise `LockstepCompileError`.
-  * `LockstepCompileError.errors` contains parse diagnostics.
-  * `LockstepCompileError.diagnostics` mirrors available pre-failure diagnostic context when parse fails.
 
 ---
 
-## 7. Regenerating parser
+## 7. Diagnostics
 
-Run the project-native generator target:
+Each diagnostic carries `severity` (`info`/`warning`/`error`), a stable `code`
+(e.g. `LCK101`), a `message`, `line`, `column`, and an optional `hint`.
+
+* **Non-fatal observations** (empty `bind` blocks, duplicate declarations,
+  unreachable statements after a `return`) are returned in
+  `LockstepCompileResult.diagnostics`; compilation still succeeds.
+* **`pure` return rules:** `LCK413` (no `return`), `LCK414` (multiple returns),
+  `LCK415` (statements after the first return), `LCK418` (return type mismatch).
+* **Type mismatches:** `LCK412` (pure-arg), `LCK416` (initializer), `LCK417`
+  (assignment), `LCK424` (mixed `int`/`float` without a cast).
+* **Fatal parse errors** raise `LockstepCompileError` (`.errors` holds parse
+  diagnostics; `.diagnostics` mirrors pre-failure context).
+
+Generated headers expose `Lockstep_SaturatedWriteIndex(...)` and per-stream
+`LOCKSTEP_CAPACITY_STREAM_<NAME>` macros. Define
+`LOCKSTEP_DEBUG_SATURATED_WRITES` to log saturated writes, and override
+`LOCKSTEP_SATURATED_WRITE_LOG(...)` to route them to custom telemetry.
+
+---
+
+## 8. Development
+
+### Dependencies (locked + hashed)
+
+Pinned lockfiles are generated from `pyproject.toml` with
+[`uv`](https://github.com/astral-sh/uv): `requirements.lock` (runtime),
+`requirements-test.lock` (+ `test`), `requirements-lsp.lock` (+ `lsp`). Install
+and refresh with:
 
 ```bash
-make generate-parser
+python -m pip install --require-hashes -r requirements-test.lock
+make lock-deps        # regenerate after changing dependencies
 ```
 
-Generated Python parser files are emitted to `generated/parser/` and committed to source control. CI enforces freshness via `make check-generated-parser`, which regenerates and fails when tracked generated files are stale.
+CI enforces freshness (`make check-lock-deps`) and installs with
+`--require-hashes`.
 
-## 8. Language Server Protocol (LSP)
+### Tests, types, and lint
 
-Lockstep now ships an opt-in LSP server so editors can surface compiler diagnostics in real time and provide semantic assistance while authoring pipelines.
+```bash
+make verify           # lint + tests + mypy
+make test-cov         # tests with a coverage floor
+```
+
+`tests/test_golden_ir.py` pins the exact LLVM IR and C header for a curated
+corpus (`tests/golden/programs/*.lock`) covering shaders, folds, filters, and
+fused pipelines; any codegen change surfaces as a reviewable diff. Regenerate
+intentional changes with `LOCKSTEP_UPDATE_GOLDEN=1 pytest tests/test_golden_ir.py`
+(or `python tests/golden/regenerate.py`).
+
+### Benchmarking
+
+Measured results for every harness are published in
+[`benchmarks/RESULTS.md`](benchmarks/RESULTS.md). Absolute numbers are
+host-dependent — treat them as regression signals.
+
+| Target | Measures |
+| --- | --- |
+| `make bench` | Frontend (parse + Python simulate) latency; writes `benchmark-results.json` |
+| `make bench-check` | Frontend results vs. `benchmarks/baselines/default.json` (10% threshold, advisory) |
+| `make bench-native` | Real throughput of `clang -O3` compiled code calling `Lockstep_Tick` |
+| `make bench-soa` | SoA vs. AoS throughput for the same kernel |
+| `make bench-fusion` | Fused vs. per-stage loop throughput |
+
+On pull requests, CI gates the **deterministic** native invariants (arena ABI +
+output `checksum`) against `benchmarks/baselines/native.json` — a drift is a real
+codegen regression. Throughput is host-dependent and reported as an artifact, not
+gated. See [`benchmarks/native/README.md`](benchmarks/native/README.md) for
+details and baseline-update steps.
+
+### Regenerating the parser
+
+```bash
+make generate-parser        # emits generated/parser/, committed to the repo
+```
+
+CI enforces freshness via `make check-generated-parser`.
+
+---
+
+## 9. Language Server (LSP)
+
+An opt-in LSP server surfaces compiler diagnostics live and provides semantic
+assistance:
 
 ```bash
 pip install -e .[lsp]
 lockstep-lsp
 ```
 
-Current capabilities:
-
-* **Live diagnostics:** Mirrors compiler parse/semantic diagnostics via `textDocument/publishDiagnostics`.
-* **Go to Definition for struct members:** Resolves `foo.bar` member access back to the `struct` field declaration when the variable type can be inferred.
-* **Hover type info:** Shows inferred type annotations on variables, struct fields, shader names, and pure function names.
-* **Bind-route autocompletion:** Suggests existing `bind` routes and callable shader/pure symbols from the current file.
-
-The server communicates over stdio and is compatible with standard editor LSP client configuration.
+Capabilities: live diagnostics (`textDocument/publishDiagnostics`), go-to-
+definition for struct members, hover type info (variables, fields, shader/pure
+names), and bind-route / symbol autocompletion. The server speaks stdio and
+works with standard editor LSP clients.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,215 +1,92 @@
-# Lockstep Roadmap — v0.1.0 → v1.0.0
-
-This document describes the planned evolution of the Lockstep compiler, language, and toolchain from the current v0.1.0 release through a stable v1.0.0. Each milestone builds on the previous one, and the ordering reflects real dependency chains in the codebase: internal representation cleanup enables backend improvements, which enable runtime features, which enable the stability guarantees required for a 1.0 release.
-
-The scope of each milestone is deliberately conservative. Lockstep is a single-maintainer project and the milestones are sized to be individually shippable without leaving the project in a half-migrated state.
-
----
-
-## Delivery status
-
-Development has outpaced the milestone prose below: a number of features
-originally planned for v0.3.0–v0.6.0 already ship in the current tree. This
-section reconciles the plan with reality so contributors don't re-implement
-delivered work. Each item links to the code that provides it. The per-milestone
-narrative that follows is preserved as the original plan of record; treat this
-table as the authoritative status.
-
-| Feature | Planned in | Status | Where |
-| --- | --- | --- | --- |
-| `uint` / `double` as first-class declared types | v0.3.0 | ✅ Delivered | `semantic_validator.py` numeric type set; `codegen.py` `_PRIMITIVE_TYPE_MAP` |
-| Semantic validator on the typed AST (non-expression + expression paths) | v0.2.0–v0.3.0 | ✅ Delivered | `semantic_validator.py`; `tests/test_semantic_validator_ast_path.py` |
-| Parameterized SIMD width (`--target-width`, `LOCKSTEP_SIMD_WIDTH`) | v0.4.0 | ✅ Delivered | `codegen.py`, `c_header.py`; `tests/test_target_width_execution.py` |
-| Out-of-process simulator reduction execution | v0.4.0 | ✅ Delivered | `simulator.py` subprocess path; `SECURITY.md` §"Pipeline simulator" |
-| Parser input-complexity limits (size / nesting / parse timeout) | v0.4.0 | ✅ Delivered | `compiler.py` `FrontendLimits`; `cli.py` `--max-source-bytes`, `--max-expr-nesting`, `--parse-timeout-ms` |
-| Arena size overflow checking + `static_assert` in the C header (`LCK502`) | v0.4.0 | ✅ Delivered | `arena_layout.py`, `c_header.py` |
-| SoA decomposition in the arena layout | v0.5.0 | ✅ Delivered | `arena_layout.py` `_flatten_type_leaves` / `_build_layout_from_bindings` |
-| Single-arena-pointer `Lockstep_Tick` ABI | v0.5.0 | ✅ Delivered | `codegen.py`; `examples/minimal_host.c` |
-| `select` expression (branchless typed mux) | v0.6.0 | ✅ Delivered | `codegen.py`, `semantic_validator.py`, `simulator.py` |
-| `import` / `#include` resolution (with root sandboxing + circular detection) | v0.6.0 | ✅ Delivered | `compiler.py` `_resolve_dependency_sources` |
-| Benchmark suite (frontend + native + SoA-vs-AoS + fusion) | v0.8.0 | ✅ Delivered | `benchmarks/`, `benchmarks/RESULTS.md` |
-| Dependency pinning with SHA-256 hash verification | v0.9.0 | ✅ Delivered | `requirements*.lock`, `make check-lock-deps` |
-| Comment-preserving formatter | v0.7.0 | ⏳ Planned | `formatter.py` still returns source unchanged when comments are present |
-| Formal `noalias` correctness proof | v0.8.0 | ⏳ Planned | backend does not yet emit `noalias` on arena pointers |
-| Grammar-aware fuzz testing | v0.8.0 | 🚧 Partial | property-based generators exist (`tests/test_property_program_generators.py`); no dedicated fuzz target yet |
-| LSP workspace-wide diagnostics / rename / `--visualize` | v0.7.0 | ⏳ Planned | LSP ships single-file diagnostics, hover, go-to-def, completion |
-
-The milestone sections below retain their original text. Items marked ✅ above
-have already landed and should be read as historical context rather than
-outstanding work.
-
----
-
-## v0.2.0 — Internal Representation Consolidation
-
-The central goal of v0.2.0 is to eliminate the dual AST / entity-dict representation that currently threads through the compiler pipeline. Today, `emit_llvm_ir`, `emit_c_header`, and the simulator all accept `AstProgram | dict[str, Any]`, with normalization shims (`_normalize_codegen_input`, `_normalize_structs`) bridging the gap. The typed `AstProgram` is already the primary path; v0.2.0 makes it the only path.
-
-### Single-source-of-truth AST
-
-The `AstProgram` frozen-dataclass tree becomes the sole internal representation passed between compiler phases. The entity dict format is retained exclusively as a serialization format for `--dump` JSON output, produced at the CLI boundary by `ast_to_entities` rather than consumed internally. The `emit_llvm_ir` and `emit_c_header` functions are refactored to accept `AstProgram` only, removing the `AstProgram | dict[str, Any]` union signatures and the associated normalization code.
-
-### Semantic validator migration (phase 1)
-
-The semantic validator begins its migration from operating on ANTLR parse-tree context nodes to operating on the typed AST. In v0.2.0 the scope is limited to the non-expression checks: struct declarations, kernel signatures, pipeline resource declarations, bind-route validation, and fold semantics. These checks are straightforward to rewrite against `AstStructDecl`, `AstKernelDecl`, `AstPipelineDecl`, and `AstBindRoute` because they involve simple name/type lookups rather than recursive expression traversal. The expression type resolver (`_resolve_expr_type`) remains parse-tree-based in this release.
-
-### Debug visitor retirement
-
-The legacy `build_debug_visitor` code path is removed from the compilation pipeline. It remains available as a standalone diagnostic tool (the `[Shader Kernel]` / `[Pipeline Topology]` pretty-printer), but the compiler no longer falls back to it when the AST builder succeeds. The `except TypeError` fallback in `_compile_lockstep_with_dependencies` is narrowed further or removed entirely once all test doubles are updated to work with the typed AST path.
-
-### Deprecation of string-based `body` fields
-
-The entity dict's `body` field (which contains statement text like `"new_pos.x = pos.x;"`) is marked as deprecated in the `--dump` output. The `body_ast` field containing typed `AstStatement` objects becomes the canonical representation. Downstream consumers (the simulator, the codegen) already require `body_ast`; this change makes the deprecation explicit and removes the `_statement_to_text` serialization from the hot path.
-
----
-
-## v0.3.0 — Semantic Validator Completion and Expression Type System
-
-### Expression type resolver on typed AST
-
-The remaining half of the semantic validator migration: `_resolve_expr_type` is rewritten to operate on the `AstExpr` discriminated union (`AstExprLiteral | AstExprVar | AstExprUnary | AstExprBinary | AstExprCall | AstExprCast`) using `isinstance` dispatch. This eliminates the `hasattr(ctx, 'mulExpr')` / `hasattr(ctx, 'bitwiseOrExpr')` pattern-matching on ANTLR context shapes, roughly halving the validator's line count and making it testable without constructing fake parse-tree nodes.
-
-### Explicit local variable declarations
-
-Local variable declarations remain aligned with the grammar's `varDecl: typeName ID ('=' expr)? ';';` rule: every local declaration carries an explicit type annotation, and initializers are validated against that declared type. Editor tooling may still surface inferred hover information for already-declared variables, but the core language does not accept untyped local allocations.
-
-### `uint` and `double` as first-class declared types
-
-The primitive type set is expanded from `{int, float, bool, string}` to include `uint` and `double`. The codegen already has `_PRIMITIVE_TYPE_MAP` entries for both; the change is in the semantic validator's `_primitive_types` set and the README's type system documentation. The `uint` type maps to `i32` (unsigned semantics enforced by using `udiv`/`urem`/`icmp unsigned` in the codegen rather than the signed variants). The `double` type maps to `f64` and participates in the same strict-matching rules as `float` — no implicit `float`↔`double` promotion.
-
-### Diagnostic catalog
-
-A machine-readable diagnostic catalog is generated from `SEMANTIC_DIAGNOSTIC_CODES` and shipped as part of the package. Each entry includes the code, default severity, message template, and a prose explanation of what the diagnostic means and how to fix it. This catalog is referenced by the LSP server's hover provider (showing diagnostic explanations inline) and published as a section of the README or a standalone `DIAGNOSTICS.md`.
-
----
-
-## v0.4.0 — Backend Hardening and Target Flexibility
-
-### Parameterized SIMD width
-
-The hardcoded `simd_width = 8` in `codegen.py` is replaced by a target-dependent parameter. The compiler accepts a `--target-width` CLI flag (defaulting to 8 for AVX2) and the codegen uses it for vector splat construction, reduction intrinsic selection, and fold loop trip counts. The C header gains a `LOCKSTEP_SIMD_WIDTH` macro so the host application can query the compile-time vector width.
-
-### Sandboxed JIT execution for the simulator
-
-The in-process MCJIT execution path in `simulator.py` is replaced by out-of-process compilation. The simulator writes LLVM IR to a temporary file, invokes `llc` + `clang` (or a bundled `lli`) as a subprocess to compile and execute the fold reduction, and reads the result back via stdout. This eliminates the highest-severity security risk identified in `SECURITY.md` (in-process native code execution with no sandboxing) and removes the process-global `@lru_cache` on the execution engine.
-
-### Input complexity limits for the parser
-
-The parser frontend enforces configurable limits on input size (maximum file size in bytes), expression nesting depth (maximum recursive descent depth), and parse time budget (wall-clock timeout). These limits are documented in `SECURITY.md` and configurable via CLI flags (`--max-file-size`, `--max-nesting-depth`, `--parse-timeout`). The defaults are generous enough to never trigger on real programs but prevent denial-of-service from pathological input.
-
-### Arena size overflow checking in the C header
-
-The `emit_c_header` arena byte-offset computation validates that the cumulative size does not overflow a 64-bit unsigned integer. If the computed arena size exceeds `SIZE_MAX` (or a configurable limit), the compiler emits a diagnostic (`LCK502`) and refuses to generate the header. The generated header also includes a `_Static_assert` (C11) or `static_assert` (C++11) that `LOCKSTEP_ARENA_BYTES` fits in `size_t` on the target platform.
-
----
-
-## v0.5.0 — Runtime and Host Integration
-
-### Generated `Lockstep_Tick` implementation in LLVM IR
-
-The `Lockstep_Tick` function currently emits a loop skeleton that loads/stores arena fields by pointer argument. In v0.5.0, the tick function is extended to operate on the `Lockstep_Arena` struct directly (accepting a single `struct Lockstep_Arena*` parameter), with correct GEP-based field access using the arena layout computed at compile time. This makes the generated IR directly compilable to a shared library or object file that a host application can link against, completing the host integration story started in `examples/`.
-
-### SoA decomposition in the arena layout
-
-The C header and LLVM IR arena layout are extended to support Struct-of-Arrays decomposition. When a stream is declared as `stream<Particle, 1000>` and `Particle` has fields `{float x; float y; float z;}`, the arena allocates three contiguous `float[1000]` arrays rather than one `Particle[1000]` array. The header emits per-field offset macros (`LOCKSTEP_OFFSET_STREAM_PARTICLES_X`, etc.) and the tick function uses the decomposed layout for SIMD-friendly access patterns. This delivers on the "SoA by Default" promise in the README.
-
-### Stream capacity as a compile-time arena dimension
-
-Stream capacities are promoted from source-level constants to first-class arena dimensions. The generated header and tick function parameterize over capacity so that a single compiled pipeline can be instantiated with different stream sizes at host bind time. The `Lockstep_BindMemory` function signature gains a capacity table argument, and the saturated write index function uses the runtime capacity rather than the compile-time constant.
-
----
-
-## v0.6.0 — Language Features for Real Workloads
-
-### `select` expression (branchless ternary)
-
-A `select(condition, true_value, false_value)` built-in is added as a first-class expression form. Unlike `mix` (which interpolates), `select` performs a bitwise mux: the condition must be `bool`, and the true/false branches must have matching types. The codegen lowers `select` to LLVM's `select` instruction, which is a single-cycle operation on all modern SIMD targets. This fills the gap between `step`/`mix` (which require float operands) and the need for branchless integer/struct selection.
-
-### Multi-stage pipeline composition
-
-Pipelines can reference other pipelines' output streams as input streams, enabling multi-stage DAG composition without manually redeclaring stream types and capacities. The compiler validates cross-pipeline type compatibility and generates a combined arena layout that encompasses all stages. The `Lockstep_Tick` function executes stages in topological order.
-
-### `import` resolution
-
-The `import "path/to/file.lock"` and `#include "path/to/file.lock"` declarations, which currently parse but are not resolved, are connected to a file resolver. The compiler reads the referenced file, prepends it to the compilation unit (similar to the existing `--lib` mechanism), and remaps diagnostics to the correct source file. Circular imports are detected and rejected with a dedicated diagnostic code.
-
----
-
-## v0.7.0 — LSP and Developer Experience
-
-### Comment-preserving formatter
-
-The `--format` flag is extended to preserve comments in their original positions. The formatter maintains a parallel token stream (including `HIDDEN`-channel comment tokens) and interleaves them with the reformatted output. This removes the current behavior of returning source unchanged when comments are present, which is correct but unhelpful.
-
-### LSP workspace-wide diagnostics
-
-The LSP server gains multi-file awareness. When a `.lock` file is opened, the server resolves its `import` declarations and validates the transitive closure of referenced files. Diagnostics from imported files are published to the editor, and go-to-definition works across file boundaries.
-
-### LSP rename support
-
-The LSP server supports `textDocument/rename` for struct names, field names, shader/filter/pure function names, and pipeline resource names. The rename operation updates all references across the workspace, including bind-route arguments and type annotations.
-
-### Interactive pipeline visualizer
-
-A `--visualize` CLI flag emits a self-contained HTML file containing a D3.js-based interactive DAG visualization of the pipeline topology. Nodes represent shaders/filters, edges represent stream dataflow, and the visualization shows stream capacities, accumulator types, and fold reduction targets. This is a developer tool for understanding complex pipeline topologies.
-
----
-
-## v0.8.0 — Performance and Correctness Verification
-
-### Formal `noalias` correctness proof
-
-The `noalias` annotation on all arena pointer parameters in the generated LLVM IR is formally verified to be sound. The proof demonstrates that the Lockstep memory model (static arena, no user-controlled pointers, SoA decomposition with disjoint field arrays, saturated write indices) guarantees that no two pointer parameters in `Lockstep_Tick` can alias. The proof is documented in a standalone `PROOFS.md` and referenced from `SECURITY.md`.
-
-### Benchmark suite
-
-A benchmark suite is added that compiles and executes representative Lockstep programs (particle simulation, signal processing, collision detection) on multiple targets (AVX2, AVX-512, ARM NEON via cross-compilation) and reports throughput in elements/second. The benchmarks run in CI on tagged releases and publish results to a tracking dashboard. This provides empirical evidence for the "mathematically guaranteed to saturate CPU vector units" claim in the README.
-
-### Fuzz testing for the parser and codegen
-
-The parser and codegen are fuzz-tested using a grammar-aware fuzzer that generates syntactically valid but semantically adversarial Lockstep programs. The fuzzer targets memory safety (no crashes, no undefined behavior in the Python compiler process), diagnostic completeness (every invalid program produces at least one diagnostic), and IR validity (every generated LLVM IR module passes `llvm-as` verification). Fuzz findings are triaged and fixed before v1.0.0.
-
----
-
-## v0.9.0 — Stability and API Freeze
-
-### Public API surface declaration
-
-The `lockstep_compiler` package declares its public API surface explicitly. `__init__.py` exports only the stable symbols, and all internal modules are prefixed with `_` or documented as unstable. The `compile_lockstep` function signature, the `LockstepCompileResult` dataclass, the `LockstepDiagnostic` dataclass, and the diagnostic code catalog are frozen — no breaking changes to these interfaces after v0.9.0.
-
-### Grammar freeze
-
-The `Lockstep.g4` grammar is frozen. No new keywords, no new expression forms, and no changes to the precedence table after v0.9.0. The grammar is versioned independently of the compiler, and the version is embedded in the generated parser files so that the compiler can detect grammar/parser version mismatches.
-
-### Dependency pinning and hash verification
-
-All runtime dependencies (`antlr4-python3-runtime`, `llvmlite`) and optional dependencies (`pygls`, `lsprotocol`) are pinned to exact versions with SHA-256 hash verification in a lockfile. The CI pipeline verifies that the lockfile is fresh and that no dependency has been tampered with. Dependabot (or equivalent) is configured for automated vulnerability scanning.
-
-### Migration guide
-
-A `MIGRATING.md` document describes all breaking changes from v0.1.0 through v0.9.0, with before/after code examples and automated fixup scripts where feasible. The guide covers entity dict format changes, removed CLI flags, renamed diagnostic codes, and any grammar additions that changed the meaning of previously valid programs.
-
----
-
-## v1.0.0 — Stable Release
-
-The v1.0.0 release is defined by three properties.
-
-First, the compiler is correct: every valid Lockstep program produces LLVM IR that, when compiled and linked with the generated C header and a conforming host application, executes with the same observable behavior as the pipeline simulator. The `noalias` proof, the fuzz testing results, and the benchmark suite provide evidence for this claim.
-
-Second, the interfaces are stable: the `compile_lockstep` API, the `LockstepCompileResult` shape, the diagnostic code catalog, the grammar, the C header ABI, and the `Lockstep_Tick` calling convention are all frozen and covered by semantic versioning guarantees. Breaking changes after v1.0.0 require a major version bump.
-
-Third, the toolchain is complete: the CLI compiler, the pipeline simulator, the LSP server, the source formatter, the C header generator, and the LLVM IR backend all work together to support the full development lifecycle of a Lockstep program, from authoring through validation through compilation through host integration.
-
----
+# Lockstep Roadmap
+
+Lockstep is a single-maintainer project. This roadmap tracks the path from the
+current release toward a stable v1.0.0 in two parts: what already ships, and
+what remains. It is the authoritative status — earlier milestone-numbered plans
+have been folded into the two lists below.
+
+## Delivered
+
+A number of features once planned for later milestones already ship in the tree.
+Each links to the code that provides it.
+
+| Feature | Where |
+| --- | --- |
+| Typed `AstProgram` as the internal representation, with an AST-based semantic validator | `ast.py`, `semantic_validator.py`, `tests/test_semantic_validator_ast_path.py` |
+| `uint` / `double` as first-class declared types | `semantic_validator.py`, `codegen.py` (`_PRIMITIVE_TYPE_MAP`) |
+| `select` expression (branchless typed mux) | `codegen.py`, `semantic_validator.py`, `simulator.py` |
+| `import` / `#include` resolution (root-sandboxed, circular-import detection) | `compiler.py` (`_resolve_dependency_sources`) |
+| SoA decomposition in the arena layout | `arena_layout.py` (`_flatten_type_leaves`, `_build_layout_from_bindings`) |
+| Single-arena-pointer `Lockstep_Tick` ABI | `codegen.py`, `examples/minimal_host.c` |
+| Parameterized SIMD width (`--target-width`, `LOCKSTEP_SIMD_WIDTH`) | `codegen.py`, `c_header.py`, `tests/test_target_width_execution.py` |
+| Fused-vector lowering, incl. accumulator-stage fusion | `codegen.py`, `benchmarks/native/fusion_probe.py` |
+| Arena size-overflow checking + C `static_assert` (`LCK502`) | `arena_layout.py`, `c_header.py` |
+| Parser input-complexity limits (size / nesting / parse timeout) | `compiler.py` (`FrontendLimits`), `cli.py` |
+| Out-of-process, resource-limited simulator reduction | `simulator.py`, `SECURITY.md` |
+| Comment-preserving formatter | `formatter.py`, `tests/test_formatter.py` |
+| Benchmark suite (frontend, native, SoA-vs-AoS, fusion) | `benchmarks/`, `benchmarks/RESULTS.md` |
+| Hashed, pinned dependency lockfiles | `requirements*.lock`, `make check-lock-deps` |
+| Opt-in LSP: diagnostics, hover, go-to-definition, completion | `lsp.py` |
+
+## Remaining toward v1.0.0
+
+**Backend**
+
+- **Emit `noalias` on arena pointers.** The static arena, SoA decomposition, and
+  saturated write indices make arena pointer parameters provably non-aliasing.
+  Emitting `noalias` — with a short soundness argument in a `PROOFS.md` — unlocks
+  alias-sensitive LLVM optimizations the backend currently forgoes.
+- **Filter-group fusion.** Accumulator stages already fuse; the remaining
+  unfused case is a stage group containing a `filter`
+  (see `benchmarks/native/README.md`).
+
+**Language**
+
+- **Multi-stage pipeline composition.** Let a pipeline consume another
+  pipeline's output streams, with a combined arena layout and topological tick
+  ordering.
+
+**Tooling & developer experience**
+
+- **Diagnostic catalog.** A machine-readable catalog generated from
+  `SEMANTIC_DIAGNOSTIC_CODES` (code, severity, message, explanation) plus a
+  `DIAGNOSTICS.md`, surfaced in LSP hovers.
+- **LSP workspace features.** Multi-file diagnostics across `import`s, rename, and
+  a `--visualize` DAG view.
+
+**Verification**
+
+- **Grammar-aware fuzzing.** A dedicated fuzz target over the existing
+  property-based generators, checking for crashes, diagnostic completeness, and
+  `llvm-as`-valid IR.
+
+**Stability (the 1.0 gate)**
+
+- **API & grammar freeze** with semantic-versioning guarantees on
+  `compile_lockstep`, `LockstepCompileResult`, the diagnostic catalog, the
+  grammar, and the C header ABI.
+- **`MIGRATING.md`** documenting breaking changes up to 1.0.
+- **Automated dependency vulnerability scanning** (Dependabot or equivalent) on
+  top of the existing hashed lockfiles.
+
+## What v1.0.0 means
+
+1. **Correct** — every valid program's generated IR, compiled against the
+   generated header, matches the simulator's observable behavior, backed by the
+   `noalias` argument, fuzzing, and the benchmark suite.
+2. **Stable** — the public API, diagnostic catalog, grammar, and C header ABI are
+   frozen under semantic versioning.
+3. **Complete** — CLI, simulator, LSP, formatter, header generator, and IR
+   backend together cover authoring → validation → compilation → host
+   integration.
 
 ## Non-goals for v1.0.0
 
-Some features are explicitly out of scope for the 1.0 release. These may appear in future major versions but are not on the critical path.
-
-Direct machine code emission (bypassing `llc`/`clang`) is not planned. The compiler produces LLVM IR text; final compilation to native code is delegated to the host's LLVM toolchain. This keeps the compiler simple and avoids shipping platform-specific LLVM backends.
-
-GPU compute shader output (SPIR-V, DXIL, Metal) is not planned for v1.0.0 despite the language's GPU-inspired design. The initial target is CPU SIMD. GPU backends may follow in a v2.x series.
-
-A package manager or build system for multi-file Lockstep projects is not planned. The `import` resolution in v0.6.0 handles file-level dependencies, but there is no lockfile, no versioning, and no repository infrastructure for shared Lockstep libraries.
-
-Runtime profiling or tracing instrumentation is not planned. The `LOCKSTEP_DEBUG_SATURATED_WRITES` mechanism in the C header is the extent of runtime observability in v1.0.0. A more comprehensive tracing framework may follow in a future release.
+- **Direct machine-code emission.** The compiler emits LLVM IR; final codegen is
+  delegated to the host's LLVM toolchain.
+- **GPU backends** (SPIR-V / DXIL / Metal). CPU SIMD is the initial target; GPU
+  may follow in a v2.x series.
+- **A package manager** for multi-file projects. `import` resolution handles
+  files; there is no registry or versioning.
+- **Runtime profiling / tracing** beyond the `LOCKSTEP_DEBUG_SATURATED_WRITES`
+  hook.


### PR DESCRIPTION
## Summary

Follow-up to #295. That PR merged only its first commit — the "delivery status table" — not the subsequent full rewrite, so `main` still carries the stale milestone-by-milestone `ROADMAP.md` (215 lines, 8 obsolete `v0.x` sections describing shipped features as future work) and the verbose 363-line `README.md`. This PR lands the concise versions and folds in the feature work that has since merged (#296, #298, #299), so the docs match the current tree.

## ROADMAP (215 → 92 lines)

- Replaces the milestone prose with two lists: **Delivered** (each item linked to the code that provides it) and **Remaining toward v1.0.0** (backend `noalias`/filter fusion, multi-stage pipelines, diagnostic catalog + LSP tooling, fuzzing, and the 1.0 stability gate), plus a trimmed 1.0 definition and non-goals.
- **Comment-preserving formatter (#299)** and the **resource-limited simulator subprocess (#296)** are now listed under Delivered.

## README (363 → 288 lines)

- Four overlapping benchmarking subsections → one table.
- Accuracy fixes: lockfiles are generated with **`uv`**, not pip-tools; added the delivered **`select`** intrinsic; tempered the intro's "mathematically guaranteed to saturate"; noted the simulator's **POSIX resource limits (#296)** and the **lint + coverage-floor** dev workflow (#298).

## Scope

Documentation only. All technical claims verified against the merged tree (formatter preserves comments, `_subprocess_resource_limits` present, `make lint` / coverage floor present).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHd6rPoCoz2gez6kEzje9B)_