### PR TITLE
fix: repair the opt-in LLVM simulator reduction path

### DIFF
--- a/lockstep_compiler/simulator.py
+++ b/lockstep_compiler/simulator.py
@@ -134,8 +134,10 @@ def _build_reduce_program_ir(values: list[float]) -> str:
     builder.position_at_end(loop_body)
     row_ptr = builder.gep(data_arg, [idx_phi], inbounds=True, name="row_ptr")
     row_value = builder.load(row_ptr, name="row")
-    next_acc = builder.fadd(acc_phi, row_value, name="next_acc")
-    next_acc.fastmath.add("fast")
+    # Fast-math flags must be passed to the builder call; llvmlite instructions
+    # have no `.fastmath` attribute (the old form raised AttributeError, which
+    # left the opt-in LLVM reduction path dead for every input).
+    next_acc = builder.fadd(acc_phi, row_value, name="next_acc", flags=["fast"])
     next_idx = builder.add(idx_phi, ir.Constant(int_ty, 1), name="next_idx")
     builder.branch(loop_cond)
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -868,3 +868,47 @@ def test_simulate_pipeline_entities_defaults_to_python_mode_without_runtime_bina
         )["uniforms"]["total"]
         == 5.0
     )
+
+
+def test_build_reduce_program_ir_emits_fast_math_without_raising():
+    # Regression: the reduction IR builder used `instr.fastmath.add(...)`, an
+    # attribute llvmlite instructions do not have, so it raised AttributeError
+    # for every input and left the opt-in LLVM reduction path dead. Fast-math
+    # flags must be passed to the builder call instead.
+    from lockstep_compiler.simulator import _build_reduce_program_ir
+
+    ir_text = _build_reduce_program_ir([1.0, 2.0, 3.0])
+    assert "fadd fast" in ir_text
+
+
+def test_run_reduce_subprocess_sums_values_end_to_end():
+    # Exercises the real out-of-process path (previous tests mocked it, which is
+    # how the AttributeError went unnoticed). Skips when no toolchain is present.
+    import pytest
+
+    from lockstep_compiler.simulator import (
+        _run_reduce_subprocess,
+        _simulator_runtime_command,
+    )
+
+    if _simulator_runtime_command() is None:
+        pytest.skip("no clang/lli runtime toolchain available")
+
+    assert _run_reduce_subprocess([1.0, 2.0, 3.0, 4.0]) == pytest.approx(10.0)
+
+
+def test_jit_numeric_reduce_llvm_runtime_matches_python():
+    import pytest
+
+    from lockstep_compiler.simulator import (
+        _jit_numeric_reduce,
+        _simulator_runtime_command,
+    )
+
+    if _simulator_runtime_command() is None:
+        pytest.skip("no clang/lli runtime toolchain available")
+
+    values = [1.5, 2.5, 3.0]
+    llvm_result = _jit_numeric_reduce("sum", values, use_llvm_runtime=True)
+    python_result = _jit_numeric_reduce("sum", values)
+    assert llvm_result == pytest.approx(python_result)


### PR DESCRIPTION
## Summary

The opt-in LLVM-backed simulator reduction (`LOCKSTEP_SIM_USE_LLVM=1`, or `use_llvm_runtime=True`) is **broken for every input**. `simulator._build_reduce_program_ir` sets the fast-math flag with:

```python
next_acc = builder.fadd(acc_phi, row_value, name="next_acc")
next_acc.fastmath.add("fast")   # AttributeError
```

`builder.fadd(...)` returns a plain llvmlite `Instruction`, which has no `.fastmath` attribute, so this raises `AttributeError: 'Instruction' object has no attribute 'fastmath'` while *building* the IR — before any subprocess runs. Reproduced on the pinned `llvmlite==0.43.0`:

```
>>> simulator._run_reduce_subprocess([1.0, 2.0, 3.0])
AttributeError: 'Instruction' object has no attribute 'fastmath'
```

## Fix

Pass the fast-math flag to the builder call, which is the supported API and emits `fadd fast`:

```python
next_acc = builder.fadd(acc_phi, row_value, name="next_acc", flags=["fast"])
```

After the fix, `_run_reduce_subprocess([1.0, 2.0, 3.0, 4.0])` returns `10.0` and the IR contains `fadd fast`.

## Why it wasn't caught

The one existing test touching this path (`test_jit_numeric_reduce_raises_mode_specific_error_when_llvm_runtime_fails`) **mocks** `_run_reduce_subprocess` to raise, so the real builder was never invoked. This PR adds genuine coverage:

- `test_build_reduce_program_ir_emits_fast_math_without_raising` — builds the IR and asserts `fadd fast` (no toolchain needed; directly locks the fix).
- `test_run_reduce_subprocess_sums_values_end_to_end` and `test_jit_numeric_reduce_llvm_runtime_matches_python` — exercise the real out-of-process reduction, skipped when `clang`/`lli` is unavailable.

mypy (strict, includes `simulator.py`), ruff, and the full suite pass.

## Note on `codegen.py:1600`

An earlier revision of this description flagged `codegen.py:1600` (`reduced.fastmath.add("fast")`) as an identical latent bug. **On investigation it is not a bug and needs no change:** there `reduced` is a `CallInstr` (from `tick_builder.call(...)`), and `CallInstr` *does* expose `.fastmath` — it renders `call fast` correctly. The crash was specific to the simulator's plain `fadd` `Instruction`, which lacks that attribute. A real float `fold` compiles cleanly today.