### PR TITLE
codegen: mark Lockstep_Tick arena parameter noalias nocapture

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,12 @@ coercions**.
 Lockstep targets **LLVM IR** directly.
 
 * **Single-arena ABI.** Kernels receive a `struct Lockstep_Arena*` and compute
-  byte offsets into it. The backend does not yet emit blanket `noalias` on
-  arena-derived pointers, so do not assume alias-based optimizations from the
-  arena representation alone (see [ROADMAP.md](ROADMAP.md)).
+  byte offsets into it. `Lockstep_Tick`'s arena parameter is marked
+  `noalias nocapture` (it is the sole pointer parameter and every access is
+  derived from it, so it is provably non-aliasing — a `restrict`-like guarantee
+  at the ABI boundary). Scoped alias metadata on the individual arena-derived
+  stream/accumulator pointers inside the tick is not yet emitted, so do not
+  assume full intra-loop alias disambiguation (see [ROADMAP.md](ROADMAP.md)).
 * **SSA locals.** Scalar and concrete-struct locals are lowered through
   SSA-friendly values where possible; arena loads/stores stay byte-addressed for
   ABI stability.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,10 +32,13 @@ Each links to the code that provides it.
 
 **Backend**
 
-- **Emit `noalias` on arena pointers.** The static arena, SoA decomposition, and
-  saturated write indices make arena pointer parameters provably non-aliasing.
-  Emitting `noalias` — with a short soundness argument in a `PROOFS.md` — unlocks
-  alias-sensitive LLVM optimizations the backend currently forgoes.
+- **Scoped alias metadata on arena-derived pointers.** `Lockstep_Tick`'s arena
+  parameter is already `noalias nocapture` (provably sound — the sole pointer
+  parameter). What remains is disambiguating the individual stream/accumulator
+  pointers *inside* the tick: emitting `noalias` on kernel pointer parameters
+  (guarded by a whole-program check that no bind route feeds one resource to two
+  pointer params) and/or `!alias.scope` metadata per disjoint arena region,
+  backed by a short soundness argument in a `PROOFS.md`.
 - **Filter-group fusion.** Accumulator stages already fuse; the remaining
   unfused case is a stage group containing a `filter`
   (see `benchmarks/native/README.md`).

--- a/lockstep_compiler/codegen.py
+++ b/lockstep_compiler/codegen.py
@@ -1049,6 +1049,16 @@ def emit_llvm_ir(
     )
     arena_ptr = tick.args[0]
     arena_ptr.name = "arena"
+    # The arena is Lockstep_Tick's only pointer parameter, and every memory
+    # access in the tick is derived from it by constant/loop-index GEPs; the only
+    # other memory touched is function-local allocas, which can never alias it.
+    # So the arena provably does not alias anything reachable through a different
+    # pointer -> `noalias`. The tick also never stores the arena pointer itself
+    # anywhere that outlives the call (only values loaded/stored through derived
+    # pointers) -> `nocapture`. Both let LLVM's alias analysis treat the arena
+    # like a C `restrict` pointer at the ABI boundary.
+    arena_ptr.add_attribute("noalias")
+    arena_ptr.add_attribute("nocapture")
 
     tick_entry = tick.append_basic_block("entry")
     tick_builder = ir.IRBuilder(tick_entry)

--- a/tests/golden/filter_aggregation.ll
+++ b/tests/golden/filter_aggregation.ll
@@ -91,7 +91,7 @@ entry:
   ret i1 1
 }
 
-define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")
+define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* noalias nocapture %"arena")
 {
 entry:
   %"DropInvalid_idx" = alloca i32

--- a/tests/golden/fused_accumulator.ll
+++ b/tests/golden/fused_accumulator.ll
@@ -83,7 +83,7 @@ entry:
   ret void
 }
 
-define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")
+define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* noalias nocapture %"arena")
 {
 entry:
   %"fused_0_idx" = alloca i32

--- a/tests/golden/minimal.ll
+++ b/tests/golden/minimal.ll
@@ -59,7 +59,7 @@ entry:
   ret void
 }
 
-define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")
+define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* noalias nocapture %"arena")
 {
 entry:
   %"Brighten_idx" = alloca i32

--- a/tests/golden/physics_accumulator.ll
+++ b/tests/golden/physics_accumulator.ll
@@ -106,7 +106,7 @@ entry:
   ret void
 }
 
-define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")
+define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* noalias nocapture %"arena")
 {
 entry:
   %"IntegrateAndAccumulate_idx" = alloca i32

--- a/tests/test_compiler_api.py
+++ b/tests/test_compiler_api.py
@@ -117,7 +117,7 @@ def test_compile_lockstep_works_without_passing_parser_classes(monkeypatch):
 
     assert result.llvm_ir.startswith('; ModuleID = "lockstep"\n')
     assert (
-        'define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")'
+        'define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* noalias nocapture %"arena")'
         in result.llvm_ir
     )
 
@@ -435,7 +435,10 @@ def test_emit_llvm_ir_generates_expected_declarations():
     assert 'define float @"pure_demo"()' in llvm_ir
     assert 'define void @"shader_ApplyGravity"()' in llvm_ir
     assert 'define i1 @"filter_Cull"()' in llvm_ir
-    assert 'define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* %"arena")' in llvm_ir
+    assert (
+        'define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* noalias nocapture %"arena")'
+        in llvm_ir
+    )
     assert "; bind: out = ApplyGravity(inp, out, energy, dt);" in llvm_ir
     assert 'declare float @"llvm.maxnum.f32"(float %".1", float %".2")' in llvm_ir
     assert 'declare float @"llvm.minnum.f32"(float %".1", float %".2")' in llvm_ir


### PR DESCRIPTION
## Summary

Emits `noalias nocapture` on `Lockstep_Tick`'s arena pointer parameter — the provably-sound foundation of the roadmap's `noalias` work.

```llvm
define void @"Lockstep_Tick"(%"struct.Lockstep_Arena"* noalias nocapture %"arena")
```

## Soundness

This is the one arena annotation that needs no whole-program analysis to justify:

- **`noalias`** — the arena is the tick's *only* pointer parameter, and every memory access in the tick is derived from it by constant/loop-index GEPs. The only other memory touched is function-local `alloca`s, which can never alias it. So the arena provably does not alias anything reachable through a different pointer.
- **`nocapture`** — the tick only loads/stores *values* through arena-derived pointers; it never stores the arena pointer itself anywhere that outlives the call.

Together they give LLVM a `restrict`-like guarantee at the ABI boundary.

## Verification (beyond IR text)

An unsound `noalias` miscompiles silently under optimization, so I verified behavior, not just the IR string: the **native benchmark** recompiles each workload's generated IR with `clang -O3` and checks the deterministic output **checksums** (and arena ABI). All three workloads — `particle_energy`, `telemetry_filter_aggregation`, `multi_stage_pipeline` — match the committed baseline unchanged:

```
Native benchmark invariants OK for 3 workload(s) (ABI + checksums; throughput not gated).
```

- Golden IR snapshots regenerated — the **only** change is the Tick signature gaining the attributes.
- Two `test_compiler_api` assertions updated to match; full suite, ruff, and mypy green.

## Scope / follow-up

This covers the arena **parameter**. The higher-value intra-loop win — scoped alias metadata on the individual arena-derived **stream/accumulator** pointers (e.g. `noalias` on kernel pointer params, or `!alias.scope` per disjoint region) — needs a whole-program check that no bind route feeds one resource to two pointer params (the validator does not currently enforce accumulator linearity), so it's deferred to its own PR. README §4 and ROADMAP are updated to reflect exactly what's done vs. remaining.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHd6rPoCoz2gez6kEzje9B)_